### PR TITLE
지도 화면에서 네이버 지도 카메라를 현재 위치로 계속 이동하는 오류 수정

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -181,11 +181,10 @@ extension MapViewController {
 extension MapViewController {
     func updateUserLocation(_ coordinate: Coordinate?) {
         guard let coordinate else { return }
-
-        naverMapView.mapView.positionMode = .direction
-
         guard didMoveToCurrentLocation == false else { return }
         didMoveToCurrentLocation = true
+
+        naverMapView.mapView.positionMode = .direction
 
         let latLng = NMGLatLng(lat: coordinate.latitude, lng: coordinate.longitude)
         let cameraUpdate = NMFCameraUpdate(scrollTo: latLng)


### PR DESCRIPTION
## 작업 내용
- 지도 화면에서 드래그를 통해 다른 화면으로 옮겨도 현재 위치로 다시 옮겨지는 오류 수정

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
