### PR TITLE
지도 UI 구현

### DIFF
--- a/Meomun/Meomun.xcodeproj/project.pbxproj
+++ b/Meomun/Meomun.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1628F47E2EF5376C005E6C42 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 1628F47D2EF5376C005E6C42 /* NMapsMap */; };
 		531A22FE2EF9367C0014BE96 /* Secrets.example.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 531A22FD2EF9367C0014BE96 /* Secrets.example.xcconfig */; };
 		531A23002EF936BA0014BE96 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 531A22FF2EF936BA0014BE96 /* Config.xcconfig */; };
+		7866C0112F0EDCCC00C69ADE /* SeoulCityHall.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 7866C0102F0EDCCC00C69ADE /* SeoulCityHall.gpx */; };
 		90E847342F0B899D005C8966 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 90E847332F0B899D005C8966 /* Secrets.xcconfig */; };
 /* End PBXBuildFile section */
 
@@ -17,6 +18,7 @@
 		1628F46A2EF53602005E6C42 /* Meomun.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Meomun.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		531A22FD2EF9367C0014BE96 /* Secrets.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.example.xcconfig; sourceTree = "<group>"; };
 		531A22FF2EF936BA0014BE96 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		7866C0102F0EDCCC00C69ADE /* SeoulCityHall.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = SeoulCityHall.gpx; sourceTree = "<group>"; };
 		90E847332F0B899D005C8966 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -57,6 +59,7 @@
 			isa = PBXGroup;
 			children = (
 				90E847332F0B899D005C8966 /* Secrets.xcconfig */,
+				7866C0102F0EDCCC00C69ADE /* SeoulCityHall.gpx */,
 				531A22FF2EF936BA0014BE96 /* Config.xcconfig */,
 				531A22FD2EF9367C0014BE96 /* Secrets.example.xcconfig */,
 				1628F46C2EF53602005E6C42 /* Meomun */,
@@ -142,6 +145,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7866C0112F0EDCCC00C69ADE /* SeoulCityHall.gpx in Resources */,
 				90E847342F0B899D005C8966 /* Secrets.xcconfig in Resources */,
 				531A23002EF936BA0014BE96 /* Config.xcconfig in Resources */,
 				531A22FE2EF9367C0014BE96 /* Secrets.example.xcconfig in Resources */,

--- a/Meomun/Meomun/Info.plist
+++ b/Meomun/Meomun/Info.plist
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NMFNcpKeyId</key>
+	<string>$(NMFNcpKeyId)</string>
 	<key>NAVER_API_KEY</key>
 	<string>$(NAVER_API_KEY)</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>위치 정보를 사용하시겠습니까?</string>
 </dict>
 </plist>

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -12,7 +12,7 @@ struct MapView: View {
 
     var body: some View {
         ZStack {
-            // TODO: - 지도뷰
+            MapViewWrapper()
 
             VStack {
                 Spacer()

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -11,6 +11,9 @@ import UIKit
 
 final class MapViewController: UIViewController {
 
+    private var locationManager = CLLocationManager()
+    private var didMoveToCurrentLocation = false
+
     private let naverMapView: NMFNaverMapView = {
         let naverMapView = NMFNaverMapView()
 
@@ -64,6 +67,61 @@ extension MapViewController {
         ])
     }
 }
+
+// MARK: - CLLocationManagerDelegate
+
+extension MapViewController: CLLocationManagerDelegate {
+    private func configureLocationManager() {
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    private func requestLocationAuthorizationIfNeeded() {
+        let status = locationManager.authorizationStatus
+
+        switch status {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse, .authorizedAlways:
+            startUpdatingLocationIfNeeded()
+        case .denied, .restricted:
+            print("위치 권한이 거부/제한되어 있어 현재 위치로 이동할 수 없습니다.")
+        @unknown default:
+            break
+        }
+    }
+
+    private func startUpdatingLocationIfNeeded() {
+        locationManager.startUpdatingLocation()
+        naverMapView.mapView.positionMode = .direction
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        requestLocationAuthorizationIfNeeded()
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let currentLocation = locations.last else { return }
+        guard didMoveToCurrentLocation == false else { return }
+
+        didMoveToCurrentLocation = true
+
+        let latLng = NMGLatLng(
+            lat: currentLocation.coordinate.latitude,
+            lng: currentLocation.coordinate.longitude
+        )
+
+        // 현재 위치로 카메라 이동
+        let cameraUpdate = NMFCameraUpdate(scrollTo: latLng)
+        cameraUpdate.animation = .easeIn
+        naverMapView.mapView.moveCamera(cameraUpdate)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("위치 업데이트 실패: \(error)")
+    }
+}
+
 // MARK: - MapViewWrapper
 
 struct MapViewWrapper: UIViewControllerRepresentable {

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -22,6 +22,11 @@ final class MapViewController: UIViewController {
         naverMapView.showScaleBar = false
         naverMapView.showZoomControls = false
         naverMapView.showLocationButton = true
+        naverMapView.showScaleBar = true
+
+        // 최소 및 최대 줌 레벨 설정
+        naverMapView.mapView.minZoomLevel = 15
+        naverMapView.mapView.maxZoomLevel = 18
 
         // 지도 스타일
         naverMapView.mapView.customStyleId = "9d41e3bf-0e89-45bc-8261-776fcdd1660d"
@@ -29,7 +34,7 @@ final class MapViewController: UIViewController {
         // 초기 카메라
         let camera = NMFCameraPosition(
             NMGLatLng(lat: 37.5665, lng: 126.9780),
-            zoom: 16,
+            zoom: 17,
             tilt: 45,
             heading: 0
         )

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -1,0 +1,76 @@
+//
+//  MapViewController.swift
+//  Meomun
+//
+//  Created by hoon on 1/6/26.
+//
+
+import NMapsMap
+import SwiftUI
+import UIKit
+
+final class MapViewController: UIViewController {
+
+    private let naverMapView: NMFNaverMapView = {
+        let naverMapView = NMFNaverMapView()
+
+        // 지도 UI 설정
+        naverMapView.showCompass = false
+        naverMapView.showScaleBar = false
+        naverMapView.showZoomControls = false
+        naverMapView.showLocationButton = true
+
+        // 지도 스타일
+        naverMapView.mapView.customStyleId = "9d41e3bf-0e89-45bc-8261-776fcdd1660d"
+
+        // 초기 카메라
+        let camera = NMFCameraPosition(
+            NMGLatLng(lat: 37.5665, lng: 126.9780),
+            zoom: 16,
+            tilt: 45,
+            heading: 0
+        )
+
+        naverMapView.mapView.moveCamera(NMFCameraUpdate(position: camera))
+
+        return naverMapView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureLocationManager()
+        configureSubviews()
+        configureLayout()
+        requestLocationAuthorizationIfNeeded()
+    }
+}
+
+// MARK: - Configure UI
+
+extension MapViewController {
+    private func configureSubviews() {
+        view.addSubview(naverMapView)
+        naverMapView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func configureLayout() {
+        let safeArea = view.safeAreaLayoutGuide
+
+        NSLayoutConstraint.activate([
+            naverMapView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            naverMapView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            naverMapView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            naverMapView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)
+        ])
+    }
+}
+// MARK: - MapViewWrapper
+
+struct MapViewWrapper: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> MapViewController {
+        let viewController = MapViewController()
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: MapViewController, context: Context) { }
+}

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -19,10 +19,9 @@ final class MapViewController: UIViewController {
 
         // 지도 UI 설정
         naverMapView.showCompass = false
-        naverMapView.showScaleBar = false
+        naverMapView.showScaleBar = true
         naverMapView.showZoomControls = false
         naverMapView.showLocationButton = true
-        naverMapView.showScaleBar = true
 
         // 최소 및 최대 줌 레벨 설정
         naverMapView.mapView.minZoomLevel = 15

--- a/Meomun/Secrets.example.xcconfig
+++ b/Meomun/Secrets.example.xcconfig
@@ -10,3 +10,4 @@
 
 // 복사해서 Secrets.xcconfig로 만들고 실제 키를 넣어주시면 됩니다
 NAVER_API_KEY = PUT_YOUR_KEY_HERE
+NMFNcpKeyId = PUT_YOUR_KEY_HERE

--- a/Meomun/SeoulCityHall.gpx
+++ b/Meomun/SeoulCityHall.gpx
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+    <wpt lat="37.5665" lon="126.9780">
+      <name>Seoul City Hall</name>
+    </wpt>
+</gpx>


### PR DESCRIPTION
## 배경

- closed #97 
- closed #98 
- closed #110 
- closed #112 

## 작업 요약
- [x] Naver Map SDK를 활용한 지도 UI 구성
- [x] 지도 확대/축소 범위 제한
- [x] 위치 정보 권한 요청
- [x] 사용자의 위치를 기준으로 지도 화면 표시
- [x] 시뮬레이터용 위치 정보 GPX 파일 추가

## 작업 내용

### 1. 지도 UI 구현

NMFNaverMapView를 생성하고 MapViewController의 루트 뷰에 전체 화면으로 배치했습니다. 지도 화면에서 불필요한 기본 UI 요소를 줄여 서비스 UX에 맞는 지도를 구성했습니다.

- showCompass = false: 나침반 UI 비활성화
- showScaleBar = true: 스케일바 표시
- showZoomControls = false: 확대/축소 버튼 UI 비활성화
- showLocationButton = true: 내 위치 버튼 활성화

지도 커스터마이징을 위해 customStyleId를 적용하여 서비스 분위기에 맞는 스타일을 사용하도록 설정했습니다.

```swift
// 지도 UI 설정
naverMapView.showCompass = false
naverMapView.showScaleBar = true
naverMapView.showZoomControls = false
naverMapView.showLocationButton = true

// 지도 스타일
naverMapView.mapView.customStyleId = "9d41e3bf-0e89-45bc-8261-776fcdd1660d"
```

초기 화면 진입 시 사용자가 빈 화면을 보지 않도록, 기본 카메라를 서울 시청 좌표로 세팅했습니다. 이후 실제 위치를 수신하면 현재 위치 기반으로 카메라를 다시 이동합니다.

```swift
let camera = NMFCameraPosition(
    NMGLatLng(lat: 37.5665, lng: 126.9780),
    zoom: 17,
    tilt: 45,
    heading: 0
)
naverMapView.mapView.moveCamera(NMFCameraUpdate(position: camera))
```

### 2. 지도 확대/축소 범위 제한

서비스 UX를 고려해 사용자가 과도하게 멀리/가깝게 이동하지 않도록 줌 레벨 범위를 제한했습니다.
[회의록](https://github.com/boostcampwm2025/ios04-ChanaPing/wiki/2025.12.15-(월)-회의록-%E2%80%90-오전)을 기반으로 유사한 크기를 선택하였습니다.

- 현재 설정:
    최소 줌: 15 (너무 광범위한 지도 탐색 방지)
    최대 줌: 18 (필요 이상 과도한 확대 방지)

### 3. 위치 정보 권한 요청

앱 실행 후 지도 화면이 표시될 때, 위치 기반 기능을 사용할 수 있도록 CLLocationManager를 사용하였습니다.
desiredAccuracy를 kCLLocationAccuracyBest로 설정해 최초 위치를 가능한 정확히 수신하도록 했습니다.

- 권한 상태에 따라 분기 처리:
    .notDetermined인 경우: requestWhenInUseAuthorization()로 권한 요청
    승인된 경우: 위치 업데이트 시작
    거부/제한된 경우: 현재 위치 기반 카메라 이동 불가 로그 출력

```swift
private func requestLocationAuthorizationIfNeeded() {
    let status = locationManager.authorizationStatus

    switch status {
    case .notDetermined:
        locationManager.requestWhenInUseAuthorization()
    case .authorizedWhenInUse, .authorizedAlways:
        startUpdatingLocationIfNeeded()
    case .denied, .restricted:
        print("위치 권한이 거부/제한되어 있어 현재 위치로 이동할 수 없습니다.")
    @unknown default:
        break
    }
}
```

권한 상태가 변경되는 시점을 놓치지 않기 위해 locationManagerDidChangeAuthorization에서 동일 로직을 재실행하도록 처리하였습니다.

```swift
func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
    requestLocationAuthorizationIfNeeded()
}
```

### 4. 사용자의 위치를 기준으로 지도 화면 표시

didUpdateLocations에서 최초로 수신한 사용자의 좌표를 기준으로 카메라를 이동합니다.
카메라 이동은 초기 1회만 수행되도록 didMoveToCurrentLocation 플래그로 보호했습니다.
- 이유: 위치 업데이트가 연속으로 들어오는 환경에서 카메라가 계속 튀거나, 사용자가 지도를 탐색하려는 UX를 방해하지 않도록 하기 위함

```swift
func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
    guard let currentLocation = locations.last else { return }
    guard didMoveToCurrentLocation == false else { return }

    didMoveToCurrentLocation = true

    let latLng = NMGLatLng(
        lat: currentLocation.coordinate.latitude,
        lng: currentLocation.coordinate.longitude
    )

    let cameraUpdate = NMFCameraUpdate(scrollTo: latLng)
    cameraUpdate.animation = .easeIn
    naverMapView.mapView.moveCamera(cameraUpdate)
}
```

위치 업데이트를 시작하는 시점에 positionMode 설정했습니다.
이를 통해 지도 화면에서 처음 사용자의 위치 오버레이를 표시할 수 있습니다.

### 5. 시뮬레이터용 GPX 파일 설정

시뮬레이터의 위치 정보를 서울 시청으로 고정하기 위해 Seoul City Hall.gpx 파일을 추가하였습니다.
시뮬레이터에서 사용하는 경우 다음과 같은 방식으로 위치 정보를 설정할 수 있습니다.

<img width="1822" height="1185" alt="스크린샷 2026-01-08 오전 4 36 31" src="https://github.com/user-attachments/assets/a1733639-7058-4105-990c-c081475fa7e5" />

## 스크린샷
|위치 정보 권한 요청|시작 위치 설정|확대|축소|
|---|---|---|---|
|<img width="1206" height="2622" alt="위치정보허용" src="https://github.com/user-attachments/assets/bd01b89a-d4a1-4a4e-af1f-c8c1bebc62b7" />|<img width="1206" height="2622" alt="기본" src="https://github.com/user-attachments/assets/a671c9a4-a927-4d64-b480-0f30bfab3e4f" />|<img width="1206" height="2622" alt="최대" src="https://github.com/user-attachments/assets/0d45d5e3-e135-4438-9f5e-5f660d36a04b" />|<img width="1206" height="2622" alt="최소" src="https://github.com/user-attachments/assets/cb59ca1b-eb82-4084-85b4-9f6edbee27e5" />|

## 리뷰 요구사항
gps 정확도를 위해 [cllocationaccuracy](https://developer.apple.com/documentation/corelocation/cllocationaccuracy)를 설정할 수 있습니다. 현재는 kCLLocationAccuracyBest를 사용하고 있습니다. 이 보다 높은 수준의 kCLLocationAccuracyBestForNavigation의 경우 공식 문서에서 배터리 소모가 크다고 소개되어 있습니다. 어떤 설정을 선택하면 좋을지 고민입니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
