### PR TITLE
지도 화면에서 메세지 작성 화면으로 전환

### DIFF
--- a/Meomun/Meomun/Presentation/Root/RootView.swift
+++ b/Meomun/Meomun/Presentation/Root/RootView.swift
@@ -25,6 +25,7 @@ struct RootView: View {
                 }
             )
         }
+        .ignoresSafeArea(.keyboard)
         .task {
             await store.send(intent: .onAppear)
         }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -11,45 +11,54 @@ struct MapView: View {
     @StateObject private var store = MapStore()
 
     var body: some View {
-        ZStack {
-            MapViewWrapper(messages: store.state.messages)
-                .ignoresSafeArea()
+        NavigationStack {
+            ZStack {
+                MapViewWrapper(messages: store.state.messages)
+                    .ignoresSafeArea()
 
-            VStack {
-                FloatingNavigationBar(
-                    title: "머문",
-                    onTapSearch: {}
-                )
+                VStack {
+                    FloatingNavigationBar(
+                        title: "머문",
+                        onTapSearch: {}
+                    )
 
-                Spacer()
-                HStack {
                     Spacer()
-                    WriteButton {
-                        Task {
-                            await store.send(intent: .tapWriteButton)
+
+                    HStack {
+                        Spacer()
+
+                        WriteButton {
+                            Task {
+                                await store.send(intent: .tapWriteButton)
+                            }
                         }
                     }
+                }
+                .padding(.top, 12)
+                .padding(.bottom, 96)
+            }
+            .navigationDestination(
+                isPresented: Binding(
+                    get: { store.state.isShowingAddMessage },
+                    set: { isPresented in
+                        if !isPresented {
+                            Task {
+                                await store.send(intent: .dismissAddMessage)
+                            }
+                        }
+                    }
+                )
+            ) {
+                MessageComposeView()
+            }
+            .task {
+                await store.send(intent: .onAppear)
+            }
+            .onDisappear {
+                Task {
+                    await store.send(intent: .onDisappear)
                 }
             }
-            .padding(.top, 12)
-            .padding(.bottom, 96)
-        }
-        .sheet(
-            isPresented: Binding(
-                get: { store.state.isShowingAddMessage },
-                set: { isPresented in
-                    if !isPresented {
-                        Task {
-                            await store.send(intent: .dismissAddMessage)
-                        }
-                    }
-                }
-            )
-        ) {
-            AddMessageView()
-        }
-        .task {
-            await store.send(intent: .onAppear)
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposeView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposeView.swift
@@ -61,6 +61,8 @@ struct MessageComposeView: View {
             Spacer(minLength: 0)
 
             ConfirmButton(action: {})
+
+            Spacer(minLength: 0)
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 24)


### PR DESCRIPTION
## 배경

- closed #125 
- closed #121 

## 작업 요약

- [x] 지도 화면에서 메세지 작성 화면 전환
- [x] 메세지 작성 화면 레이아웃 조절
- [x] 키보드 사용 시 탭바만 가리기

## 작업 내용

### 1. 메세지 작성 화면 전환

지도 화면에서 메세지 작성 버튼 탭 하는 경우 새 메세지 작성 화면으로 전환합니다.
새 메시지 작성 화면에서 탭바가 작성 완료 버튼을 가리는 문제 때문에 `MessageComposeView`의 레이아웃을 수정하였습니다.

### 2. 탭바 위치 고정

새 메세지 작성 시 텍스트필드에 입력하기 위한 키보드가 생성됩니다.
기존 코드에서 키보드 생성 시 화면 요소가 가려지지 않도록 레이아웃이 전부 올라오는 문제가 있었습니다.
탭바의 경우 키보드 생성 시에도 아래에 있도록 변경하였습니다.

## 스크린샷

https://github.com/user-attachments/assets/49817426-40a0-45dc-9d1c-8c944b10ac39

## 리뷰 요구사항

현재 MapStore에 있는 dismissAddMessage을 통해 `isShowingAddMessage` 상태를 변경합니다.
`isShowingAddMessage` 대신 “경로(path)”를 Store가 소유하고 관리하는 방식도 좋을 것 같습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
