### PR TITLE
공간 메시지 작성 버튼 및 텍스트 검열 기능 추가

### DIFF
--- a/.github/workflows/build_test_on_develop.yml
+++ b/.github/workflows/build_test_on_develop.yml
@@ -17,7 +17,23 @@ jobs:
     steps:
     # repository 체크아웃(저장소의 코드를 실행 환경으로 가져옴)
     - uses: actions/checkout@v4
-    
+
+    # Secrets.xcconfig 생성
+    - name: Create Secrets.xcconfig 🔐
+      run: |
+        echo "repo root: $(pwd)"
+        echo "PROJECT_DIR: $PROJECT_DIR"
+        ls -al
+
+        # Config.xcconfig가 있는 폴더(Meomun) 옆에 생성
+        cat <<EOF > "$PROJECT_DIR/Secrets.xcconfig"
+        NAVER_API_KEY = ${{ secrets.NAVER_API_KEY }}
+        EOF
+
+        echo "✅ created:"
+        ls -al "$PROJECT_DIR"
+        test -f "$PROJECT_DIR/Secrets.xcconfig"
+        
     # 해당 가상 머신 환경에서의 가용 Xcode 버전을 출력
     - name: List available Xcode versions
       run: ls /Applications | grep Xcode

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,8 @@ iOSInjectionProject/
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
 
+Secrets.xcconfig
+
 # Cursor
 .cursorrules
 .cursor/

--- a/Meomun/Config.xcconfig
+++ b/Meomun/Config.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Config.xcconfig
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
+
+#include "Secrets.xcconfig"

--- a/Meomun/Meomun.xcodeproj/project.pbxproj
+++ b/Meomun/Meomun.xcodeproj/project.pbxproj
@@ -8,15 +8,30 @@
 
 /* Begin PBXBuildFile section */
 		1628F47E2EF5376C005E6C42 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 1628F47D2EF5376C005E6C42 /* NMapsMap */; };
+		531A22F72EF92C540014BE96 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 531A22F62EF92C540014BE96 /* Secrets.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		1628F46A2EF53602005E6C42 /* Meomun.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Meomun.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		531A22F62EF92C540014BE96 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		531A22F92EF92D490014BE96 /* Exceptions for "Meomun" folder in "Meomun" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 1628F4692EF53602005E6C42 /* Meomun */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		1628F46C2EF53602005E6C42 /* Meomun */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				531A22F92EF92D490014BE96 /* Exceptions for "Meomun" folder in "Meomun" target */,
+			);
 			path = Meomun;
 			sourceTree = "<group>";
 		};
@@ -37,6 +52,7 @@
 		1628F4612EF53602005E6C42 = {
 			isa = PBXGroup;
 			children = (
+				531A22F62EF92C540014BE96 /* Secrets.xcconfig */,
 				1628F46C2EF53602005E6C42 /* Meomun */,
 				1628F46B2EF53602005E6C42 /* Products */,
 			);
@@ -120,6 +136,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				531A22F72EF92C540014BE96 /* Secrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -145,6 +162,7 @@
 /* Begin XCBuildConfiguration section */
 		1628F4732EF53604005E6C42 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 531A22F62EF92C540014BE96 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -207,6 +225,7 @@
 		};
 		1628F4742EF53604005E6C42 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 531A22F62EF92C540014BE96 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -272,6 +291,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Meomun/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -318,6 +338,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Meomun/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;

--- a/Meomun/Meomun.xcodeproj/project.pbxproj
+++ b/Meomun/Meomun.xcodeproj/project.pbxproj
@@ -9,11 +9,15 @@
 /* Begin PBXBuildFile section */
 		1628F47E2EF5376C005E6C42 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 1628F47D2EF5376C005E6C42 /* NMapsMap */; };
 		531A22F72EF92C540014BE96 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 531A22F62EF92C540014BE96 /* Secrets.xcconfig */; };
+		531A22FE2EF9367C0014BE96 /* Secrets.example.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 531A22FD2EF9367C0014BE96 /* Secrets.example.xcconfig */; };
+		531A23002EF936BA0014BE96 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 531A22FF2EF936BA0014BE96 /* Config.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		1628F46A2EF53602005E6C42 /* Meomun.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Meomun.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		531A22F62EF92C540014BE96 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		531A22FD2EF9367C0014BE96 /* Secrets.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.example.xcconfig; sourceTree = "<group>"; };
+		531A22FF2EF936BA0014BE96 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -52,6 +56,8 @@
 		1628F4612EF53602005E6C42 = {
 			isa = PBXGroup;
 			children = (
+				531A22FF2EF936BA0014BE96 /* Config.xcconfig */,
+				531A22FD2EF9367C0014BE96 /* Secrets.example.xcconfig */,
 				531A22F62EF92C540014BE96 /* Secrets.xcconfig */,
 				1628F46C2EF53602005E6C42 /* Meomun */,
 				1628F46B2EF53602005E6C42 /* Products */,
@@ -136,6 +142,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				531A23002EF936BA0014BE96 /* Config.xcconfig in Resources */,
+				531A22FE2EF9367C0014BE96 /* Secrets.example.xcconfig in Resources */,
 				531A22F72EF92C540014BE96 /* Secrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -162,7 +170,7 @@
 /* Begin XCBuildConfiguration section */
 		1628F4732EF53604005E6C42 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 531A22F62EF92C540014BE96 /* Secrets.xcconfig */;
+			baseConfigurationReference = 531A22FF2EF936BA0014BE96 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -225,7 +233,7 @@
 		};
 		1628F4742EF53604005E6C42 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 531A22F62EF92C540014BE96 /* Secrets.xcconfig */;
+			baseConfigurationReference = 531A22FF2EF936BA0014BE96 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/Meomun/Meomun/App/AppConfig.swift
+++ b/Meomun/Meomun/App/AppConfig.swift
@@ -1,0 +1,19 @@
+//
+//  AppConfig.swift
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+import Foundation
+
+enum AppConfig {
+    static var naverAPIKey: String {
+        guard let key = Bundle.main.object(
+            forInfoDictionaryKey: "NAVER_API_KEY"
+        ) as? String else {
+            fatalError("NAVER_API_KEY not found")
+        }
+        return key
+    }
+}

--- a/Meomun/Meomun/ContentView.swift
+++ b/Meomun/Meomun/ContentView.swift
@@ -10,10 +10,7 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            MapView()
         }
         .padding()
     }

--- a/Meomun/Meomun/Info.plist
+++ b/Meomun/Meomun/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NAVER_API_KEY</key>
+	<string>$(NAVER_API_KEY)</string>
+</dict>
+</plist>

--- a/Meomun/Meomun/Presentation/AddMessageView/AddMessageView.swift
+++ b/Meomun/Meomun/Presentation/AddMessageView/AddMessageView.swift
@@ -1,0 +1,80 @@
+//
+//  AddMessageView.swift
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+import SwiftUI
+
+struct AddMessageView: View {
+    @StateObject private var viewModel = TextModerationViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("텍스트 안전성 검사(임시 데모)")
+                .font(.headline)
+
+            TextEditor(text: $viewModel.inputText)
+                .frame(height: 140)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.secondary.opacity(0.4))
+                )
+
+            HStack(spacing: 10) {
+                Button("검사하기") {
+                    Task { await viewModel.runModeration() }
+                }
+                .buttonStyle(.borderedProminent)
+
+                if case .loading = viewModel.state {
+                    ProgressView()
+                }
+            }
+
+            resultView
+                .padding(.top, 4)
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var resultView: some View {
+        switch viewModel.state {
+        case .idle:
+            Text("텍스트를 입력하고 검사하기를 눌러줘.")
+                .foregroundStyle(.secondary)
+
+        case .loading:
+            Text("검사 중…")
+                .foregroundStyle(.secondary)
+
+        case .success(let r):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("판정:").foregroundStyle(.secondary)
+                    Text(r.decision.rawValue).font(.title3).bold()
+                }
+                Text("라벨: \(r.labels.joined(separator: ", "))")
+                    .foregroundStyle(.secondary)
+                Text(String(format: "확신도: %.2f", r.score))
+                    .foregroundStyle(.secondary)
+                Text("사유: \(r.reason)")
+            }
+            .padding()
+            .background(.thinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+        case .failure(let msg):
+            Text("오류: \(msg)")
+                .foregroundStyle(.red)
+        }
+    }
+}
+
+#Preview {
+    AddMessageView()
+}

--- a/Meomun/Meomun/Presentation/AddMessageView/TextModerationViewModel.swift
+++ b/Meomun/Meomun/Presentation/AddMessageView/TextModerationViewModel.swift
@@ -122,15 +122,12 @@ labels는 아래 중에서만 선택:
         req.timeoutInterval = 20
         req.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
 
-        print("request:", endpoint.absoluteString)
-
         let (bytes, response) = try await URLSession.shared.bytes(for: req)
 
         guard let http = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
         }
-        print("response:", http)
-
+        
         guard (200..<300).contains(http.statusCode) else {
             var raw = ""
             for try await line in bytes.lines.prefix(50) { raw += line + "\n" }

--- a/Meomun/Meomun/Presentation/AddMessageView/TextModerationViewModel.swift
+++ b/Meomun/Meomun/Presentation/AddMessageView/TextModerationViewModel.swift
@@ -1,0 +1,269 @@
+//
+//  TextModerationViewModel.swift
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+import SwiftUI
+import Combine
+
+// MARK: - Model
+
+struct ModerationResult: Codable {
+    enum Decision: String, Codable {
+        case ALLOW, REVIEW, BLOCK
+        case UNKNOWN
+
+        init(from decoder: Decoder) throws {
+            let value = try decoder.singleValueContainer().decode(String.self)
+            self = Decision(rawValue: value) ?? .UNKNOWN
+        }
+    }
+    var decision: Decision
+    var labels: [String]
+    var score: Double
+    var reason: String
+}
+
+enum ModerationState {
+    case idle
+    case loading
+    case success(ModerationResult)
+    case failure(String)
+}
+
+// MARK: - ViewModel
+
+@MainActor
+final class TextModerationViewModel: ObservableObject {
+
+    @Published var inputText: String = ""
+    @Published private(set) var state: ModerationState = .idle
+
+    // curl의 Bearer <api-key> 값(토큰 값만)
+    private let apiKey: String = AppConfig.naverAPIKey
+
+    private let requestId: String = "meomun-moderation-demo"
+    private let endpoint = URL(string: "https://clovastudio.stream.ntruss.com/v3/chat-completions/HCX-005")!
+
+    func runModeration() async {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            state = .failure("텍스트를 입력해줘")
+            return
+        }
+
+        state = .loading
+        do {
+            let result = try await callClovaModeration(text: text)
+            state = .success(result)
+        } catch {
+            state = .failure(error.localizedDescription)
+        }
+    }
+
+    // MARK: - CLOVA call (SSE)
+
+    private func callClovaModeration(
+        text: String
+    ) async throws -> ModerationResult {
+        let systemPrompt =
+"""
+너는 한국어 사용자 생성 텍스트(UGC) 안전성/매너 검열기다.
+서비스 정책은 "타인에 대한 비하/모욕/조롱/혐오"를 강하게 제한한다.
+
+판정 규칙(반드시 준수):
+- BLOCK: 명확한 욕설/모욕/비하/조롱, 외모/신체/장애/인종/성별 등 대상에 대한 공격, 혐오 표현, 성적 모욕, 폭력/자해/불법 조장
+- REVIEW: 모욕/비하 의도가 강하게 의심되거나, 특정 대상을 겨냥하지 않았더라도 공격적 표현(예: "개같다", "개웃기게 생김", "병신같다" 등), 조롱/비아냥, 경멸적 표현
+- ALLOW: 공격성/비하/모욕이 없고 중립적인 표현
+
+특수 규칙:
+- 비속어 접두(개-, 존나, ㅈㄴ 등) + 사람/외모/행동 평가가 결합되면 최소 REVIEW
+- "웃기게 생김"처럼 외모/인상 평가로 타인을 낮추는 표현은 최소 REVIEW (정책상 공격성으로 취급)
+- 대상이 불특정이라도 공격적 표현이면 REVIEW 이상
+
+출력은 반드시 하나의 JSON 객체만. JSON 외 텍스트 금지.
+decision은 ALLOW|REVIEW|BLOCK 중 하나.
+labels는 아래 중에서만 선택:
+["HARASSMENT","HATE","VIOLENCE","SEXUAL","SELF_HARM","ILLEGAL","PROFANITY","OTHER"]
+
+출력 형식:
+{
+  "decision": "ALLOW|REVIEW|BLOCK",
+  "labels": [],
+  "score": 0.0,
+  "reason": "한국어로 짧은 근거"
+}
+"""
+
+        // curl 파라미터 + user 메시지까지 포함
+        let body: [String: Any] = [
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": "텍스트: \"\"\"\(text)\"\"\""]
+            ],
+            "topP": 0.5,
+            "topK": 0,
+            "maxTokens": 256,
+            "temperature": 0.0,
+            "repetitionPenalty": 1.1,
+            "stop": [],
+            "seed": 0,
+            "includeAiFilters": true
+        ]
+
+        var req = URLRequest(url: endpoint)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        req.setValue(requestId, forHTTPHeaderField: "X-NCP-CLOVASTUDIO-REQUEST-ID")
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        req.timeoutInterval = 20
+        req.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+
+        print("request:", endpoint.absoluteString)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: req)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        print("response:", http)
+
+        guard (200..<300).contains(http.statusCode) else {
+            var raw = ""
+            for try await line in bytes.lines.prefix(50) { raw += line + "\n" }
+            throw NSError(domain: "CLOVA", code: http.statusCode,
+                          userInfo: [NSLocalizedDescriptionKey: "요청 실패(\(http.statusCode)):\n\(raw)"])
+        }
+
+        var accumulated = ""
+        var finalContent: String? = nil
+
+        for try await line in bytes.lines {
+            guard line.hasPrefix("data:") else { continue }
+            let payload = line.dropFirst("data:".count).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if payload == "[DONE]" || payload.contains("\"data\":\"[DONE]\"") {
+                break
+            }
+
+            guard let (chunk, isFinal) = extractContentAndFinish(fromSSEPayload: Data(payload.utf8)) else {
+                continue
+            }
+
+            if isFinal {
+                // 최종본이 오면 그걸로 확정
+                finalContent = chunk
+                break
+            } else {
+                accumulated += chunk
+            }
+        }
+
+        let contentToDecode = (finalContent ?? accumulated).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !contentToDecode.isEmpty else {
+            throw NSError(domain: "CLOVA", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "스트림에서 content를 못 받았어"])
+        }
+
+        return try decodeModerationResult(from: contentToDecode)
+    }
+    /// payload에서 (content, isFinal)을 뽑아냄
+    private func extractContentAndFinish(fromSSEPayload data: Data) -> (String, Bool)? {
+        guard
+            let obj = try? JSONSerialization.jsonObject(with: data),
+            let dict = obj as? [String: Any]
+        else { return nil }
+
+        if let done = dict["data"] as? String, done == "[DONE]" {
+            return nil
+        }
+
+        if let message = dict["message"] as? [String: Any],
+           let content = message["content"] as? String {
+
+            let finishReason = dict["finishReason"] as? String
+            let isFinal = (finishReason == "stop" || finishReason == "length" || finishReason == "end")
+            return (content, isFinal)
+        }
+
+        return nil
+    }
+    /// SSE payload JSON에서 "content 조각"을 뽑아낸다.
+    /// CLOVA/LLM 스트리밍은 보통 choices[0].delta.content 형태지만,
+    /// 스펙이 다를 수 있어서 여러 경로를 다 시도함.
+    private func extractContentChunk(fromSSEPayload data: Data) -> String? {
+        guard
+            let obj = try? JSONSerialization.jsonObject(with: data, options: []),
+            let dict = obj as? [String: Any]
+        else { return nil }
+
+        if let done = dict["data"] as? String, done == "[DONE]" {
+            return nil
+        }
+
+        if let message = dict["message"] as? [String: Any],
+           let content = message["content"] as? String {
+            return content
+        }
+
+        // 다른 스키마 대비용
+        if let choices = dict["choices"] as? [[String: Any]],
+           let delta = choices.first?["delta"] as? [String: Any],
+           let content = delta["content"] as? String {
+            return content
+        }
+
+        if let choices = dict["choices"] as? [[String: Any]],
+           let message = choices.first?["message"] as? [String: Any],
+           let content = message["content"] as? String {
+            return content
+        }
+
+        if let result = dict["result"] as? [String: Any],
+           let message = result["message"] as? [String: Any],
+           let content = message["content"] as? String {
+            return content
+        }
+
+        return nil
+    }
+
+    private func decodeModerationResult(from content: String) throws -> ModerationResult {
+        // 1) 코드블록 제거 + 트림
+        let cleaned = content
+            .replacingOccurrences(of: "```json", with: "")
+            .replacingOccurrences(of: "```", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // 2) content 안에 섞여있는 텍스트 제거: JSON 객체만 추출
+        guard let jsonOnly = extractFirstJSONObject(from: cleaned) else {
+            throw NSError(
+                domain: "CLOVA",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "모델 응답에서 JSON 객체를 못 찾았어.\n원문:\n\(cleaned)"]
+            )
+        }
+
+        // 3) 디코딩
+        do {
+            return try JSONDecoder().decode(ModerationResult.self, from: Data(jsonOnly.utf8))
+        } catch {
+            throw NSError(
+                domain: "CLOVA",
+                code: -3,
+                userInfo: [NSLocalizedDescriptionKey: "JSON 디코딩 실패: \(error.localizedDescription)\nJSON:\n\(jsonOnly)"]
+            )
+        }
+    }
+
+    /// 문자열 안에서 첫 번째 JSON 오브젝트( {...} )를 추출
+    private func extractFirstJSONObject(from text: String) -> String? {
+        guard let start = text.firstIndex(of: "{"),
+              let end = text.lastIndex(of: "}") else { return nil }
+        guard start < end else { return nil }
+        return String(text[start...end]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Meomun/Meomun/Presentation/Common/Component/WriteButton.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/WriteButton.swift
@@ -1,0 +1,74 @@
+//
+//  WriteButton.swift
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+import SwiftUI
+
+struct LeftTopCutRoundedShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let radius: CGFloat = 22
+        let cutRadius: CGFloat = 34   // 왼쪽 상단만 더 큼
+
+        var path = Path()
+
+        path.move(to: CGPoint(x: cutRadius, y: 0))
+
+        // top
+        path.addLine(to: CGPoint(x: rect.maxX - radius, y: 0))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: radius),
+            control: CGPoint(x: rect.maxX, y: 0)
+        )
+
+        // right
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - radius))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - radius, y: rect.maxY),
+            control: CGPoint(x: rect.maxX, y: rect.maxY)
+        )
+
+        // bottom
+        path.addLine(to: CGPoint(x: radius, y: rect.maxY))
+        path.addQuadCurve(
+            to: CGPoint(x: 0, y: rect.maxY - radius),
+            control: CGPoint(x: 0, y: rect.maxY)
+        )
+
+        // left
+        path.addLine(to: CGPoint(x: 0, y: cutRadius))
+        path.addQuadCurve(
+            to: CGPoint(x: cutRadius, y: 0),
+            control: CGPoint(x: 0, y: 0)
+        )
+
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct WriteButton: View {
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "pencil")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 56, height: 56)
+                .background(
+                    LeftTopCutRoundedShape()
+                        .fill(Color.mamunButton)
+                )
+                .shadow(color: .black.opacity(0.15), radius: 6, y: 4)
+        }
+    }
+}
+
+#Preview {
+    WriteButton(action: {
+        MapView()
+    })
+}

--- a/Meomun/Meomun/Presentation/Common/Extension/Color + hex.swift
+++ b/Meomun/Meomun/Presentation/Common/Extension/Color + hex.swift
@@ -1,0 +1,27 @@
+//
+//  Color + hex.swift
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+import SwiftUI
+
+extension Color {
+    static let mamunButton = Color(hex: "#5C9397")
+}
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.replacingOccurrences(of: "#", with: "")
+        let scanner = Scanner(string: hex)
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+
+        self.init(
+            red: Double((rgb >> 16) & 0xFF) / 255,
+            green: Double((rgb >> 8) & 0xFF) / 255,
+            blue: Double(rgb & 0xFF) / 255
+        )
+    }
+}

--- a/Meomun/Meomun/Presentation/MapView/MapView.swift
+++ b/Meomun/Meomun/Presentation/MapView/MapView.swift
@@ -1,0 +1,37 @@
+//
+//  MapView.swift
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+import SwiftUI
+
+struct MapView: View {
+    @State private var showAddMessage = false
+
+    var body: some View {
+        ZStack {
+            // TODO: - 지도뷰
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    WriteButton {
+                        showAddMessage = true
+                    }
+                }
+            }
+            .padding(.bottom, 30)
+            .padding(.trailing, 30)
+        }
+        .sheet(isPresented: $showAddMessage) {
+            AddMessageView()
+        }
+    }
+}
+
+#Preview {
+    MapView()
+}

--- a/Meomun/Meomun/Presentation/presentation.swift
+++ b/Meomun/Meomun/Presentation/presentation.swift
@@ -1,7 +1,0 @@
-//
-//  presentation.swift
-//  Meomun
-//
-//  Created by Hayeon Park on 12/19/25.
-//
-

--- a/Meomun/Secrets.example.xcconfig
+++ b/Meomun/Secrets.example.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Secrets.example.xcconfig
+//  Meomun
+//
+//  Created by 송지연 on 12/22/25.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
+
+// 복사해서 Secrets.xcconfig로 만들고 실제 키를 넣어주시면 됩니다
+NAVER_API_KEY = PUT_YOUR_KEY_HERE


### PR DESCRIPTION
## 배경
- closed #15

## 작업 요약
- 메인 지도 화면 Write 버튼 추가
- 커스텀 버튼 UI
- 메시지 작성 화면(AddMessageView)
- CLOVA Studio(HCX-005) 기반 텍스트 검열 로직
- API Key 관리 방식 정리

## 작업 내용
### 1. 메인 지도 화면 Write 버튼 추가
- MapView 우측 하단에 **메시지 작성 버튼(WriteButton) 배치**
- ZStack 기반 레이아웃으로 지도 위에 플로팅 형태로 노출
  - 추후 지도 및 탭바 추가 후 레이아웃 조정 예정
- 버튼 탭 시 AddMessageView를 `.sheet` 방식으로 표시 (임시)
```swift
@State private var showAddMessage = false

WriteButton {
    showAddMessage = true
}
.sheet(isPresented: $showAddMessage) {
    AddMessageView()
}
```

### 2. 커스텀 버튼 UI
- 원형 버튼이 아닌, 좌상단이 커팅 처리된 사각형 형태의 커스텀 Shape 적용
- 포인트 컬러 `#5C9397` 사용 (변경 가능)
  - Color extension 활용 -> hex값으로 색상 조절 가능하도록 확장
- 지도 위에서 인지되도록 shadow 추가
- 구성 요소:
  - LeftTopCutRoundedShape: 버튼 외곽 커스텀 Shape 정의
  - WriteButton: Shape + 색상 + 아이콘을 조합한 재사용 컴포넌트
  ```swift
  .background(
    LeftTopCutRoundedShape()
        .fill(Color.mamunButton)
  )
  ```

### 3. 메시지 작성 화면 (AddMessageView) - 임시
- 텍스트 입력을 위한 TextEditor
- 검사 버튼 클릭 시 비동기 검열 요청 실행
- 검열 상태에 따라 UI 분기 처리

#### 상태 흐름
`idle -> loading -> success / failure`

### 4. CLOVA Studio(HCX-005) 기반 텍스트 검열 로직
- TextModerationViewModel에서 CLOVA Chat Completion API 직접 호출
- SSE(text/event-stream) 응답을 처리하여 최종 content 수정
- 모델 응답에서 JSON만 안전하게 추출 후 디코딩
- 검열 결과 모델: 
  ```
  decision: ALLOW | REVIEW | BLOCK
  labels: [String]
  score: Double
  reason: String
  ```
  - 텍스트 검열 결과를 `BLOCK`, `REVIEW`, `ALLOW`로 나누어 분류하고 이를 활용하여 추후 정책 확장이 가능하도록 설계
    - `BLOCK`: 업로드 차단
    - `REVIEW`: 관리자 검토
    - `ALLOW`: 정상 게시

### 5. API Key 관리 방식 정리
- API Key는 Secrets.xcconfig에 저장
  - Secrets.xcconfig는 `.gitignore` 처리하여 노출되지 않도록 관리
- Info.plist에 담고, AppConfig를 통해 접근하도록 함.

```swift
enum AppConfig {
    static var naverAPIKey: String {
        Bundle.main.object(forInfoDictionaryKey: "NAVER_API_KEY") as? String ?? ""
    }
}
```

---
### 설계 의도 및 고려 사항
* **SNS와 달리 댓글/좋아요 없는 구조**이기 때문에 메시지 자체가 공격적으로 확산되는 것을 방지해야 했음
* 따라서 작성 시점에서 1차적으로 **텍스트 안전성 검열을 거치는 구조**를 선제적으로 도입
* 현재는 데모 성격이지만 이후 서버 업로드 전 검열 단계로 자연스럽게 확장 가능

### 이후 확장 예정
* 실제 메시지 업로드 API 연동
* ALLOW / REVIEW / BLOCK 결과에 따른 UX 분기
* 메시지 TTL 적용 및 공간 반구 UI와 연결
* 신고 누적 기반 사용자/공간 단위 제재 로직

## 스크린샷
![Simulator Screen Recording - iPhone 17 Pro - 2025-12-22 at 17 08 38](https://github.com/user-attachments/assets/63836cce-8a50-4dca-8ce1-addb8477d4b2)

## 리뷰 요구사항
UI 디자인이나 아키텍처 등은 아직 적용하지 않고 임시적인 동작만을 클라이언트에 넣어 놓은 상태입니다. 해당 부분 고려해주시면 감사하겠습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
