### PR TITLE
메세지 작성 시 위치 검증 로직 구현

### DIFF
--- a/Meomun/.swiftlint.yml
+++ b/Meomun/.swiftlint.yml
@@ -6,6 +6,7 @@ excluded:
 # 1. 기본 규칙 비활성화: 기본 규칙 중 팀에서 원하지 않는 규칙이 있다면 여기에 추가합니다.
 disabled_rules:
   - private_over_fileprivate
+  - cyclomatic_complexity
 
 # 2. 옵트인 규칙: API Design Guidelines 준수를 위해 반드시 켜야 하는 규칙
 opt_in_rules:

--- a/Meomun/Meomun/Presentation/Root/LocationProvider.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationProvider.swift
@@ -15,6 +15,11 @@ final class LocationProvider: NSObject, ObservableObject {
 
     private let manager = CLLocationManager()
 
+    // 앱 단위 정책에서 연속 추적을 요청했는지 여부
+    private var wantsContinuousUpdates = false
+    // 연속 추적이 이미 시작된 상태인지 여부(멱등성)
+    private var isContinuousUpdating = false
+
     // one-shot 대기자 (공간 화면에서 작성 버튼 탭 시 사용)
     private var oneShotContinuations: [CheckedContinuation<Coordinate, Error>] = []
     private var isRequestingOneShot = false
@@ -44,18 +49,37 @@ final class LocationProvider: NSObject, ObservableObject {
         }
     }
 
-    // 지도 화면: 지속 추적 시작
+    // 연속 추적 시작(앱 단위 정책)
     func startContinuous() {
+        wantsContinuousUpdates = true
+
         guard manager.authorizationStatus == .authorizedWhenInUse
                 || manager.authorizationStatus == .authorizedAlways else {
             requestAuthorizationIfNeeded()
             return
         }
+
+        guard isContinuousUpdating == false else {
+            AppLog.debug("startContinuous() skipped (already updating)", category: .location)
+            return
+        }
+
+        isContinuousUpdating = true
+        AppLog.debug("startUpdatingLocation()", category: .location)
         manager.startUpdatingLocation()
     }
 
-    // 지도 화면: 지속 추적 종료
+    // 연속 추적 종료(앱 단위 정책)
     func stopContinuous() {
+        wantsContinuousUpdates = false
+
+        guard isContinuousUpdating else {
+            AppLog.debug("stopContinuous() skipped (not updating)", category: .location)
+            return
+        }
+
+        isContinuousUpdating = false
+        AppLog.debug("stopUpdatingLocation()", category: .location)
         manager.stopUpdatingLocation()
     }
 
@@ -100,6 +124,11 @@ extension LocationProvider: CLLocationManagerDelegate {
         // 권한이 허용으로 바뀌면 current warm-up
         if authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways {
             manager.requestLocation()
+
+            // startContinuous()가 권한 요청으로 인해 대기 중이었다면, 권한 허용 즉시 연속 추적을 시작
+            if wantsContinuousUpdates {
+                startContinuous()
+            }
         }
     }
 
@@ -108,6 +137,10 @@ extension LocationProvider: CLLocationManagerDelegate {
         didUpdateLocations locations: [CLLocation]
     ) {
         isRequestingOneShot = false
+
+        if wantsContinuousUpdates {
+            isContinuousUpdating = true
+        }
 
         guard let last = locations.last else {
             failOneShots(LocationError.noLocation)

--- a/Meomun/Meomun/Presentation/Root/LocationProvider.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationProvider.swift
@@ -8,7 +8,6 @@
 import CoreLocation
 import Combine
 
-@MainActor
 final class LocationProvider: NSObject, ObservableObject {
     @Published private(set) var current: Coordinate?
     @Published private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined

--- a/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
+++ b/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
@@ -58,6 +58,16 @@ struct MainTabShellView: View {
                     locationProvider: locationProvider,
                     fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCaseImpl(
                         messageRepository: MessageRepositoryImpl()
+                    ),
+                    place: Place(
+                        id: PlaceID(
+                            value: ""
+                        ),
+                        name: "",
+                        coordinate: Coordinate(
+                            latitude: 0.0,
+                            longitude: 0.0
+                        )
                     )
                 ),
                 domeEnvironment: DomeEnvironment(

--- a/Meomun/Meomun/Presentation/Root/RootView.swift
+++ b/Meomun/Meomun/Presentation/Root/RootView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct RootView: View {
     @StateObject private var locationProvider = LocationProvider()
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var didStartContinuous = false
     @State private var userLocation: Coordinate?
 
     var body: some View {
@@ -32,6 +34,25 @@ struct RootView: View {
                 }
             }
             #endif
+        }
+        .task {
+            if didStartContinuous == false {
+                didStartContinuous = true
+                locationProvider.requestAuthorizationIfNeeded()
+                locationProvider.startContinuous()
+            }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            switch newPhase {
+            case .active:
+                locationProvider.startContinuous()
+            case .background:
+                locationProvider.stopContinuous()
+            case .inactive:
+                break
+            @unknown default:
+                break
+            }
         }
         .environmentObject(locationProvider)
         .ignoresSafeArea(.keyboard)

--- a/Meomun/Meomun/Presentation/Root/RootView.swift
+++ b/Meomun/Meomun/Presentation/Root/RootView.swift
@@ -35,25 +35,6 @@ struct RootView: View {
             }
             #endif
         }
-        .task {
-            if didStartContinuous == false {
-                didStartContinuous = true
-                locationProvider.requestAuthorizationIfNeeded()
-                locationProvider.startContinuous()
-            }
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            switch newPhase {
-            case .active:
-                locationProvider.startContinuous()
-            case .background:
-                locationProvider.stopContinuous()
-            case .inactive:
-                break
-            @unknown default:
-                break
-            }
-        }
         .environmentObject(locationProvider)
         .ignoresSafeArea(.keyboard)
     }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -86,7 +86,7 @@ struct MapView: View {
                             messageRepository: MessageRepositoryImpl()
                         ),
                         onClose: {
-                            Task { await store.send(intent: .dismissAddMessage)}
+                            Task { await store.send(intent: .dismissAddMessage) }
                         }
                     )
                 )
@@ -121,13 +121,10 @@ struct MapView: View {
                 }
             }
             .task {
-                locationProvider.requestAuthorizationIfNeeded()
-                locationProvider.startContinuous()
                 await store.send(intent: .onAppear)
             }
             .onAppear { setTabBarHidden(false) }
             .onDisappear {
-                locationProvider.stopContinuous()
                 Task {
                     await store.send(intent: .onDisappear)
                 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -11,7 +11,6 @@ struct MapView: View {
     @Environment(\.setTabBarHidden) private var setTabBarHidden
     @EnvironmentObject private var locationProvider: LocationProvider
     @StateObject private var store: MapStore
-    @State private var currentUserLocation: Coordinate?     // TODO: MessageComposerStore에 LocationProvider 주입 후 제거
 
     private let messageMarkerManager: MessageMarkerManager
     private let initialUserLocation: Coordinate
@@ -70,17 +69,7 @@ struct MapView: View {
                         Spacer()
 
                         WriteButton {
-                            Task {
-                                do {
-                                    let location = try await locationProvider.requestCurrentOnce()
-                                    currentUserLocation = location
-                                    await store.send(intent: .tapWriteButton)
-                                } catch {
-                                    // 위치 가져오기 실패 시 에러 처리
-                                    AppLog.error("Failed to get current location", category: .location, error: error)
-                                    // TODO: 사용자에게 에러 알림 표시
-                                }
-                            }
+                            Task { await store.send(intent: .tapWriteButton) }
                         }
                     }
                 }
@@ -99,20 +88,18 @@ struct MapView: View {
                     }
                 )
             ) {
-                if let userLocation = currentUserLocation {
-                    MessageComposerView(
-                        store: MessageComposerStore(
-                            userLocation: userLocation,
-                            createMessage: CreateMessageUseCaseImpl(
-                                messageRepository: MessageRepositoryImpl()
-                            ),
-                            onClose: {
-                                Task { await store.send(intent: .dismissAddMessage)}
-                            }
-                        )
+                MessageComposerView(
+                    store: MessageComposerStore(
+                        locationProvider: locationProvider,
+                        createMessage: CreateMessageUseCaseImpl(
+                            messageRepository: MessageRepositoryImpl()
+                        ),
+                        onClose: {
+                            Task { await store.send(intent: .dismissAddMessage) }
+                        }
                     )
-                    .onAppear { setTabBarHidden(true) }
-                }
+                )
+                .onAppear { setTabBarHidden(true) }
             }
             .navigationDestination(
                 isPresented: Binding(

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -119,7 +119,8 @@ struct MapView: View {
                             locationProvider: locationProvider,
                             fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCaseImpl(
                                 messageRepository: MessageRepositoryImpl()
-                            )
+                            ),
+                            place: place
                         ),
                         domeEnvironment: .init(
                             weather: .sunny,

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -14,6 +14,8 @@ fileprivate enum BoundaryPolicy {
     static let boundaryRadiusMeters: CLLocationDistance = 60
     static let outsideBoundaryAlertTitle = "현재 머문 위치를 벗어났습니다."
     static let outsideBoundaryAlertMessage = "메세지는 계속 작성할 수 있어요."
+    static let primaryButtonTitle = "새 위치로 갱신"
+    static let secondaryButtonTitle = "기존 위치에 남기기"
 }
 
 final class MessageComposerStore: Store {
@@ -21,6 +23,32 @@ final class MessageComposerStore: Store {
         let id: UUID = UUID()
         let title: String
         let message: String
+        let primaryButton: AlertButton
+        let secondaryButton: AlertButton?
+
+        init(
+            title: String,
+            message: String,
+            primaryButton: AlertButton = .init(title: "확인", intent: .dismissAlert),
+            secondaryButton: AlertButton? = nil
+        ) {
+            self.title = title
+            self.message = message
+            self.primaryButton = primaryButton
+            self.secondaryButton = secondaryButton
+        }
+    }
+
+    struct AlertButton: Equatable {
+        let title: String
+        let intent: Intent
+    }
+
+    // 위치 이탈 상태에서 사용자의 선택을 반영하기 위한 상태
+    enum OutsideBoundaryDecision: Equatable {
+        case none
+        case refreshStartLocation   // "새 위치로 갱신"
+        case keepWritingWithoutTag  // "기존 위치에 남기기"
     }
 
     struct State: Equatable {
@@ -29,6 +57,9 @@ final class MessageComposerStore: Store {
 
         var isOutsideBoundary: Bool = false
         var didPresentOutsideBoundaryAlert: Bool = false
+
+        var outsideBoundaryDecision: OutsideBoundaryDecision = .none
+        var isPlaceTagLocked: Bool = false
 
         var message: String = ""
         var placeText: String = ""
@@ -43,7 +74,7 @@ final class MessageComposerStore: Store {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty == false
             && isConfirmLoading == false
-            && isOutsideBoundary == false
+            && (isOutsideBoundary == false || outsideBoundaryDecision == .keepWritingWithoutTag)
         }
 
         init(userLocation: Coordinate) {
@@ -52,7 +83,7 @@ final class MessageComposerStore: Store {
         }
     }
 
-    enum Intent {
+    enum Intent: Equatable {
         case setMessage(String)
         case updateCurrentLocation(Coordinate?)
 
@@ -64,6 +95,8 @@ final class MessageComposerStore: Store {
         case selectSuggestedPlace(String)
 
         case tapConfirm
+        case tapRefreshStartLocation
+        case tapKeepWritingWithoutTag
         case dismissAlert
         case dismissToast
     }
@@ -75,6 +108,9 @@ final class MessageComposerStore: Store {
         case presentPlaceSearch(Bool)
         case updatePlace(String)
         case clearPlace
+
+        case refreshStartLocation
+        case keepWritingWithoutTag
 
         case setConfirmLoading(Bool)
         case presentAlert(AlertState?)
@@ -132,16 +168,23 @@ final class MessageComposerStore: Store {
                 continuation.yield(.showToast(nil))
 
             case .tapConfirm:
-                if state.isOutsideBoundary {
+                if state.isOutsideBoundary, state.outsideBoundaryDecision == .none {
                     continuation.yield(
                         .presentAlert(
                             .init(
                                 title: BoundaryPolicy.outsideBoundaryAlertTitle,
-                                message: BoundaryPolicy.outsideBoundaryAlertMessage
+                                message: BoundaryPolicy.outsideBoundaryAlertMessage,
+                                primaryButton: .init(
+                                    title: BoundaryPolicy.primaryButtonTitle,
+                                    intent: .tapRefreshStartLocation
+                                ),
+                                secondaryButton: .init(
+                                    title: BoundaryPolicy.secondaryButtonTitle,
+                                    intent: .tapKeepWritingWithoutTag
+                                )
                             )
                         )
                     )
-
                     break
                 }
 
@@ -151,6 +194,12 @@ final class MessageComposerStore: Store {
 
                 createMessage(continuation: continuation)
                 return
+
+            case .tapRefreshStartLocation:
+                continuation.yield(.refreshStartLocation)
+
+            case .tapKeepWritingWithoutTag:
+                continuation.yield(.keepWritingWithoutTag)
             }
 
             continuation.finish()
@@ -178,10 +227,19 @@ final class MessageComposerStore: Store {
             // 제한 범위 밖으로 나가는 경우
             if wasOutOfBoundary == false,
                newState.isOutsideBoundary == true,
-               newState.didPresentOutsideBoundaryAlert == false {
+               newState.didPresentOutsideBoundaryAlert == false,
+                newState.outsideBoundaryDecision == .none {
                 newState.alert = .init(
                     title: BoundaryPolicy.outsideBoundaryAlertTitle,
-                    message: BoundaryPolicy.outsideBoundaryAlertMessage
+                    message: BoundaryPolicy.outsideBoundaryAlertMessage,
+                    primaryButton: .init(
+                        title: BoundaryPolicy.primaryButtonTitle,
+                        intent: .tapRefreshStartLocation
+                    ),
+                    secondaryButton: .init(
+                        title: BoundaryPolicy.secondaryButtonTitle,
+                        intent: .tapKeepWritingWithoutTag
+                    )
                 )
                 newState.didPresentOutsideBoundaryAlert = true
             }
@@ -190,6 +248,10 @@ final class MessageComposerStore: Store {
             if wasOutOfBoundary == true,
                newState.isOutsideBoundary == false {
                 newState.didPresentOutsideBoundaryAlert = false
+
+                // 범위 내로 복귀하면 장소 태그는 자동으로 다시 활성화
+                newState.isPlaceTagLocked = false
+                newState.outsideBoundaryDecision = .none
             }
 
         case .presentPlaceSearch(let isPresented):
@@ -200,6 +262,37 @@ final class MessageComposerStore: Store {
 
         case .clearPlace:
             newState.placeText = ""
+
+        case .refreshStartLocation:
+            // 현재 위치를 기준으로 startLocation 갱신
+            if let current = newState.currentLocation {
+                newState.startLocation = current
+            }
+
+            // 장소 태그는 새 기준에서 다시 선택하도록 초기화
+            newState.placeText = ""
+
+            // 선택 상태 갱신
+            newState.outsideBoundaryDecision = .refreshStartLocation
+            newState.isPlaceTagLocked = false
+
+            // 새 기준에서는 이탈 상태를 해제(다음 위치 업데이트에서 재계산됨)
+            newState.isOutsideBoundary = false
+            newState.didPresentOutsideBoundaryAlert = false
+
+            // 알럿 닫기
+            newState.alert = nil
+
+        case .keepWritingWithoutTag:
+            // 초기 위치는 유지하고, 장소 태그 없이 계속 작성 모드로 전환
+            newState.outsideBoundaryDecision = .keepWritingWithoutTag
+            newState.isPlaceTagLocked = true
+
+            // 장소 태그가 있다면 제거
+            newState.placeText = ""
+
+            // 알럿 닫기
+            newState.alert = nil
 
         case .setConfirmLoading(let isLoading):
             newState.isConfirmLoading = isLoading

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -193,10 +193,6 @@ final class MessageComposerStore: Store {
                     break
                 }
 
-                if state.placeText.isEmpty == false {
-                    // TODO: 1차 검증) 장소 태그 존재 시, 현재 위치 기준으로 거리 검증
-                }
-
                 createMessage(continuation: continuation)
                 return
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -11,12 +11,12 @@ import CoreLocation
 import Supabase
 
 fileprivate enum BoundaryPolicy {
-    static let boundaryRadiusMeters: CLLocationDistance = 60
+    static let boundaryRadiusMeters: CLLocationDistance = 200
     static let outsideBoundaryAlertTitle = "현재 머문 위치를 벗어났습니다."
     static let outsideBoundaryAlertMessage = "메세지는 계속 작성할 수 있어요."
     static let primaryButtonTitle = "새 위치로 갱신"
     static let secondaryButtonTitle = "기존 위치에 남기기"
-    static let placeTagLockedToastMessage = "현재 위치에서는 장소 태그를 선택할 수 없어요."
+    static let placeTagLockedMessage = "현재 위치에서는 장소 태그를 선택할 수 없어요."
 }
 
 final class MessageComposerStore: Store {
@@ -68,6 +68,10 @@ final class MessageComposerStore: Store {
 
         var alert: AlertState?
         var toastMessage: String?
+
+        var placeTagLockedHintMessage: String {
+            BoundaryPolicy.placeTagLockedMessage
+        }
 
         var isConfirmLoading: Bool = false
         var isConfirmEnabled: Bool {
@@ -147,12 +151,6 @@ final class MessageComposerStore: Store {
                 continuation.yield(.updateCurrentLocation(coordinate))
 
             case .tapPlaceField:
-                // 장소 태그가 비활성화된 상태에서는 장소 검색을 열지 않고 안내 토스트 표시
-                if state.isPlaceTagLocked {
-                    continuation.yield(.showToast(BoundaryPolicy.placeTagLockedToastMessage))
-                    break
-                }
-
                 continuation.yield(.presentPlaceSearch(true))
 
             case .dismissPlaceSearch:
@@ -215,6 +213,7 @@ final class MessageComposerStore: Store {
 
     func reduce(state: State, action: Action) -> State {
         var newState = state
+
         switch action {
         case .updateMessage(let message):
             newState.message = message

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -152,12 +152,20 @@ final class MessageComposerStore: Store {
                                     .init(
                                         title: BoundaryPolicy.primaryButtonTitle,
                                         role: .normal,
-                                        action: nil // Intent.tapRefreshStartLocation
+                                        action: { [weak self] in
+                                            Task {
+                                                await self?.send(intent: .tapRefreshStartLocation)
+                                            }
+                                        }
                                     ),
                                     .init(
                                         title: BoundaryPolicy.secondaryButtonTitle,
                                         role: .normal,
-                                        action: nil // Intent.tapKeepWritingWithoutTag
+                                        action: { [weak self] in
+                                            Task {
+                                                await self?.send(intent: .tapKeepWritingWithoutTag)
+                                            }
+                                        }
                                     )
                                 ]
                             )
@@ -217,12 +225,20 @@ final class MessageComposerStore: Store {
                         .init(
                             title: BoundaryPolicy.primaryButtonTitle,
                             role: .normal,
-                            action: nil // Intent.tapRefreshStartLocation
+                            action: { [weak self] in
+                                Task {
+                                    await self?.send(intent: .tapRefreshStartLocation)
+                                }
+                            }
                         ),
                         .init(
                             title: BoundaryPolicy.secondaryButtonTitle,
                             role: .normal,
-                            action: nil // Intent.tapKeepWritingWithoutTag
+                            action: { [weak self] in
+                                Task {
+                                    await self?.send(intent: .tapKeepWritingWithoutTag)
+                                }
+                            }
                         )
                     ]
                 )

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -24,7 +24,6 @@ final class MessageComposerStore: Store {
     }
 
     struct State: Equatable {
-        var userLocation: Coordinate
         var startLocation: Coordinate
         var currentLocation: Coordinate?
 
@@ -48,7 +47,6 @@ final class MessageComposerStore: Store {
         }
 
         init(userLocation: Coordinate) {
-            self.userLocation = userLocation
             self.startLocation = userLocation
             self.currentLocation = userLocation
         }
@@ -99,7 +97,7 @@ final class MessageComposerStore: Store {
         self.state = State(userLocation: userLocation)
         self.createMessageUseCase = createMessage
         self.onClose = onClose
-        AppLog.debug("userLocation: \(userLocation)", category: .location)
+        AppLog.debug("startLocation: \(state.startLocation)", category: .location)
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {
@@ -143,8 +141,8 @@ final class MessageComposerStore: Store {
                             )
                         )
                     )
-                    continuation.finish()
-                    return
+
+                    break
                 }
 
                 if state.placeText.isEmpty == false {
@@ -154,6 +152,7 @@ final class MessageComposerStore: Store {
                 createMessage(continuation: continuation)
                 return
             }
+
             continuation.finish()
         }
     }
@@ -171,6 +170,9 @@ final class MessageComposerStore: Store {
             if let current = coordinate {
                 let distance = distanceMeters(from: newState.startLocation, to: current)
                 newState.isOutsideBoundary = distance > BoundaryPolicy.boundaryRadiusMeters
+            } else {
+                // 위치 정보를 받아오지 못한 경우, 기본값은 제한 범위 내부로 처리
+                newState.isOutsideBoundary = false
             }
 
             // 제한 범위 밖으로 나가는 경우

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -280,7 +280,7 @@ final class MessageComposerStore: Store {
             newState.placeText = ""
 
             // 선택 상태 갱신
-            newState.outsideBoundaryDecision = .refreshStartLocation
+            newState.outsideBoundaryDecision = .none
             newState.isPlaceTagLocked = false
 
             // 새 기준에서는 이탈 상태를 해제(다음 위치 업데이트에서 재계산됨)

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -18,6 +18,12 @@ final class MessageComposerStore: Store {
 
     struct State: Equatable {
         var userLocation: Coordinate
+        var startLocation: Coordinate
+        var currentLocation: Coordinate?
+
+        var isOutOfBoundary: Bool = false
+        var didShowOutOfBoundaryAlert: Bool = false
+
         var message: String = ""
         var placeText: String = ""
         var isPlaceSearchPresented: Bool = false
@@ -32,10 +38,17 @@ final class MessageComposerStore: Store {
                 .isEmpty == false
             && isConfirmLoading == false
         }
+
+        init(userLocation: Coordinate) {
+            self.userLocation = userLocation
+            self.startLocation = userLocation
+            self.currentLocation = userLocation
+        }
     }
 
     enum Intent {
         case setMessage(String)
+        case updateCurrentLocation(Coordinate?)
 
         case tapPlaceField
         case dismissPlaceSearch
@@ -51,6 +64,7 @@ final class MessageComposerStore: Store {
 
     enum Action {
         case updateMessage(String)
+        case updateCurrentLocation(Coordinate?)
 
         case presentPlaceSearch(Bool)
         case updatePlace(String)
@@ -85,6 +99,9 @@ final class MessageComposerStore: Store {
             switch intent {
             case .setMessage(let message):
                 continuation.yield(.updateMessage(message))
+
+            case .updateCurrentLocation(let coordinate):
+                continuation.yield(.updateCurrentLocation(coordinate))
 
             case .tapPlaceField:
                 continuation.yield(.presentPlaceSearch(true))
@@ -124,6 +141,9 @@ final class MessageComposerStore: Store {
         switch action {
         case .updateMessage(let message):
             newState.message = message
+
+        case .updateCurrentLocation(let coordinate):
+            newState.currentLocation = coordinate
 
         case .presentPlaceSearch(let isPresented):
             newState.isPlaceSearchPresented = isPresented

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -7,7 +7,14 @@
 
 import Foundation
 import Combine
+import CoreLocation
 import Supabase
+
+fileprivate enum BoundaryPolicy {
+    static let boundaryRadiusMeters: CLLocationDistance = 60
+    static let outsideBoundaryAlertTitle = "현재 머문 위치를 벗어났습니다."
+    static let outsideBoundaryAlertMessage = "메세지는 계속 작성할 수 있어요."
+}
 
 final class MessageComposerStore: Store {
     struct AlertState: Identifiable, Equatable {
@@ -21,8 +28,8 @@ final class MessageComposerStore: Store {
         var startLocation: Coordinate
         var currentLocation: Coordinate?
 
-        var isOutOfBoundary: Bool = false
-        var didShowOutOfBoundaryAlert: Bool = false
+        var isOutsideBoundary: Bool = false
+        var didPresentOutsideBoundaryAlert: Bool = false
 
         var message: String = ""
         var placeText: String = ""
@@ -37,6 +44,7 @@ final class MessageComposerStore: Store {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty == false
             && isConfirmLoading == false
+            && isOutsideBoundary == false
         }
 
         init(userLocation: Coordinate) {
@@ -126,9 +134,23 @@ final class MessageComposerStore: Store {
                 continuation.yield(.showToast(nil))
 
             case .tapConfirm:
-                if state.placeText != "" {
+                if state.isOutsideBoundary {
+                    continuation.yield(
+                        .presentAlert(
+                            .init(
+                                title: BoundaryPolicy.outsideBoundaryAlertTitle,
+                                message: BoundaryPolicy.outsideBoundaryAlertMessage
+                            )
+                        )
+                    )
+                    continuation.finish()
+                    return
+                }
+
+                if state.placeText.isEmpty == false {
                     // TODO: 1차 검증) 장소 태그 존재 시, 현재 위치 기준으로 거리 검증
                 }
+
                 createMessage(continuation: continuation)
                 return
             }
@@ -144,6 +166,29 @@ final class MessageComposerStore: Store {
 
         case .updateCurrentLocation(let coordinate):
             newState.currentLocation = coordinate
+            let wasOutOfBoundary = newState.isOutsideBoundary
+
+            if let current = coordinate {
+                let distance = distanceMeters(from: newState.startLocation, to: current)
+                newState.isOutsideBoundary = distance > BoundaryPolicy.boundaryRadiusMeters
+            }
+
+            // 제한 범위 밖으로 나가는 경우
+            if wasOutOfBoundary == false,
+               newState.isOutsideBoundary == true,
+               newState.didPresentOutsideBoundaryAlert == false {
+                newState.alert = .init(
+                    title: BoundaryPolicy.outsideBoundaryAlertTitle,
+                    message: BoundaryPolicy.outsideBoundaryAlertMessage
+                )
+                newState.didPresentOutsideBoundaryAlert = true
+            }
+
+            // 제한 범위 밖에서 다시 내부로 들어오는 경우
+            if wasOutOfBoundary == true,
+               newState.isOutsideBoundary == false {
+                newState.didPresentOutsideBoundaryAlert = false
+            }
 
         case .presentPlaceSearch(let isPresented):
             newState.isPlaceSearchPresented = isPresented
@@ -201,8 +246,8 @@ extension MessageComposerStore {
     private func makeCreateMessageRequest() -> CreateMessageRequestDTO {
         CreateMessageRequestDTO(
             content: state.message,
-            latitude: state.userLocation.latitude,
-            longitude: state.userLocation.longitude,
+            latitude: state.startLocation.latitude,
+            longitude: state.startLocation.longitude,
             place: nil
         )
     }
@@ -235,4 +280,10 @@ extension MessageComposerStore {
         }
     }
 
+    private func distanceMeters(from start: Coordinate, to current: Coordinate) -> CLLocationDistance {
+        let startLocation = CLLocation(latitude: start.latitude, longitude: start.longitude)
+        let currentLocation = CLLocation(latitude: current.latitude, longitude: current.longitude)
+
+        return startLocation.distance(from: currentLocation)
+    }
 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -28,7 +28,7 @@ final class MessageComposerStore: Store {
     }
 
     struct State: Equatable {
-        var startLocation: Coordinate
+        var startLocation: Coordinate?
         var currentLocation: Coordinate?
 
         var isOutsideBoundary: Bool = false
@@ -38,7 +38,7 @@ final class MessageComposerStore: Store {
         var isPlaceTagLocked: Bool = false
 
         var message: String = ""
-        var placeText: String = ""
+        var selectedPlace: Place?
         var isPlaceSearchPresented: Bool = false
 
         var alert: AlertModel?
@@ -56,21 +56,17 @@ final class MessageComposerStore: Store {
             && isConfirmLoading == false
             && (isOutsideBoundary == false || outsideBoundaryDecision == .keepWritingWithoutTag)
         }
-
-        init(userLocation: Coordinate) {
-            self.startLocation = userLocation
-            self.currentLocation = userLocation
-        }
     }
 
     enum Intent: Equatable {
+        case onAppear
         case setMessage(String)
         case updateCurrentLocation(Coordinate?)
         case resetDraft
 
         case tapPlaceField
         case dismissPlaceSearch
-        case selectPlace(String)
+        case selectPlace(Place)
         case clearPlace
 
         case tapConfirm
@@ -79,14 +75,16 @@ final class MessageComposerStore: Store {
 
         case setAlert(AlertModel?)
         case setToast(String?)
+        case onDisappear
     }
 
     enum Action {
+        case setInitLocation(Coordinate?)
         case updateMessage(String)
         case updateCurrentLocation(Coordinate?)
 
         case presentPlaceSearch(Bool)
-        case updatePlace(String)
+        case updatePlace(Place)
         case clearPlace
 
         case refreshStartLocation
@@ -101,23 +99,28 @@ final class MessageComposerStore: Store {
     @Published var state: State
 
     private let createMessageUseCase: CreateMessageUseCase
+    let locationProvider: LocationProvider
 
     private let onClose: () -> Void
 
     init(
-        userLocation: Coordinate,
+        locationProvider: LocationProvider,
         createMessage: CreateMessageUseCase,
         onClose: @escaping () -> Void
     ) {
-        self.state = State(userLocation: userLocation)
+        self.state = State()
+        self.locationProvider = locationProvider
         self.createMessageUseCase = createMessage
         self.onClose = onClose
-        AppLog.debug("startLocation: \(state.startLocation)", category: .location)
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {
         AsyncStream<Action>(bufferingPolicy: .unbounded) { continuation in
             switch intent {
+            case .onAppear:
+                locationProvider.startContinuous()
+                continuation.yield(.setInitLocation(locationProvider.current))
+
             case .setMessage(let message):
                 continuation.yield(.updateMessage(message))
 
@@ -188,6 +191,9 @@ final class MessageComposerStore: Store {
 
             case .setToast(let message):
                 continuation.yield(.presentToast(message))
+
+            case .onDisappear:
+                locationProvider.stopContinuous()
             }
 
             continuation.finish()
@@ -198,6 +204,10 @@ final class MessageComposerStore: Store {
         var newState = state
 
         switch action {
+        case .setInitLocation(let coordinate):
+            newState.startLocation = coordinate
+            newState.currentLocation = coordinate
+
         case .updateMessage(let message):
             newState.message = message
 
@@ -205,8 +215,8 @@ final class MessageComposerStore: Store {
             newState.currentLocation = coordinate
             let wasOutOfBoundary = newState.isOutsideBoundary
 
-            if let current = coordinate {
-                let distance = distanceMeters(from: newState.startLocation, to: current)
+            if let current = coordinate, let start = newState.startLocation {
+                let distance = distanceMeters(from: start, to: current)
                 newState.isOutsideBoundary = distance > BoundaryPolicy.boundaryRadiusMeters
             } else {
                 // 위치 정보를 받아오지 못한 경우, 기본값은 제한 범위 내부로 처리
@@ -259,10 +269,10 @@ final class MessageComposerStore: Store {
             newState.isPlaceSearchPresented = isPresented
 
         case .updatePlace(let place):
-            newState.placeText = place
+            newState.selectedPlace = place
 
         case .clearPlace:
-            newState.placeText = ""
+            newState.selectedPlace = nil
 
         case .refreshStartLocation:
             // 현재 위치를 기준으로 startLocation 갱신
@@ -271,7 +281,7 @@ final class MessageComposerStore: Store {
             }
 
             // 장소 태그는 새 기준에서 다시 선택하도록 초기화
-            newState.placeText = ""
+            newState.selectedPlace = nil
 
             // 선택 상태 갱신
             newState.outsideBoundaryDecision = .none
@@ -290,7 +300,7 @@ final class MessageComposerStore: Store {
             newState.isPlaceTagLocked = true
 
             // 장소 태그가 있다면 제거
-            newState.placeText = ""
+            newState.selectedPlace = nil
 
             // 알럿 닫기
             newState.alert = nil
@@ -322,10 +332,12 @@ extension MessageComposerStore {
             }
 
             do {
-                try await createMessageUseCase.execute(makeCreateMessageRequest())
+                guard let createMessageRequest = makeCreateMessageRequest() else { return }
+                try await createMessageUseCase.execute(createMessageRequest)
 
                 continuation.yield(.presentToast("메시지가 등록되었어요."))
                 try await Task.sleep(nanoseconds: 700_000_000)
+                locationProvider.stopContinuous()
                 continuation.yield(.close)
 
             } catch let error as CreateMessageError {
@@ -340,11 +352,15 @@ extension MessageComposerStore {
         }
     }
 
-    private func makeCreateMessageRequest() -> CreateMessageRequestDTO {
-        CreateMessageRequestDTO(
+    private func makeCreateMessageRequest() -> CreateMessageRequestDTO? {
+        guard let latitude = state.startLocation?.latitude,
+              let longitude = state.startLocation?.longitude
+        else { return nil }
+
+        return CreateMessageRequestDTO(
             content: state.message,
-            latitude: state.startLocation.latitude,
-            longitude: state.startLocation.longitude,
+            latitude: latitude,
+            longitude: longitude,
             place: nil
         )
     }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -16,6 +16,7 @@ fileprivate enum BoundaryPolicy {
     static let outsideBoundaryAlertMessage = "메세지는 계속 작성할 수 있어요."
     static let primaryButtonTitle = "새 위치로 갱신"
     static let secondaryButtonTitle = "기존 위치에 남기기"
+    static let placeTagLockedToastMessage = "현재 위치에서는 장소 태그를 선택할 수 없어요."
 }
 
 final class MessageComposerStore: Store {
@@ -146,6 +147,12 @@ final class MessageComposerStore: Store {
                 continuation.yield(.updateCurrentLocation(coordinate))
 
             case .tapPlaceField:
+                // 장소 태그가 비활성화된 상태에서는 장소 검색을 열지 않고 안내 토스트 표시
+                if state.isPlaceTagLocked {
+                    continuation.yield(.showToast(BoundaryPolicy.placeTagLockedToastMessage))
+                    break
+                }
+
                 continuation.yield(.presentPlaceSearch(true))
 
             case .dismissPlaceSearch:
@@ -228,7 +235,7 @@ final class MessageComposerStore: Store {
             if wasOutOfBoundary == false,
                newState.isOutsideBoundary == true,
                newState.didPresentOutsideBoundaryAlert == false,
-                newState.outsideBoundaryDecision == .none {
+               newState.outsideBoundaryDecision == .none {
                 newState.alert = .init(
                     title: BoundaryPolicy.outsideBoundaryAlertTitle,
                     message: BoundaryPolicy.outsideBoundaryAlertMessage,

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -17,7 +17,6 @@ fileprivate enum Constants {
 struct MessageComposerView: View {
     @FocusState var isFocused: Bool
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var locationProvider: LocationProvider
 
     @StateObject private var store: MessageComposerStore
 
@@ -43,7 +42,7 @@ struct MessageComposerView: View {
                         ),
                         userLocation: store.state.startLocation,
                         onSelect: { selected in
-                            send(.selectPlace(selected.name))
+                            send(.selectPlace(selected))
                         },
                         onDismiss: {
                             send(.dismissPlaceSearch)
@@ -54,6 +53,8 @@ struct MessageComposerView: View {
                 .zIndex(999)
             }
         }
+        .onAppear { send(.onAppear) }
+        .onDisappear { send(.onDisappear) }
     }
 }
 
@@ -72,7 +73,7 @@ extension MessageComposerView {
         .padding(24)
         .background(backgroundView)
         .onTapGesture { isFocused = false }
-        .onChange(of: locationProvider.current) { _, current in
+        .onChange(of: store.locationProvider.current) { _, current in
             send(.updateCurrentLocation(current))
         }
         .navigationBarBackButtonHidden()
@@ -104,18 +105,20 @@ extension MessageComposerView {
                     isFocused = false
                     send(.tapPlaceField)
                 } label: {
-                    Text(
-                        store.state.isPlaceTagLocked
-                        ? Constants.textEditorPlaceholderWhenBlocked
-                        : store.state.placeText.isEmpty ? Constants.textEditorPlaceholder : store.state.placeText
+                    let isPlaceSelected = store.state.selectedPlace != nil
+                    let placeName = store.state.selectedPlace?.name ?? ""
+
+                    Text(store.state.isPlaceTagLocked
+                         ? Constants.textEditorPlaceholderWhenBlocked
+                         : isPlaceSelected ? placeName : Constants.textEditorPlaceholder
                     )
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(
-                            store.state.isPlaceTagLocked
-                            ? Color(.placeholderText)
-                            : (store.state.placeText.isEmpty ? Color(.placeholderText) : Color.tabActive)
-                        )
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(
+                        store.state.isPlaceTagLocked
+                        ? Color(.placeholderText)
+                        : isPlaceSelected ? Color.tabActive : Color(.placeholderText)
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
 
@@ -202,6 +205,7 @@ extension MessageComposerView {
 
             let trimmed = store.state.message.trimmingCharacters(in: .whitespacesAndNewlines)
             guard trimmed.isEmpty == false else {
+                send(.onDisappear)
                 dismiss()
                 return
             }
@@ -232,10 +236,7 @@ extension MessageComposerView {
     NavigationStack {
         MessageComposerView(
             store: MessageComposerStore(
-                userLocation: .init(
-                    latitude: 37.5665,
-                    longitude: 126.9780
-                ),
+                locationProvider: LocationProvider(),
                 createMessage: CreateMessageUseCaseImpl(
                     messageRepository: MessageRepositoryImpl()
                 ),

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -73,9 +73,7 @@ extension MessageComposerView {
         .background(backgroundView)
         .onTapGesture { isFocused = false }
         .onChange(of: locationProvider.current) { _, current in
-            Task {
-                await store.send(intent: .updateCurrentLocation(current))
-            }
+            send(.updateCurrentLocation(current))
         }
         .navigationBarBackButtonHidden()
         .toolbar { toolbarContent }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -11,6 +11,7 @@ fileprivate enum Constants {
     static let navigationTitle = "잠시 남겨놓기"
     static let textEditorTitle = "이 말은 잠시 머물 거에요."
     static let textEditorPlaceholder = "지금 어디에 있나요?"
+    static let textEditorPlaceholderWhenBlocked = "선택한 장소와 너무 멀어요."
 }
 
 struct MessageComposerView: View {
@@ -89,7 +90,11 @@ extension MessageComposerView {
                         isFocused = false
                         Task { await store.send(intent: .tapPlaceField) }
                     } label: {
-                        Text(store.state.placeText.isEmpty ? Constants.textEditorPlaceholder : store.state.placeText)
+                        Text(
+                            store.state.isPlaceTagLocked
+                            ? Constants.textEditorPlaceholderWhenBlocked
+                            : store.state.placeText.isEmpty ? Constants.textEditorPlaceholder : store.state.placeText
+                        )
                             .font(.system(size: 16, weight: .medium))
                             .foregroundStyle(
                                 store.state.isPlaceTagLocked
@@ -104,6 +109,14 @@ extension MessageComposerView {
                     Task { await store.send(intent: .clearPlace) }
                 }
             }
+            .disabled(store.state.isPlaceTagLocked)
+
+            Text(store.state.placeTagLockedHintMessage)
+                .font(.subheadline)
+                .foregroundStyle(Color(.placeholderText))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .opacity(store.state.isPlaceTagLocked ? 1.0 : 0.0)
+                .accessibilityHidden(store.state.isPlaceTagLocked == false)
 
             Spacer(minLength: 0)
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -86,14 +86,21 @@ extension MessageComposerView {
             HStack(spacing: 8) {
                 PlaceSearchContainerView {
                     Button {
+                        guard store.state.isPlaceTagLocked == false else { return }
+
                         isFocused = false
                         Task { await store.send(intent: .tapPlaceField) }
                     } label: {
                         Text(store.state.placeText.isEmpty ? Constants.textEditorPlaceholder : store.state.placeText)
                             .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(store.state.placeText.isEmpty ? Color(.placeholderText) : Color.tabActive)
+                            .foregroundStyle(
+                                store.state.isPlaceTagLocked
+                                ? Color(.placeholderText)
+                                : (store.state.placeText.isEmpty ? Color(.placeholderText) : Color.tabActive)
+                            )
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                    .disabled(store.state.isPlaceTagLocked)
                 }
 
                 CancelButton {
@@ -104,7 +111,7 @@ extension MessageComposerView {
             Spacer(minLength: 0)
 
             ConfirmButton(action: {
-                Task { await store.send(intent: .tapConfirm)}
+                Task { await store.send(intent: .tapConfirm) }
             })
             .disabled(!store.state.isConfirmEnabled)
             .opacity(store.state.isConfirmEnabled ? 1.0 : 0.4)
@@ -151,13 +158,26 @@ extension MessageComposerView {
             }
         }
         .alert(item: alertBinding) { alert in
-            Alert(
-                title: Text(alert.title),
-                message: Text(alert.message),
-                dismissButton: .default(Text("확인"), action: {
-                    Task { await store.send(intent: .dismissAlert) }
-                })
-            )
+            if let secondary = alert.secondaryButton {
+                return Alert(
+                    title: Text(alert.title),
+                    message: Text(alert.message),
+                    primaryButton: .default(Text(alert.primaryButton.title), action: {
+                        Task { await store.send(intent: alert.primaryButton.intent) }
+                    }),
+                    secondaryButton: .cancel(Text(secondary.title), action: {
+                        Task { await store.send(intent: secondary.intent) }
+                    })
+                )
+            } else {
+                return Alert(
+                    title: Text(alert.title),
+                    message: Text(alert.message),
+                    dismissButton: .default(Text(alert.primaryButton.title), action: {
+                        Task { await store.send(intent: alert.primaryButton.intent) }
+                    })
+                )
+            }
         }
         .overlay(alignment: .bottom) {
             if let toast = store.state.toastMessage {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -86,8 +86,6 @@ extension MessageComposerView {
             HStack(spacing: 8) {
                 PlaceSearchContainerView {
                     Button {
-                        guard store.state.isPlaceTagLocked == false else { return }
-
                         isFocused = false
                         Task { await store.send(intent: .tapPlaceField) }
                     } label: {
@@ -100,7 +98,6 @@ extension MessageComposerView {
                             )
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .disabled(store.state.isPlaceTagLocked)
                 }
 
                 CancelButton {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -16,6 +16,7 @@ fileprivate enum Constants {
 struct MessageComposerView: View {
     @FocusState var isFocused: Bool
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var locationProvider: LocationProvider
 
     @StateObject private var store: MessageComposerStore
 
@@ -121,6 +122,11 @@ extension MessageComposerView {
         .onTapGesture {
             isFocused = false
         }
+        .onChange(of: locationProvider.current) { _, current in
+            Task {
+                await store.send(intent: .updateCurrentLocation(current))
+            }
+        }
         .navigationBarBackButtonHidden()
         .toolbar {
             if #available(iOS 26.0, *) {
@@ -187,5 +193,6 @@ extension MessageComposerView {
                 }
             )
         )
+        .environmentObject(LocationProvider())
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -114,7 +114,7 @@ extension MessageComposerView {
             Text(store.state.placeTagLockedHintMessage)
                 .font(.subheadline)
                 .foregroundStyle(Color(.placeholderText))
-                .frame(maxWidth: .infinity, alignment: .center)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .opacity(store.state.isPlaceTagLocked ? 1.0 : 0.0)
                 .accessibilityHidden(store.state.isPlaceTagLocked == false)
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -36,7 +36,7 @@ struct MessageComposerView: View {
                                 network: NetworkClientImpl()
                             )
                         ),
-                        userLocation: store.state.userLocation,
+                        userLocation: store.state.startLocation,
                         onSelect: { selected in
                             Task { await store.send(intent: .selectPlace(selected.name)) }
                         },
@@ -176,8 +176,6 @@ extension MessageComposerView {
 }
 
 #Preview {
-    @Previewable @State var message: String = ""
-
     NavigationStack {
         MessageComposerView(
             store: MessageComposerStore(

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
@@ -43,7 +43,7 @@ final class PlaceSearchStore: Store {
     struct State {
         var query: String = ""
         var phase: Phase = .idle
-        var userLocation: Coordinate
+        var userLocation: Coordinate?
     }
 
     @Published var state: State
@@ -59,7 +59,7 @@ final class PlaceSearchStore: Store {
 
     init(
         searchPlaces: SearchNearbyPlaceUseCase,
-        userLocation: Coordinate,
+        userLocation: Coordinate?,
         radiusMeters: Double = 60,
         onSelect: @escaping (Place) -> Void,
         onDismiss: @escaping () -> Void
@@ -134,7 +134,7 @@ final class PlaceSearchStore: Store {
         let useCase = self.searchNearbyPlaces
 
         searchTask = Task { [weak self] in
-            guard let self else { return [] }
+            guard let self, let userLocation else { return [] }
 
             if !immediate {
                 // 디바운스 300ms

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
@@ -29,7 +29,7 @@ final class SpaceStore: Store {
         var isLoading: Bool = false
         var errorMessage: String = ""
         var messages: [Message] = []
-        var userLocation: Coordinate? = nil     // TODO: - 지도 > 공간 진입 시점 좌표 넘겨주고, 옵셔널 지우기
+        var userLocation: Coordinate?           // TODO: - 지도 > 공간 진입 시점 좌표 넘겨주고, 옵셔널 지우기
         var isShowingAddMessage: Bool = false
         var currentPlaceID: PlaceID?
     }
@@ -43,13 +43,17 @@ final class SpaceStore: Store {
 
     private var fetchMessagesTask: Task<Void, Never>?
 
+    private let place: Place
+
     init(
         locationProvider: LocationProvider,
-        fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCase
+        fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCase,
+        place: Place
     ) {
         self.locationProvider = locationProvider
         self.state = State()
         self.fetchPlaceMessagesUseCase = fetchPlaceMessagesUseCase
+        self.place = place
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -80,19 +80,17 @@ struct SpaceView: View {
                     }
                 )
             ) {
-                if let coordinate = store.state.userLocation {
-                    MessageComposerView(
-                        store: MessageComposerStore(
-                            userLocation: coordinate,
-                            createMessage: CreateMessageUseCaseImpl(
-                                messageRepository: MessageRepositoryImpl()
-                            ),
-                            onClose: {
-                                Task { await store.send(intent: .dismissAddMessage) }
-                            }
-                        )
+                MessageComposerView(
+                    store: MessageComposerStore(
+                        locationProvider: locationProvider,
+                        createMessage: CreateMessageUseCaseImpl(
+                            messageRepository: MessageRepositoryImpl()
+                        ),
+                        onClose: {
+                            Task { await store.send(intent: .dismissAddMessage) }
+                        }
                     )
-                }
+                )
             }
         }
         .task {

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -501,6 +501,16 @@ private struct BubblePlacer {
                 locationProvider: .init(),
                 fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCaseImpl(
                     messageRepository: MessageRepositoryImpl()
+                ),
+                place: .init(
+                    id: .init(
+                        value: .init()
+                    ),
+                    name: "광화문",
+                    coordinate: .init(
+                        latitude: 0,
+                        longitude: 0
+                    )
                 )
             ),
             domeEnvironment: .init(


### PR DESCRIPTION
## 배경

- closed #201 

## 작업 요약

- [x] 메세지 작성 화면에서 위치 이탈 감지
- [x] 위치 이탈 시 알럿 표시
- [x] 작성 중 위치 이탈에 따른 동작 로직 추가
    - [x] 새 위치로 갱신
    - [x] 기존 위치에 남기기
- [x] 위치 재이탈 예외 처리
- [x] 장소 태그 비활성화 및 토스트 표시
- [x] 작성 완료 조건 추가
- [x] 위치 추적 정책 앱 단위로 관리
- [x] LocationProvider 연속 추적 안정화

## 작업 내용

### 1. 메시지 작성 화면에서 위치 이탈을 감지하기 위한 기준 위치(startLocation) 도입

배경

메시지 작성 기능은 사용자가 **실제로 머문 장소에 대한 인상을 남기는 것**을 핵심 가치로 합니다.
기존에는 메시지 작성 시점의 위치 제약이 없어, 사용자가 해당 장소에 머물지 않은 상태에서도 메시지를 남길 수 있는 문제가 있었습니다.
이를 해결하기 위해, **작성 화면 진입 시점을 기준으로 한 위치 검증 정책**이 필요하다고 판단하였습니다.

기존 문제

- 메시지 작성 중 사용자의 이동 여부를 판단할 기준 위치가 없음
- 작성 시작 위치와 무관한 장소에 메시지를 남길 수 있음
- “어디에서 작성한 메시지인지”에 대한 신뢰도가 낮음

개선 방향

- 메시지 작성 화면 진입 시의 위치를 **초기 위치(startLocation)**로 고정
- 작성 중에는 **현재 위치(currentLocation)**를 지속적으로 수신
- startLocation 기준 **반경 60m 이내에서만 정상 작성 가능**하도록 정책 도입

구현

- MessageComposerStore에 다음 상태를 분리하여 도입하였습니다.
    
    ```swift
    var startLocation:Coordinate
    var currentLocation:Coordinate?
    ```
    
- currentLocation이 갱신될 때마다 startLocation과의 거리를 계산하여
    
    ```swift
    distance> 60m→ 위치 이탈 상태
    ```
    
    로 판단하도록 구현하였습니다.

결과

- 메시지 작성이 “실제 머문 위치”를 기준으로 이루어지도록 개선되었습니다.
- 이후 위치 이탈 UX 및 정책 확장의 기준점이 되는 구조를 확보하였습니다.

### 2. 작성 중 위치 이탈 시 사용자 선택 기반 작성 플로우 설계

배경

사용자가 메시지를 작성하던 중 이동할 수 있다는 점을 고려할 때, 위치 이탈 시 **즉시 작성 불가 처리**는 UX 측면에서 과도하다고 판단하였습니다.
따라서, 위치 이탈 상황에서도 **사용자에게 선택권을 제공하는 방식**이 필요했습니다.

기존 문제

- 위치 이탈 시 처리 정책이 정의되어 있지 않음
- 이탈 이후 작성/저장 가능 여부가 모호함

개선 방향

위치 이탈이 최초로 감지되는 시점에 경고 알럿을 표시하고, 다음 두 가지 선택지를 제공하도록 설계하였습니다.

- **새 위치로 갱신**
- **기존 위치에 남기기**

이 선택은 메시지를 즉시 저장하는 동작이 아니라, **이후 작성 모드를 결정하는 정책 선택**으로 정의하였습니다.

구현

- 위치 이탈 최초 감지 시 AlertState를 생성하여 알럿을 표시하였습니다.
- 알럿 버튼은 각각 다음 intent로 연결됩니다.
    
    ```swift
    .tapRefreshStartLocation
    .tapKeepWritingWithoutTag
    ```

결과

- 위치 이탈 상황에서도 사용자가 맥락을 이해한 상태에서 작성 흐름을 선택할 수 있게 되었습니다.
- 강제 차단이 아닌, 정책 기반 UX 흐름을 구성할 수 있었습니다.

### 3. “새 위치로 갱신” 선택 시 기준 위치 재설정 및 재이탈 처리

문제

“새 위치로 갱신”을 선택한 이후에도, 다시 기준 위치를 벗어났을 때 **경고가 재표시되지 않는 문제**가 발생하였습니다.
이는 사용자 선택 상태가 계속 유지되면서 이후 이탈 상황을 정상적으로 감지하지 못하는 구조 때문이었습니다.

개선 방향

- “새 위치로 갱신”은 **일회성 기준 위치 갱신 동작**으로 정의
- 갱신 이후에는 다시 정상 상태로 복귀하여
    - 이후 위치 이탈 시 경고가 다시 표시되도록 상태를 초기화

구현

```swift
case .refreshStartLocation:
    newState.startLocation= current
    newState.outsideBoundaryDecision= .none
    newState.isOutsideBoundary=false
    newState.didPresentOutsideBoundaryAlert=false
```

결과

- 기준 위치를 갱신한 이후에도, 다시 60m를 벗어나면 경고 알럿이 정상적으로 재표시됩니다.
- 위치 이탈 정책이 반복적으로 일관되게 동작하도록 개선되었습니다.

### 4. “기존 위치에 남기기” 선택 시 장소 태그 잠금 정책 도입

배경

“기존 위치에 남기기”는 **초기 위치에 대한 메시지를 끝까지 작성하겠다는 의사 표현**입니다.
이 경우, 현재 위치 기준의 장소 태그를 추가하는 것은 메시지의 공간적 의미를 흐릴 수 있다고 판단하였습니다.

개선 방향

- “기존 위치에 남기기” 선택 시
    - 장소 태그 입력을 비활성화
    - 기존에 선택된 장소 태그가 있다면 제거
- 메시지는 계속 작성 가능하되, **태그 없이 작성하는 모드**로 전환

구현

```swift
case .keepWritingWithoutTag:
    newState.outsideBoundaryDecision= .keepWritingWithoutTag
    newState.isPlaceTagLocked=true
    newState.placeText=""
```

결과

- 위치 이탈 이후에도 메시지를 작성할 수 있으면서,
- 메시지와 장소 정보 간의 불일치를 방지할 수 있게 되었습니다.

## 5. 장소 태그 비활성 상태에 대한 UX 보완 (토스트 안내)

문제

장소 태그가 비활성화된 상태에서 입력 영역을 탭했을 때, 아무 반응이 없는 것처럼 보이는 문제가 있었습니다.

개선 방향

- 태그 입력은 항상 Store로 intent를 전달
- 태그가 잠긴 상태일 경우
    - 장소 검색 화면으로 이동하지 않고
    - 현재 상태를 설명하는 토스트 메시지를 표시

구현

```swift
case .tapPlaceField:
if state.isPlaceTagLocked {
        yield(.showToast("현재 위치에서는 장소 태그를 선택할 수 없어요."))
    }
```

결과

- 사용자가 현재 상태를 명확하게 인지할 수 있는 UX를 제공하게 되었습니다.
- “왜 동작하지 않는지”에 대한 혼란을 줄일 수 있었습니다.

### 6. 위치 추적 정책을 화면 단위에서 앱 단위(RootView)로 통일

문제

기존에는 MapView, SpaceView 등 화면 단위에서 위치 추적 start/stop을 관리하고 있어,

- 네비게이션 전환 시 위치 업데이트가 중단되거나
- 화면 간 책임이 불분명해지는 문제가 있었습니다.

### 개선 방향

- 위치 추적 정책을 RootView에서 앱 단위로 관리
- 화면들은 위치를 “제어”하지 않고 “구독”만 하도록 역할 분리

구현

- RootView에서 continuous location 정책 관리
- scenePhase 기반으로 foreground / background 처리
- MapView, SpaceView에서 start/stop 로직 제거

결과

- 지도 → 공간 → 작성 화면 전환 시에도 위치 업데이트가 안정적으로 유지됩니다.
- 위치 정책의 책임이 명확해지고, 구조적 복잡도가 감소하였습니다.

## 스크린샷

### 새 위치로 갱신

https://github.com/user-attachments/assets/c835474e-adaf-41b1-bad8-cd22b2533aae

### 기존 위치에 남기기

https://github.com/user-attachments/assets/38e7e536-b2f3-4816-b54b-be3bdb6d3d46

## 리뷰 요구사항

### 위치 이탈 시 처리 스펙

[메세지 작성 위치 이탈 시 처리 스펙](https://github.com/boostcampwm2025/ios04-ChanaPing/wiki/메시지-작성-위치-이탈-시-처리-스펙) 문서화 파일을 위키에 추가하였습니다.
문서에 자세한 사용자 선택 기반 작성 플로우를 작성해 두었습니다. 보시고 수정할 부분이 있다면 말씀해 주시면 감사하겠습니다.
또, 이런 스펙 문서를 위키에 남기는 것은 어떤지도 궁금합니다.

### 위치 추적 정책을 RootView로 통합

위치 추적(start/stop) 정책을 각 화면(MapView, SpaceView 등) 단위에서 관리하던 방식에서, RootView에서 앱 단위로 통합하여 관리하도록 구조를 변경하였습니다.
기존 코드에서는 화면 전환(Navigation push/pop) 과정에서 부모 View의 onDisappear가 호출되며 위치 추적이 중단됩니다.
메시지 작성 화면과 같이 지도 화면 이후에 이어지는 화면에서도 위치 정보가 지속적으로 필요한 경우 위치 업데이트가 끊기는 문제가 있었습니다.

지도 기반 서비스의 경우,

- 사용자의 현재 위치가 앱 전반의 핵심 컨텍스트가 되고
- 지도 화면 → 상세 화면 → 작성 화면 등 여러 화면에서 동일한 위치 흐름을 공유하며
- 화면 전환 여부와 관계없이 앱이 foreground에 있는 동안 위치 추적이 유지되는 것이 자연스러운 UX

라고 판단하였습니다. (ex. 네이버 지도)

이에 따라,

- 위치 추적 시작/중지 책임을 RootView로 통합하고
- scenePhase를 기준으로 foreground / background 상태에서만 start/stop을 제어하며
- 각 화면은 위치 추적을 제어하지 않고 위치 정보를 구독하여 사용하는 역할만 담당

하도록 구조를 변경하였습니다.

이와 같은 RootView + scenePhase 기반 위치 추적 정책이 지도 중심 앱 구조에 적절한 설계인지, 또는 모든 화면에서 위치 정보를 받고 있기 때문에 배터리 이슈 등과 같은 부분을 좀 더 생각해야 할 지에 대해 의견 남겨주시면 감사하겠습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continuous location tracking with guarded start/stop, resumes on authorization and app foreground; avoids duplicate starts.
  * Message composition enforces a 200m boundary: leaving prompts an alert to refresh start location or continue without place-tag, locks place-tagging, shows hint, and updates UI accordingly.

* **Chores**
  * Lint configuration adjusted to disable cyclomatic complexity rule.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->