### PR TITLE
실시간 메시지 업데이트 정보 수신 구현

### DIFF
--- a/Meomun-Server/Supabase/process_message_expirations.sql
+++ b/Meomun-Server/Supabase/process_message_expirations.sql
@@ -1,0 +1,7 @@
+begin
+  update public.messages
+  set expired_at = now()
+  where expired_at is null
+    and expires_at <= now()
+    and deleted_at is null;
+end;

--- a/Meomun-Server/Supabase/process_message_freshness.sql
+++ b/Meomun-Server/Supabase/process_message_freshness.sql
@@ -1,0 +1,8 @@
+begin
+  update public.messages
+  set is_fresh = false
+  where is_fresh = true
+    and created_at <= now() - interval '20 minutes'
+    and deleted_at is null
+    and expired_at is null;
+end;

--- a/Meomun-Server/Supabase/trg_messages_expired_broadcast.sql
+++ b/Meomun-Server/Supabase/trg_messages_expired_broadcast.sql
@@ -1,0 +1,12 @@
+begin
+  if old.expired_at is null and new.expired_at is not null then
+    perform realtime.send(
+      jsonb_build_object('type','expired','id', new.id),
+      'messages:nearby',
+      'messages-nearby',
+      false
+    );
+  end if;
+
+  return new;
+end;

--- a/Meomun-Server/Supabase/trg_messages_insert_broadcast.sql
+++ b/Meomun-Server/Supabase/trg_messages_insert_broadcast.sql
@@ -1,0 +1,37 @@
+declare
+  v_place jsonb;
+begin
+  if new.place_id is not null then
+    select jsonb_build_object(
+      'place_id', p.place_id,
+      'name', p.name,
+      'latitude', st_y(p.location::geometry),
+      'longitude', st_x(p.location::geometry)
+    )
+    into v_place
+    from public.places p
+    where p.place_id = new.place_id;
+  else
+    v_place := null;
+  end if;
+
+  perform realtime.send(
+    jsonb_build_object(
+      'type', 'created',
+      'message', jsonb_build_object(
+        'id', new.id,
+        'author_id', new.author_id,
+        'created_at', new.created_at,
+        'content', new.content,
+        'latitude', new.latitude,
+        'longitude', new.longitude,
+        'place', v_place
+      )
+    ),
+    'messages:nearby',
+    'messages-nearby',
+    false
+  );
+
+  return new;
+end;

--- a/Meomun-Server/Supabase/trg_messages_soft_delete_broadcast.sql
+++ b/Meomun-Server/Supabase/trg_messages_soft_delete_broadcast.sql
@@ -1,0 +1,12 @@
+begin
+  if old.deleted_at is null and new.deleted_at is not null then
+    perform realtime.send(
+      jsonb_build_object('type','deleted','id', new.id),
+      'messages:nearby',
+      'messages-nearby',
+      false
+    );
+  end if;
+
+  return new;
+end;

--- a/Meomun-Server/Supabase/trg_messages_stale_broadcast.sql
+++ b/Meomun-Server/Supabase/trg_messages_stale_broadcast.sql
@@ -1,0 +1,12 @@
+begin
+  if old.is_fresh = true and new.is_fresh = false then
+    perform realtime.send(
+      jsonb_build_object('type','stale','id', new.id),
+      'messages:nearby',
+      'messages-nearby',
+      false
+    );
+  end if;
+
+  return new;
+end;

--- a/Meomun/Meomun/App/AppLog.swift
+++ b/Meomun/Meomun/App/AppLog.swift
@@ -18,6 +18,7 @@ enum LogCategory: String {
     case space = "Space"    // 3D 공간, Realitykit 관련
     case resource = "Resource"  // 모델, material, 에셋 로딩 관련
     case login = "Login"
+    case realtime = "Realtime"
 }
 
 enum AppLog {

--- a/Meomun/Meomun/Data/DTO/RealtimeMessageDTO.swift
+++ b/Meomun/Meomun/Data/DTO/RealtimeMessageDTO.swift
@@ -16,6 +16,20 @@ struct RealtimeCreatedMessageDTO: Decodable {
     let longitude: Double
     let placeId: PlaceDTO?
 
+    enum CodingKeys: String, CodingKey {
+        case id
+        case authorId = "author_id"
+        case createdAt = "created_at"
+        case content
+        case latitude
+        case longitude
+        case placeId = "place_id"
+    }
+}
+
+// MARK: - Mapping
+
+extension RealtimeCreatedMessageDTO {
     func toDomain() -> Message {
         Message(
             id: MessageID(value: id),

--- a/Meomun/Meomun/Data/DTO/RealtimeMessageDTO.swift
+++ b/Meomun/Meomun/Data/DTO/RealtimeMessageDTO.swift
@@ -14,7 +14,7 @@ struct RealtimeCreatedMessageDTO: Decodable {
     let content: String
     let latitude: Double
     let longitude: Double
-    let placeId: String?
+    let placeId: PlaceDTO?
 
     func toDomain() -> Message {
         Message(
@@ -26,18 +26,7 @@ struct RealtimeCreatedMessageDTO: Decodable {
                 latitude: latitude,
                 longitude: longitude
             ),
-            placeTag: (
-                placeId == nil ? nil : Place(
-                    id: PlaceID(
-                        value: placeId!
-                    ),
-                    name: "",   // place도 같이 받아와야 되는구나..
-                    coordinate: Coordinate(
-                        latitude: latitude,
-                        longitude: longitude
-                    )
-                )
-            )
+            placeTag: (placeId == nil ? nil : placeId?.toDomain())
         )
     }
 }

--- a/Meomun/Meomun/Data/DTO/RealtimeMessageDTO.swift
+++ b/Meomun/Meomun/Data/DTO/RealtimeMessageDTO.swift
@@ -1,0 +1,43 @@
+//
+//  RealtimeMessageDTO.swift
+//  Meomun
+//
+//  Created by 지연 on 1/20/26.
+//
+
+import Foundation
+
+struct RealtimeCreatedMessageDTO: Decodable {
+    let id: UUID
+    let authorId: UUID
+    let createdAt: Date
+    let content: String
+    let latitude: Double
+    let longitude: Double
+    let placeId: String?
+
+    func toDomain() -> Message {
+        Message(
+            id: MessageID(value: id),
+            authorID: UserID(value: authorId),
+            createdAt: createdAt,
+            content: content,
+            coordinate: Coordinate(
+                latitude: latitude,
+                longitude: longitude
+            ),
+            placeTag: (
+                placeId == nil ? nil : Place(
+                    id: PlaceID(
+                        value: placeId!
+                    ),
+                    name: "",   // place도 같이 받아와야 되는구나..
+                    coordinate: Coordinate(
+                        latitude: latitude,
+                        longitude: longitude
+                    )
+                )
+            )
+        )
+    }
+}

--- a/Meomun/Meomun/Data/Extension/AnyJSON+toAnyObject.swift
+++ b/Meomun/Meomun/Data/Extension/AnyJSON+toAnyObject.swift
@@ -1,0 +1,52 @@
+//
+//  AnyJSON+toAnyObject.swift
+//  Meomun
+//
+//  Created by 지연 on 1/20/26.
+//
+
+import Foundation
+import Supabase
+
+extension AnyJSON {
+    var stringValue: String? {
+        guard case let .string(value) = self else { return nil }
+        return value
+    }
+
+    var objectValue: [String: AnyJSON]? {
+        guard case let .object(dictionary) = self else { return nil }
+        return dictionary
+    }
+
+    func toAnyObject() -> Any {
+        switch self {
+        case .string(let value):
+            return value
+
+        case .double(let value):
+            return value
+
+        case .integer(let value):
+            return value
+
+        case .bool(let value):
+            return value
+
+        case .null:
+            return NSNull()
+
+        case .array(let elements):
+            return elements.map { $0.toAnyObject() }
+
+        case .object(let dictionary):
+            return dictionary.mapValues { $0.toAnyObject() }
+        }
+    }
+}
+
+extension Dictionary where Key == String, Value == AnyJSON {
+    func toAnyObject() -> [String: Any] {
+        mapValues { $0.toAnyObject() }
+    }
+}

--- a/Meomun/Meomun/Data/MessageRealtimeManager.swift
+++ b/Meomun/Meomun/Data/MessageRealtimeManager.swift
@@ -1,0 +1,134 @@
+//
+//  MessageRealtimeManager.swift
+//  Meomun
+//
+//  Created by 지연 on 1/16/26.
+//
+
+import Supabase
+import Foundation
+
+final class MessageRealtimeManager: MessageRealtimeManaging {
+    private let supabase: SupabaseClient
+
+    private var channel: RealtimeChannelV2?
+    private var listenTask: Task<Void, Never>?
+
+    init(supabase: SupabaseClient = SupabaseService.shared.client) {
+        self.supabase = supabase
+    }
+
+    func subscribeNearby(topic: String = "messages:nearby") -> AsyncStream<MessageRealtimeEvent> {
+        AsyncStream { continuation in
+            stopListening()
+
+            let channel = supabase.realtimeV2.channel("messages-nearby")
+            self.channel = channel
+
+            listenTask = Task { [weak self] in
+                guard let self else { return }
+                defer { continuation.finish() }
+
+                await channel.subscribe()
+                AppLog.debug("subscribed to \(topic)", category: .realtime)
+
+                let stream = channel.broadcastStream(event: topic)
+
+                for await message in stream {
+                    if Task.isCancelled { break }
+
+                    if let event = self.parseBroadcast(message) {
+                        continuation.yield(event)
+                    } else {
+                        AppLog.error("failed to parse message: \(message)", category: .realtime)
+                    }
+                }
+            }
+            continuation.onTermination = { [weak self] _ in
+                self?.stopListening()
+            }
+        }
+    }
+
+    func unsubscribeNearby() {
+        stopListening()
+    }
+}
+
+private extension MessageRealtimeManager {
+    func stopListening() {
+        listenTask?.cancel()
+        listenTask = nil
+
+        guard let channel else { return }
+
+        Task { [weak self] in
+            await channel.unsubscribe()
+            self?.channel = nil
+            AppLog.debug("unsubscribed from messages-nearby", category: .realtime)
+        }
+    }
+
+    func parseBroadcast(_ message: JSONObject) -> MessageRealtimeEvent? {
+            let root = extractPayloadObject(from: message)
+
+            guard let type = root["type"]?.stringValue else { return nil }
+
+            switch type {
+            case "created":
+                do {
+                    let data = try JSONSerialization.data(withJSONObject: root.toAnyObject(), options: [])
+                    let dto = try JSONDecoders.iso8601.decode(RealtimeCreatedMessageDTO.self, from: data)
+                    return .created(dto.toDomain())
+                } catch {
+                    AppLog.error("created decode failed:", category: .realtime, error: error)
+                    return nil
+                }
+
+            case "deleted":
+                return parseIdEvent(root, as: .deleted)
+
+            case "expired":
+                return parseIdEvent(root, as: .expired)
+
+            case "stale":
+                return parseIdEvent(root, as: .becameStale)
+
+            default:
+                return nil
+            }
+        }
+
+        func extractPayloadObject(from message: JSONObject) -> JSONObject {
+            // 1) payload 키로 감싸진 경우
+            if let payload = message["payload"]?.objectValue {
+                return payload
+            }
+            // 2) 바로 내려오는 경우
+            return message
+        }
+
+        enum IdEventKind {
+            case deleted, expired, becameStale
+        }
+
+        func parseIdEvent(_ root: JSONObject, as kind: IdEventKind) -> MessageRealtimeEvent? {
+            guard
+                let idString = root["id"]?.stringValue,
+                let uuid = UUID(uuidString: idString)
+            else { return nil }
+
+            let id = MessageID(value: uuid)
+
+            switch kind {
+            case .deleted:
+                return .deleted(id: id)
+
+            case .expired:
+                return .expired(id: id)
+
+            case .becameStale:
+                return .becameStale(id: id)
+            }
+        }
+}

--- a/Meomun/Meomun/Data/MessageRealtimeManager.swift
+++ b/Meomun/Meomun/Data/MessageRealtimeManager.swift
@@ -76,8 +76,10 @@ private extension MessageRealtimeManager {
 
             switch type {
             case "created":
+                guard let messageObject = root["message"]?.objectValue else { return nil }
+
                 do {
-                    let data = try JSONSerialization.data(withJSONObject: root.toAnyObject(), options: [])
+                    let data = try JSONSerialization.data(withJSONObject: messageObject.toAnyObject(), options: [])
                     let dto = try JSONDecoders.iso8601.decode(RealtimeCreatedMessageDTO.self, from: data)
                     return .created(dto.toDomain())
                 } catch {

--- a/Meomun/Meomun/Domain/Entity/RealtimeEvent.swift
+++ b/Meomun/Meomun/Domain/Entity/RealtimeEvent.swift
@@ -10,3 +10,10 @@ enum RealtimeEvent {
     case insert
     case delete
 }
+
+enum MessageRealtimeEvent: Sendable {
+    case created(Message)           // 새 메시지 payload 전체
+    case deleted(id: MessageID)     // soft delete
+    case expired(id: MessageID)     // ttl 만료
+    case becameStale(id: MessageID) // 20분 지나 fresh -> false
+}

--- a/Meomun/Meomun/Domain/MessageRealtimeManaging.swift
+++ b/Meomun/Meomun/Domain/MessageRealtimeManaging.swift
@@ -1,0 +1,11 @@
+//
+//  MessageRealtimeManaging.swift
+//  Meomun
+//
+//  Created by 지연 on 1/16/26.
+//
+
+protocol MessageRealtimeManaging: Sendable {
+    func subscribeNearby(topic: String) -> AsyncStream<MessageRealtimeEvent>
+    func unsubscribeNearby()
+}


### PR DESCRIPTION
## 배경
- closed #212

## 작업 요약
- 실시간 메시지 업데이트 정보 수신 구현
  - **서버**: trigger 함수 연결
  - **클라이언트**: RealtimeManager 구현

## 작업 내용
### 1. 실시간 메시지 상태 동기화 구현
#### 배경
지도 화면에서 근처 메시지 목록을 최초 로드(전체)한 뒤, 이후 DB 상태 변화에 따라 **실시간으로 메시지 상태를 동기화**해야 함.

- 동기화 대상 이벤트
  1. **created**: 다른 사용자가 메시지를 생성
  2. **deleted**: soft delete 발생 (deleted_at 채워짐)
  3. **expired**: TTL 만료 처리 (expired_at 채워짐)
  4. **stale**: 최신 메시지 조건 해제 (is_fresh = false)

> created는 지도에 바로 그릴 수 있도록 **메시지 전체 정보 + place 태그(선택)**까지 전달하고,
> deleted/expired/stale는 **메시지 id만** 전달해도 충분함.

#### 전체 구조
* **DB (Postgres)**
  * 메시지 상태 변경을 정규화된 컬럼으로 표현
    * 삭제: deleted_at
    * 만료: expired_at
    * 최신 여부: is_fresh
  * 즉시 이벤트(created/deleted)는 trigger로 감지
  * 시간 기반 이벤트(expired/stale)는 cron이 주기적으로 갱신
* **Realtime (Supabase Realtime v2)**
  * DB/cron/trigger에서 발생한 이벤트를 realtime.send로 **broadcast**
  * 클라이언트는 특정 채널/이벤트(topic)를 subscribe해서 받음.
* **Client (iOS)**
  * MessageRealtimeManager가 Realtime 채널 구독을 담당
  * 수신 payload를 MessageRealtimeEvent로 파싱 후, 화면(Store)에 전달
  * created는 Message 도메인으로 변환해서 즉시 UI에 반영 가능하도록 함.

#### 1) DB 컬럼 기반 상태 모델
메시지 테이블에서 상태 변경을 컬럼 업데이트로 표현하여 실시간 감지가 용이하게 되도록 하였다.
* deleted_at IS NOT NULL → 삭제됨(soft delete)
* expired_at IS NOT NULL → 만료됨
* is_fresh = false → 최신 메시지 아님
⠀
#### 2) 시간 기반 상태 변화는 cron이 처리
1. **TTL 만료 처리: expired_at 채우기**
```sql
begin
  update public.messages
  set expired_at = now()
  where expired_at is null
    and expires_at <= now()
    and deleted_at is null;
end;
```

2. **최신 상태 해제: is_fresh = false**
```sql
begin
  update public.messages
  set is_fresh = false
  where is_fresh = true
    and created_at <= now() - interval '20 minutes'
    and deleted_at is null
    and expired_at is null;
end;
```

#### 3) 즉각적인 이벤트는 trigger가 처리
1. **created: insert 시 broadcast (place 포함)**
   - created는 지도 UI에 바로 표시할 수 있도록 **message 오브젝트 전체**를 보낸다.
2. **deleted: deleted_at이 null → not null로 바뀔 때**
3. **expired: expired_at이 null → not null로 바뀔 때**
4. **stale: is_fresh가 true → false로 바뀔 때**
   - deleted/expired/stale는 화면에서 해당 메시지 id만 처리하면 되므로 id만 보낸다.

#### 4) 클라이언트: Realtime v2 구독 + 파싱 + 도메인 변환
1. 구독 담당 객체: **MessageRealtimeManager**
   * 특정 채널(messages-nearby)에 구독
   * 특정 event(topic: messages:nearby)의 broadcastStream을 읽음
   * payload를 파싱해서 MessageRealtimeEvent로 외부에 흘려보냄
2. payload 감싸짐 처리
   - Supabase v2의 broadcast payload는 일반적으로 아래와 같이 옴.
     ```
     {
     	"type": "broadcast",
     	"event": "messages:nearby",
     	 "meta": {...},
     	"payload": {...}
     }
     ```
   - -> 클라이언트에서는 payload 키가 있으면 payload를 root로 사용, 없으면 그대로 message를 root로 사용해야 함.
     ```swift
     func extractPayloadObject(from message: JSONObject) -> JSONObject {
     	if let payload = message["payload"]?.objectValue { return payload }
     	return message
     }
     ```

#### 5) created 이벤트는 DTO -> Domain으로 변환하여 사용
created의 message는 데이터 구조가 크므로 DTO로 디코딩 처리를 거침.
```swift
struct RealtimeCreatedMessageDTO: Decodable {
    let id: UUID
    let authorId: UUID
    let createdAt: Date
    let content: String
    let latitude: Double
    let longitude: Double
    let placeId: PlaceDTO?
    ...
}
```

#### 6) AnyJSON -> JSONDecoder로 넘기기 위한 변환 유틸
Supabase broadcastStream이 내려주는 타입이 `JSONObject (Dictionary<String, AnyJSON>)`이기 때문에 **JSONDecoder로 바로 decode가 안됨.**

-> 다음의 확장을 통해 변환 과정을 거침
* AnyJSON을 Any로 변환 (`toAnyObject()`)
* JSONObject를 `[String: Any]`로 변환
* 이를 `JSONSerialization.data(withJSONObject:)`로 Data 만들고 decode
```swift
let data = try JSONSerialization.data(withJSONObject: messageObject.toAnyObject(), options: [])
let dto = try JSONDecoders.iso8601.decode(RealtimeCreatedMessageDTO.self, from: data)
```

#### 7) 이벤트 UI 처리
* `.created(Message)`
  * -> 지도/공간 화면의 메시지 리스트에 append
* `.deleted(id)` / `.expired(id)` / `.becameStale(id)`
  * -> 이미 가지고 있던 메시지 배열에서 id로 찾기
    * 삭제/만료면 제거 혹은 숨김 처리
    * stale이면 최신 여부 인디케이터 색상 변경(주황 -> 파랑)

## 스크린샷
### 테스트 시나리오
#### 1. created 테스트
* place_id null / not null 두 케이스로 insert
* 클라 콘솔에서 .created(...) 이벤트가 오고 place가 포함되면 성공

#### 2. deleted 테스트
* 특정 메시지의 deleted_at = now() 업데이트
* .deleted(id:) 수신 확인

#### 3. expired 테스트
* expires_at = now() + interval '1 minute'로 넣고 cron 기다림
* expired_at 채워지고 .expired(id:) 수신 확인

#### 4. stale 테스트
* created_at = now() - interval '21 minutes' 혹은 cron 기다림
* is_fresh = false로 바뀌고 .becameStale(id:) 수신 확인

### 테스트 결과: 연결 성공 후 실시간 데이터 수신 확인 완료
<img width="861" height="172" alt="스크린샷 2026-01-20 오전 2 33 01" src="https://github.com/user-attachments/assets/7bc2b5bc-1d52-44d7-a7d9-fa41fb15c7be" />

<img width="808" height="37" alt="스크린샷 2026-01-20 오전 2 33 10" src="https://github.com/user-attachments/assets/cd039643-0e16-4171-951d-cea72dd40700" />

<img width="872" height="138" alt="스크린샷 2026-01-20 오전 2 33 19" src="https://github.com/user-attachments/assets/424e0d8a-0d27-42eb-8006-9c3fa3b204a9" />
 

## 리뷰 요구사항
현재 서버 및 클라이언트 실시간 이벤트 동기화를 위한 함수는 전부 작성된 상태이고, 이를 사용자 화면에 표시하기 위하여 연결하는 로직은 아직 작성되지 않았으며 다음 pr에 포함될 예정인 점 참고 부탁드립니다!

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
