### PR TITLE
SwiftLint private_over_fileprivate 규칙 비활성화

### DIFF
--- a/Meomun/.swiftlint.yml
+++ b/Meomun/.swiftlint.yml
@@ -5,6 +5,7 @@ excluded:
 
 # 1. 기본 규칙 비활성화: 기본 규칙 중 팀에서 원하지 않는 규칙이 있다면 여기에 추가합니다.
 disabled_rules:
+  - private_over_fileprivate
 
 # 2. 옵트인 규칙: API Design Guidelines 준수를 위해 반드시 켜야 하는 규칙
 opt_in_rules:


### PR DESCRIPTION
## 배경
- `fileprivate` 사용 시 SwiftLint 경고로 인해 팀원들과 합의 후 해당 규칙을 비활성화 하는 것으로 결정.

## 작업 요약
- `disabled_rules`에 `private_over_fileprivate`를 추가하여 해당 규칙을 비활성화 합니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
