### PR TITLE
config 자동 생성을 위한 CI 스크립트 수정

### DIFF
--- a/.github/workflows/build_test_on_develop.yml
+++ b/.github/workflows/build_test_on_develop.yml
@@ -17,7 +17,14 @@ jobs:
     steps:
     # repository 체크아웃(저장소의 코드를 실행 환경으로 가져옴)
     - uses: actions/checkout@v4
-    
+
+   # Secrets.xcconfig 생성
+    - name: Create Secrets.xcconfig 🔐
+      run: |
+        cat <<EOF > Meomun/Secrets.xcconfig
+        NAVER_API_KEY=${{ secrets.NAVER_API_KEY }}
+        EOF
+        
     # 해당 가상 머신 환경에서의 가용 Xcode 버전을 출력
     - name: List available Xcode versions
       run: ls /Applications | grep Xcode


### PR DESCRIPTION
## 배경
- closed #17

## 작업 요약
- Secrets.xcconfig 파일 자동 생성을 위한 ci 스크립트 수정

## 작업 내용
### 1. 변경 배경
NAVER_API_KEY 등 민감한 값을 코드에 직접 포함하고 Git에 노출하지 않으면서 **로컬 개발 환경, GitHub Actions CI 환경 모두에서 빌드가 정상적으로 동작**하도록 시크릿 관리 방식을 정리할 필요가 있었다.

### 2. 변경 내용
#### 1) Secrets.xcconfig Git 관리 정책 정리
* Secrets.xcconfig
  * `.gitignore`에 추가 → **Git에 올라가지 않음**
* Secrets.example.xcconfig
  * 템플릿 용도로 Git에 포함
  * 로컬 개발 시 참고용

#### 2) GitHub Repository Secrets 기반 CI 자동 생성 방식 적용
* GitHub Repository Secrets에 MEOMUN_SECRETS_XCCONFIG 항목으로 **Secrets.xcconfig 전체 내용**을 저장
* CI 실행 시 해당 값을 사용하여 Secrets.xcconfig 파일을 **자동 생성**
  - `echo "$MEOMUN_SECRETS_XCCONFIG" > Secrets.xcconfig`
- -> 이후 시크릿 값이 추가/변경되더라도 **CI 스크립트 수정 없이 Repository Secrets만 갱신**하면 됨.

#### 3) 로컬/CI 환경 분리
- 로컬:
  - Secrets.example.xcconfig 복사 -> Secrets.xcconfig 생성
  - 개인 키 입력 후 사용
- CI 환경:
  - GitHub Secrets 기반으로 자동 생성
  - 키가 없어 빌드 실패하는 문제 방지

#### 4) 참고
- 공용 Config.xcconfig가 Build Settings > Base Configuration에 연결되어 있음. (텍스트 검열 기능 pr에 포함)
- 키 사용은 Info.plist -> AppConfig를 통해 접근