### PR TITLE
프로토타입 탭 뷰 추가

### DIFF
--- a/Fleeting-Prototype/Fleeting-Prototype/ContentView.swift
+++ b/Fleeting-Prototype/Fleeting-Prototype/ContentView.swift
@@ -7,13 +7,16 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            Tab("Map", systemImage: "map") {
+                MainMapViewWrapper()
+                    .ignoresSafeArea()
+            }
+
+            Tab("Dome", systemImage: "field.of.view.wide") {
+                DomeScreen()
+            }
         }
-        .padding()
     }
 }
 

--- a/Fleeting-Prototype/Fleeting-Prototype/Dome/DomeScreen.swift
+++ b/Fleeting-Prototype/Fleeting-Prototype/Dome/DomeScreen.swift
@@ -16,7 +16,7 @@ struct DomeScreen: View {
             modelFileExtension: "usdz",
             dragDelta: dragDelta
         )
-        .ignoresSafeArea()
+        .ignoresSafeArea(.container, edges: [.top, .leading, .trailing])
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { value in


### PR DESCRIPTION
## 배경

- closed #11 

## 작업 요약

- [x] 프로토타입 기능 별 탭 뷰 추가

## 작업 내용

- 데모를 위한 프로토타입 화면 별 탭 뷰 추가

## 스크린샷

https://github.com/user-attachments/assets/c850131d-e5bf-4eb0-bb1d-aec0cb2ed6f5

## 데모 준비

- info.plist에 네이버 맵 sdk 키 추가해야 합니다.
- 메시지 100개에서 10개 정도로 줄여서 보여도 될 것 같습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
