### PR TITLE
메시지 작성 완료 토스트 구현

### DIFF
--- a/Meomun-Server/Supabase/messages/index.ts
+++ b/Meomun-Server/Supabase/messages/index.ts
@@ -22,20 +22,14 @@ function validateCreateMessageBody(body: any): CreateMessageRequest | string {
   if (!body || typeof body !== "object") return "Body must be a JSON object";
   if (typeof body.content !== "string" || body.content.trim().length === 0) return "content is required";
 
-  const coord = body.coordinate;
-  if (!coord || typeof coord !== "object") return "coordinate is required";
-  if (!isFiniteNumber(coord.latitude)) return "coordinate.latitude must be a number";
-  if (!isFiniteNumber(coord.longitude)) return "coordinate.longitude must be a number";
+  if (body.latitude !== undefined && !isFiniteNumber(body.latitude)) return "coordinate.latitude must be a number";
+  if (body.latitude !== undefined && !isFiniteNumber(body.longitude)) return "coordinate.longitude must be a number";
 
-  const placeTag = body.placeTag;
-  if (placeTag !== undefined && placeTag !== null) {
-    if (typeof placeTag !== "object") return "placeTag must be an object";
-    if (placeTag.coordinate !== undefined && placeTag.coordinate !== null) {
-      const pc = placeTag.coordinate;
-      if (typeof pc !== "object") return "placeTag.coordinate must be an object";
-      if (pc.latitude !== undefined && !isFiniteNumber(pc.latitude)) return "placeTag.coordinate.latitude must be a number";
-      if (pc.longitude !== undefined && !isFiniteNumber(pc.longitude)) return "placeTag.coordinate.longitude must be a number";
-    }
+  const place = body.place;
+  if (place !== undefined && place !== null) {
+    if (typeof place !== "object") return "place must be an object";
+      if (place.latitude !== undefined && !isFiniteNumber(place.latitude)) return "place.latitude must be a number";
+      if (place.longitude !== undefined && !isFiniteNumber(place.longitude)) return "place.longitude must be a number";
   }
 
   return body as CreateMessageRequest;

--- a/Meomun-Server/Supabase/messages/messagesRepo.ts
+++ b/Meomun-Server/Supabase/messages/messagesRepo.ts
@@ -18,9 +18,9 @@ export async function insertMessage(
   const row: MessageInsertRow = {
     author_id: userId,
     content: req.content,
-    latitude: req.coordinate.latitude,
-    longitude: req.coordinate.longitude,
-    place_id: req.placeTag?.id ?? null,
+    latitude: req.latitude,
+    longitude: req.longitude,
+    place_id: req.place?.id ?? null,
   };
 
   const { error } = await client.from("messages").insert(row);

--- a/Meomun/Meomun/Presentation/Common/Component/ToastView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/ToastView.swift
@@ -1,0 +1,23 @@
+//
+//  ToastView.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/16/26.
+//
+
+import SwiftUI
+
+struct ToastView: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.system(size: 14, weight: .medium))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.black.opacity(0.8))
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .transition(.opacity)
+    }
+}

--- a/Meomun/Meomun/Presentation/Root/RootView.swift
+++ b/Meomun/Meomun/Presentation/Root/RootView.swift
@@ -9,20 +9,29 @@ import SwiftUI
 
 struct RootView: View {
     @StateObject private var locationProvider = LocationProvider()
-    @State private var userLocation: Coordinate? = nil
+    @State private var userLocation: Coordinate?
 
     var body: some View {
         Group {
             #if DEBUG
             MainTabShellView(userLocation: .init(latitude: 37.5665, longitude: 126.9780))
-            #endif
+                .task {
+                    await SupabaseAuthBootstrapper.signInAnonymouslyIfNeeded()
+                    await SupabaseAuthBootstrapper.logCurrentAccessToken()
+                }
+            #else
             if let userLocation {
                 MainTabShellView(userLocation: userLocation)
+                    .task {
+                        await SupabaseAuthBootstrapper.signInAnonymouslyIfNeeded()
+                        await SupabaseAuthBootstrapper.logCurrentAccessToken()
+                    }
             } else {
                 LocationGateView { coordinate in
                     self.userLocation = coordinate
                 }
             }
+            #endif
         }
         .environmentObject(locationProvider)
         .ignoresSafeArea(.keyboard)

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -79,7 +79,10 @@ struct MapView: View {
                         userLocation: store.state.userLocation,
                         createMessage: CreateMessageUseCaseImpl(
                             messageRepository: MessageRepositoryImpl()
-                        )
+                        ),
+                        onClose: {
+                            Task { await store.send(intent: .dismissAddMessage)}
+                        }
                     )
                 )
                 .onAppear { setTabBarHidden(true) }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -65,16 +65,17 @@ final class MessageComposerStore: Store {
 
     @Published var state: State
 
-    private let createMessage: CreateMessageUseCase
+    private let createMessageUseCase: CreateMessageUseCase
+
     private let onClose: () -> Void
 
     init(
         userLocation: Coordinate,
-        createMessage: CreateMessageUseCase
+        createMessage: CreateMessageUseCase,
         onClose: @escaping () -> Void
     ) {
         self.state = State(userLocation: userLocation)
-        self.createMessage = createMessage
+        self.createMessageUseCase = createMessage
         self.onClose = onClose
         AppLog.debug("userLocation: \(userLocation)", category: .location)
     }
@@ -111,54 +112,7 @@ final class MessageComposerStore: Store {
                 if state.placeText != "" {
                     // TODO: 1차 검증) 장소 태그 존재 시, 현재 위치 기준으로 거리 검증
                 }
-
-                // 메시지 작성 API  호출
-                Task {
-                    continuation.yield(.setConfirmLoading(true))
-                    defer {
-                        continuation.yield(.setConfirmLoading(false))
-                        continuation.finish()
-                    }
-
-                    do {
-                        _ = try await createMessage.execute(
-                            CreateMessageRequestDTO(
-                                content: state.message,
-                                latitude: state.userLocation.latitude,
-                                longitude: state.userLocation.longitude,
-                                place: nil
-                            )
-                        )
-                    } catch let error as CreateMessageError {
-                        switch error {
-                        case .unauthorized:
-                            continuation.yield(.presentAlert(.init(
-                                title: "인증이 필요해요.",
-                                message: "익명 로그인(세션)이 없어서 메시지를 보낼 수 없어요."
-                            )))
-                        case .blocked:
-                            continuation.yield(.presentAlert(.init(
-                                title: "메시지를 등록할 수 없어요.",
-                                message: "내용이 정책에 의해 거부되었어요."
-                            )))
-                        case .unknown:
-                            continuation.yield(.presentAlert(.init(
-                                title: "메시지를 등록할 수 없어요.",
-                                message: "정책 판단을 확정할 수 없어 등록할 수 없어요."
-                            )))
-                        case .http(let code, let rawBody):
-                            continuation.yield(.presentAlert(.init(
-                                title: "요청 실패 (\(code))",
-                                message: rawBody.isEmpty ? "잠시 후 다시 시도해 주세요." : rawBody
-                            )))
-                        }
-                    } catch {
-                        continuation.yield(.presentAlert(.init(
-                            title: "네트워크에 연결할 수 없어요.",
-                            message: "네트워크 상태를 확인하고 다시 시도해 주세요."
-                        )))
-                    }
-                }
+                createMessage(continuation: continuation)
                 return
             }
             continuation.finish()
@@ -194,4 +148,71 @@ final class MessageComposerStore: Store {
         }
         return newState
     }
+}
+
+extension MessageComposerStore {
+    private func createMessage(continuation: AsyncStream<Action>.Continuation) {
+        Task {
+            continuation.yield(.setConfirmLoading(true))
+            defer {
+                continuation.yield(.setConfirmLoading(false))
+                continuation.finish()
+            }
+
+            do {
+                try await createMessageUseCase.execute(makeCreateMessageRequest())
+
+                continuation.yield(.showToast("메시지가 등록되었어요."))
+                try await Task.sleep(nanoseconds: 700_000_000)
+                continuation.yield(.close)
+
+            } catch let error as CreateMessageError {
+                continuation.yield(mapCreateMessageErrorToAlertAction(error))
+
+            } catch {
+                continuation.yield(.presentAlert(.init(
+                    title: "네트워크에 연결할 수 없어요.",
+                    message: "네트워크 상태를 확인하고 다시 시도해 주세요."
+                )))
+            }
+        }
+    }
+
+    private func makeCreateMessageRequest() -> CreateMessageRequestDTO {
+        CreateMessageRequestDTO(
+            content: state.message,
+            latitude: state.userLocation.latitude,
+            longitude: state.userLocation.longitude,
+            place: nil
+        )
+    }
+
+    private func mapCreateMessageErrorToAlertAction(_ error: CreateMessageError) -> Action {
+        switch error {
+        case .unauthorized:
+            return .presentAlert(.init(
+                title: "인증이 필요해요.",
+                message: "익명 로그인(세션)이 없어서 메시지를 보낼 수 없어요."
+            ))
+
+        case .blocked:
+            return .presentAlert(.init(
+                title: "메시지를 등록할 수 없어요.",
+                message: "내용이 정책에 의해 거부되었어요."
+            ))
+
+        case .unknown:
+            return .presentAlert(.init(
+                title: "메시지를 등록할 수 없어요.",
+                message: "정책 판단을 확정할 수 없어 등록할 수 없어요."
+            ))
+
+        case .http(let code, let rawBody):
+            return .presentAlert(.init(
+                title: "요청 실패 (\(code))",
+                message: rawBody.isEmpty ? "잠시 후 다시 시도해 주세요." : rawBody
+            ))
+        }
+    }
+
 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -22,10 +22,6 @@ final class MessageComposerStore: Store {
         var placeText: String = ""
         var isPlaceSearchPresented: Bool = false
 
-        var suggestPlaces: [String] = [
-            "스타벅스 파주가람점", "ONUTE", "콰이어트라이트", "메가MGC커피 파주별하람마을점"
-        ]
-        var isConfirmLoading: Bool = false
         var alert: AlertState?
 
         var isConfirmEnabled: Bool {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -66,13 +66,16 @@ final class MessageComposerStore: Store {
     @Published var state: State
 
     private let createMessage: CreateMessageUseCase
+    private let onClose: () -> Void
 
     init(
         userLocation: Coordinate,
         createMessage: CreateMessageUseCase
+        onClose: @escaping () -> Void
     ) {
         self.state = State(userLocation: userLocation)
         self.createMessage = createMessage
+        self.onClose = onClose
         AppLog.debug("userLocation: \(userLocation)", category: .location)
     }
 
@@ -187,7 +190,7 @@ final class MessageComposerStore: Store {
             newState.toastMessage = message
 
         case .close:
-            break
+            onClose()
         }
         return newState
     }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -23,7 +23,9 @@ final class MessageComposerStore: Store {
         var isPlaceSearchPresented: Bool = false
 
         var alert: AlertState?
+        var toastMessage: String?
 
+        var isConfirmLoading: Bool = false
         var isConfirmEnabled: Bool {
             message
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -44,6 +46,7 @@ final class MessageComposerStore: Store {
 
         case tapConfirm
         case dismissAlert
+        case dismissToast
     }
 
     enum Action {
@@ -56,6 +59,7 @@ final class MessageComposerStore: Store {
         case setConfirmLoading(Bool)
         case presentAlert(AlertState?)
 
+        case showToast(String?)
         case close
     }
 
@@ -96,6 +100,9 @@ final class MessageComposerStore: Store {
 
             case .dismissAlert:
                 continuation.yield(.presentAlert(nil))
+
+            case .dismissToast:
+                continuation.yield(.showToast(nil))
 
             case .tapConfirm:
                 if state.placeText != "" {
@@ -175,6 +182,9 @@ final class MessageComposerStore: Store {
 
         case .presentAlert(let alertState):
             newState.alert = alertState
+
+        case .showToast(let message):
+            newState.toastMessage = message
 
         case .close:
             break

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -100,10 +100,6 @@ extension MessageComposerView {
                 }
             }
 
-            PlaceTagSlider(places: store.state.suggestPlaces) { selected in
-                Task { await store.send(intent: .selectSuggestedPlace(selected))}
-            }
-
             Spacer(minLength: 0)
 
             ConfirmButton(action: {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -153,6 +153,19 @@ extension MessageComposerView {
                 })
             )
         }
+        .overlay(alignment: .bottom) {
+            if let toast = store.state.toastMessage {
+                ToastView(message: toast)
+                    .padding(.bottom, 32)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            Task {
+                                await store.send(intent: .dismissToast)
+                            }
+                        }
+                    }
+            }
+        }
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -181,7 +181,10 @@ extension MessageComposerView {
                 ),
                 createMessage: CreateMessageUseCaseImpl(
                     messageRepository: MessageRepositoryImpl()
-                )
+                ),
+                onClose: {
+                    print("close")
+                }
             )
         )
     }

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -86,7 +86,10 @@ struct SpaceView: View {
                             userLocation: coordinate,
                             createMessage: CreateMessageUseCaseImpl(
                                 messageRepository: MessageRepositoryImpl()
-                            )
+                            ),
+                            onClose: {
+                                Task { await store.send(intent: .dismissAddMessage) }
+                            }
                         )
                     )
                 }
@@ -97,7 +100,6 @@ struct SpaceView: View {
         }
         .onChange(of: store.state.messages.map(\.id)) {
             let snapshot = store.state.messages
-            print("onchange")
             syncIfPossible(messages: snapshot)
         }
     }


### PR DESCRIPTION
## 배경
- closed #113 

## 작업 요약
- [x] 메시지 업로드 성공 시 토스트 출력
- [x] 메시지 업로드 성공 후 화면 close
- [x] Store 복잡도 리팩터링
- [x] supabase 비회원 로그인 세션 등록부 추가
- [x] 장소 추천 태그 버튼 슬라이더 제거
- [x] 메시지 작성 요청 형식 변경에 따른 Edge Function 코드 대응 (coordinate -> lat/lon)

## 작업 내용
### 메시지 업로드 성공 동작 추가

```swift
    struct State: Equatable {
        var toastMessage: String?
        ...
    }
    
    enum Intent {
        case dismissToast
    }

    enum Action {
        case showToast(String?)
    }
```

- 토스트 관련 State/Intent/Action 값 추가
- 메시지 생성 성공 시 처리 순서
  1. .showToast("메시지가 등록되었어요.")
  2. Task.sleep으로 짧게 대기 (UX 목적)
  3. .close
  
  ```swift
    continuation.yield(.showToast("메시지가 등록되었어요."))
    try await Task.sleep(nanoseconds: 700_000_000)
    continuation.yield(.close)
  ```
- store에 onClose() 추가 -> 메시지 작성 완료 후 자동으로 닫힘

### Store 복잡도로 인한 리팩터링
#### 문제
- `action(intent:)` 내부 `.tapConfirm` 로직이 과도하게 길어짐
- Cyclomatic Complexity / Function Body Length 경고 발생

#### 해결
- 메시지 생성 처리 로직을 별도 private 함수로 분리
- 에러 → Alert 매핑도 함수화

#### 결과
- `action(intent:)`는 intent routing 역할만 수행


## 스크린샷

https://github.com/user-attachments/assets/847ab6c9-45d3-49d7-a27d-59019c9aecf0

## 리뷰 요구사항
- 갬성 토스트 문구 추천 부탁드립니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
