### PR TITLE
한글 입력 분리 이슈 해결 & 메시지 작성 완료 요청 진행 상태 표시 뷰

### DIFF
--- a/Meomun-Server/Supabase/messages/messagesRepo.ts
+++ b/Meomun-Server/Supabase/messages/messagesRepo.ts
@@ -10,17 +10,49 @@ export interface MessageInsertRow {
   place_id?: string | null;    // nullable uuid
 }
 
+export interface PlaceInsertRow {
+  place_id: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  address?: string | null;
+}
+
+async function upsertPlace(
+  client: SupabaseClient,
+  place: { place_id: string; name: string; latitude: number; longitude: number; address?: string | null },
+): Promise<void> {
+  const row: PlaceInsertRow = {
+    place_id: place.place_id,
+    name: place.name,
+    latitude: place.latitude,
+    longitude: place.longitude,
+    address: place.address ?? null,
+  };
+
+  const { error } = await client
+    .from("places")
+    .upsert(row, { onConflict: "place_id" });
+
+  if (error) throw new Error(`DB_UPSERT_PLACE_FAILED: ${error.message}`);
+}
+
 export async function insertMessage(
   client: SupabaseClient,
   userId: string,
   req: CreateMessageRequest,
 ): Promise<void> {
+  // place가 있으면 먼저 places 테이블에 upsert
+  if (req.place) {
+    await upsertPlace(client, req.place);
+  }
+
   const row: MessageInsertRow = {
     author_id: userId,
     content: req.content,
     latitude: req.latitude,
     longitude: req.longitude,
-    place_id: req.place?.id ?? null,
+    place_id: req.place?.place_id ?? null,
   };
 
   const { error } = await client.from("messages").insert(row);

--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -15,10 +15,27 @@ final class MessageRepositoryImpl: MessageRepository {
         self.supabaseClient = supabaseClient
     }
 
-    func createMessage(_ request: CreateMessageRequestDTO) async throws {
+    func createMessage(_ request: CreateMessageRequest) async throws {
         let session = try await supabaseClient.auth.session
 
         let authHeader = "Bearer \(session.accessToken)"
+
+        let placeDTO: PlaceDTO? = request.place.map { place in
+            PlaceDTO(
+                placeId: place.id.value,
+                name: place.name,
+                latitude: place.coordinate.latitude,
+                longitude: place.coordinate.longitude,
+                address: place.address.isEmpty ? nil : place.address
+            )
+        }
+
+        let dto = CreateMessageRequestDTO(
+            content: request.content,
+            latitude: request.coordinate.latitude,
+            longitude: request.coordinate.longitude,
+            place: placeDTO
+        )
 
         do {
             _ = try await supabaseClient.functions.invoke(
@@ -26,7 +43,7 @@ final class MessageRepositoryImpl: MessageRepository {
                 options: FunctionInvokeOptions(
                     method: .post,
                     headers: ["Authorization": authHeader],
-                    body: request
+                    body: dto
                 ),
                 decode: { _, response in
                     if (200...299).contains(response.statusCode) { return () }

--- a/Meomun/Meomun/Domain/Entity/CreateMessageRequest.swift
+++ b/Meomun/Meomun/Domain/Entity/CreateMessageRequest.swift
@@ -1,0 +1,12 @@
+//
+//  CreateMessageRequest.swift
+//  Meomun
+//
+//  Created by Claude on 1/21/26.
+//
+
+struct CreateMessageRequest: Equatable {
+    let content: String
+    let coordinate: Coordinate
+    let place: Place?
+}

--- a/Meomun/Meomun/Domain/Repository/MessageRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/MessageRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol MessageRepository: Sendable {
-    func createMessage(_ request: CreateMessageRequestDTO) async throws
+    func createMessage(_ request: CreateMessageRequest) async throws
     func deleteMessage(messageID: MessageID) async throws
 
     func reportMessage(messageID: MessageID) async throws -> MessageID

--- a/Meomun/Meomun/Domain/UseCase/CreateMessageUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/CreateMessageUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol CreateMessageUseCase {
-    func execute(_ request: CreateMessageRequestDTO) async throws
+    func execute(_ request: CreateMessageRequest) async throws
 }
 
 final class CreateMessageUseCaseImpl: CreateMessageUseCase {
@@ -18,7 +18,7 @@ final class CreateMessageUseCaseImpl: CreateMessageUseCase {
         self.messageRepository = messageRepository
     }
 
-    func execute(_ request: CreateMessageRequestDTO) async throws {
+    func execute(_ request: CreateMessageRequest) async throws {
         try await messageRepository.createMessage(request)
     }
 }

--- a/Meomun/Meomun/Presentation/Common/Component/BackButton.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/BackButton.swift
@@ -35,8 +35,6 @@ struct BackButton: View {
             WriteButton(action: {})
         }
 
-        MessageTextEditor(text: $message)
-
         HStack {
             CancelButton(action: {})
         }

--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct LoadingOverlayView: View {
-    let message: String
+    let message: String?
 
-    init(message: String = "") {
+    init(message: String? = nil) {
         self.message = message
     }
 
@@ -24,9 +24,11 @@ struct LoadingOverlayView: View {
                     .controlSize(.large)
                     .tint(.meomunPointColor)
 
-                Text(message)
-                    .font(.subheadline.bold())
-                    .foregroundStyle(Color.meomunPrimaryColor)
+                if let message {
+                    Text(message)
+                        .font(.subheadline.bold())
+                        .foregroundStyle(Color.meomunPrimaryColor)
+                }
             }
             .padding(30)
             .background(
@@ -40,5 +42,5 @@ struct LoadingOverlayView: View {
 }
 
 #Preview {
-    LoadingOverlayView(message: "머문 흔적을 남기고 있어요")
+    LoadingOverlayView()
 }

--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -1,0 +1,44 @@
+//
+//  LoadingOverlayView.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/21/26.
+//
+
+import SwiftUI
+
+struct LoadingOverlayView: View {
+    let message: String
+
+    init(message: String = "") {
+        self.message = message
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.15)
+                .ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                ProgressView()
+                    .controlSize(.large)
+                    .tint(.meomunPointColor)
+
+                Text(message)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(Color.meomunPrimaryColor)
+            }
+            .padding(30)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(.white.opacity(0.8))
+                    .shadow(color: .black.opacity(0.05), radius: 2)
+                    .shadow(color: .black.opacity(0.05), radius: 0, x: 1, y: 1)
+            )
+        }
+    }
+}
+
+#Preview {
+    LoadingOverlayView(message: "머문 흔적을 남기고 있어요")
+}

--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -7,10 +7,17 @@
 
 import SwiftUI
 
+enum Mode {
+    case loading
+    case success
+}
+
 struct LoadingOverlayView: View {
+    let mode: Mode
     let message: String?
 
-    init(message: String? = nil) {
+    init(mode: Mode = .loading, message: String? = nil) {
+        self.mode = mode
         self.message = message
     }
 
@@ -20,9 +27,18 @@ struct LoadingOverlayView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 16) {
-                ProgressView()
-                    .controlSize(.large)
-                    .tint(.meomunPointColor)
+                Group {
+                    if mode == .loading {
+                        ProgressView()
+                            .controlSize(.large)
+                            .tint(.meomunPointColor)
+                    } else {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 40))
+                            .foregroundStyle(Color.meomunPointColor)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
 
                 if let message {
                     Text(message)
@@ -38,6 +54,7 @@ struct LoadingOverlayView: View {
                     .shadow(color: .black.opacity(0.05), radius: 0, x: 1, y: 1)
             )
         }
+        .animation(.spring(duration: 0.3), value: mode)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -18,6 +18,7 @@ final class MapStore: Store {
         case updateMessages([Message])
         case tapPlaceMarker(Place)
         case dismissSpaceView
+        case setToast(String?)
     }
 
     enum Action {
@@ -27,6 +28,7 @@ final class MapStore: Store {
         case setSelectedPlace(Place?)
         case setLoading(Bool)
         case setError(String)
+        case setToastMessage(String?)
     }
 
     struct State {
@@ -36,6 +38,7 @@ final class MapStore: Store {
         var selectedPlace: Place?
         var isLoading: Bool = false
         var errorMessage: String = ""
+        var toastMessage: String?
     }
 
     @Published var state: State
@@ -86,6 +89,10 @@ final class MapStore: Store {
             case .dismissSpaceView:
                 continuation.yield(.setSelectedPlace(nil))
                 continuation.finish()
+
+            case .setToast(let message):
+                continuation.yield(.setToastMessage(message))
+                continuation.finish()
             }
         }
     }
@@ -111,6 +118,9 @@ final class MapStore: Store {
 
         case .setError(let message):
             newState.errorMessage = message
+
+        case .setToastMessage(let message):
+            newState.toastMessage = message
         }
 
         return newState

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+fileprivate enum Constants {
+    static let successMessage = "머문 흔적을 남겼어요."
+}
+
 struct MapView: View {
     @Environment(\.setTabBarHidden) private var setTabBarHidden
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -85,8 +89,14 @@ struct MapView: View {
                         createMessage: CreateMessageUseCaseImpl(
                             messageRepository: MessageRepositoryImpl()
                         ),
-                        onClose: {
-                            Task { await store.send(intent: .dismissAddMessage)}
+                        onClose: { isSuccess in
+                            Task {
+                                await store.send(intent: .dismissAddMessage)
+
+                                if isSuccess {
+                                    await store.send(intent: .setToast(Constants.successMessage))
+                                }
+                            }
                         }
                     )
                 )
@@ -138,10 +148,23 @@ struct MapView: View {
                     await store.send(intent: .updateUserLocation(newValue))
                 }
             }
+            .toast(toastBinding, bottomPadding: 100)
         }
     }
 }
 
+extension MapView {
+    private var toastBinding: Binding<String?> {
+        Binding(
+            get: { store.state.toastMessage },
+            set: { message in
+                Task {
+                    await store.send(intent: .setToast(message))
+                }
+            }
+        )
+    }
+}
 #Preview {
     let rotationAnimator = MessageRotationAnimator()
     let bubbleImageRenderer = BubbleImageRenderer()

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -7,10 +7,6 @@
 
 import SwiftUI
 
-fileprivate enum Constants {
-    static let successMessage = "머문 흔적을 남겼어요."
-}
-
 struct MapView: View {
     @Environment(\.setTabBarHidden) private var setTabBarHidden
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -110,13 +106,9 @@ struct MapView: View {
                             createMessage: CreateMessageUseCaseImpl(
                                 messageRepository: MessageRepositoryImpl()
                             ),
-                            onClose: { isSuccess in
+                            onClose: { _ in
                                 Task {
                                     await store.send(intent: .dismissAddMessage)
-
-                                    if isSuccess {
-                                        await store.send(intent: .setToast(Constants.successMessage))
-                                    }
                                 }
                             }
                         )

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -122,6 +122,7 @@ struct MapView: View {
                         )
                     )
                     .onAppear { setTabBarHidden(true) }
+                    .onDisappear { setTabBarHidden(false) }
                 }
             }
         }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -167,8 +167,8 @@ struct MapView: View {
     }
 }
 
-extension MapView {
-    private var toastBinding: Binding<String?> {
+private extension MapView {
+    var toastBinding: Binding<String?> {
         Binding(
             get: { store.state.toastMessage },
             set: { message in
@@ -179,6 +179,7 @@ extension MapView {
         )
     }
 }
+
 #Preview {
     let rotationAnimator = MessageRotationAnimator()
     let bubbleImageRenderer = BubbleImageRenderer()

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageTextEditor.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageTextEditor.swift
@@ -13,14 +13,16 @@ struct MessageTextEditor: View {
     let maxCount: Int
     let placeholder: String
 
-    @FocusState private var isFocused: Bool
+    @FocusState.Binding private var isFocused: Bool
 
     init(
         text: Binding<String>,
-        maxCount: Int = 30,
-        placeholder: String = "지금 느낌 어때요?"
+        isFocused: FocusState<Bool>.Binding,
+        maxCount: Int,
+        placeholder: String
     ) {
         self._text = text
+        self._isFocused = isFocused
         self.maxCount = maxCount
         self.placeholder = placeholder
     }
@@ -51,11 +53,13 @@ struct MessageTextEditor: View {
                         .background(Color.clear)
                         .submitLabel(.done)
                         .onChange(of: text) { _, newValue in
-                            if newValue.contains("\n") {
+                            if newValue.contains("\n") || newValue.contains("\r") {
                                 text = newValue.replacingOccurrences(of: "\n", with: "")
-                                isFocused = false
+                                               .replacingOccurrences(of: "\r", with: "")
+                                $isFocused.wrappedValue = false
                                 return
                             }
+
                             if newValue.count > maxCount {
                                 text = String(newValue.prefix(maxCount))
                             }
@@ -97,13 +101,14 @@ struct MessageTextEditor: View {
         }
         .frame(height: 140)
         .onTapGesture {
-            isFocused = true
+            $isFocused.wrappedValue = true
         }
     }
 }
 
 #Preview {
     @Previewable @State var message: String = ""
+    @Previewable @FocusState var isFocused: Bool
 
-    MessageTextEditor(text: $message)
+    MessageTextEditor(text: $message, isFocused: $isFocused, maxCount: 30, placeholder: "지금 느낌 어때요?")
 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageTextEditor.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageTextEditor.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct MessageTextEditor: View {
     @Binding private var text: String
+    @FocusState.Binding private var isFocused: Bool
+    @State private var localText: String = ""
 
     let maxCount: Int
     let placeholder: String
-
-    @FocusState.Binding private var isFocused: Bool
 
     init(
         text: Binding<String>,
@@ -23,6 +23,7 @@ struct MessageTextEditor: View {
     ) {
         self._text = text
         self._isFocused = isFocused
+        self._localText = State(initialValue: text.wrappedValue)
         self.maxCount = maxCount
         self.placeholder = placeholder
     }
@@ -42,7 +43,7 @@ struct MessageTextEditor: View {
             VStack {
                 // Editor + placeholder
                 ZStack(alignment: .topLeading) {
-                    TextEditor(text: $text)
+                    TextEditor(text: $localText)
                         .focused($isFocused)
                         .font(.body.bold())
                         .foregroundStyle(Color.meomunPrimaryColor.opacity(0.8))
@@ -52,16 +53,24 @@ struct MessageTextEditor: View {
                         .scrollContentBackground(.hidden)
                         .background(Color.clear)
                         .submitLabel(.done)
-                        .onChange(of: text) { _, newValue in
-                            if newValue.contains("\n") || newValue.contains("\r") {
-                                text = newValue.replacingOccurrences(of: "\n", with: "")
-                                               .replacingOccurrences(of: "\r", with: "")
-                                $isFocused.wrappedValue = false
-                                return
+                        .onChange(of: localText) { _, newValue in
+                            let filtered = newValue.replacingOccurrences(of: "\n", with: "")
+
+                            if filtered.count > maxCount {
+                                localText = String(filtered.prefix(maxCount))
+                            } else {
+                                localText = filtered
                             }
 
-                            if newValue.count > maxCount {
-                                text = String(newValue.prefix(maxCount))
+                            text = localText
+
+                            if newValue.contains("\n") {
+                                $isFocused.wrappedValue = false
+                            }
+                        }
+                        .onChange(of: text) { _, newValue in
+                            if newValue != localText {
+                                localText = newValue
                             }
                         }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageTextEditor.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageTextEditor.swift
@@ -54,7 +54,9 @@ struct MessageTextEditor: View {
                         .background(Color.clear)
                         .submitLabel(.done)
                         .onChange(of: localText) { _, newValue in
-                            let filtered = newValue.replacingOccurrences(of: "\n", with: "")
+                            let filtered = newValue
+                                .replacingOccurrences(of: "\n", with: "")
+                                .replacingOccurrences(of: "\r", with: "")
 
                             if filtered.count > maxCount {
                                 localText = String(filtered.prefix(maxCount))
@@ -64,7 +66,7 @@ struct MessageTextEditor: View {
 
                             text = localText
 
-                            if newValue.contains("\n") {
+                            if newValue.contains("\n") || newValue.contains("\r") {
                                 $isFocused.wrappedValue = false
                             }
                         }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -9,6 +9,10 @@ import Foundation
 import Combine
 import Supabase
 
+enum EditorPolicy {
+    static let maxCount = 30
+}
+
 final class MessageComposerStore: Store {
     struct State: Equatable {
         var userLocation: Coordinate
@@ -96,9 +100,16 @@ final class MessageComposerStore: Store {
                 continuation.yield(.clearPlace)
 
             case .tapConfirm:
-                if state.placeText != "" {
-                    // TODO: 1차 검증) 장소 태그 존재 시, 현재 위치 기준으로 거리 검증
+                let normalized = state.message
+                    .replacingOccurrences(of: "\n", with: "")
+                    .replacingOccurrences(of: "\r", with: "")
+
+                let finalMessage = String(normalized.prefix(EditorPolicy.maxCount))
+
+                if finalMessage != state.message {
+                    continuation.yield(.updateMessage(finalMessage))
                 }
+
                 createMessage(continuation: continuation)
                 return
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -56,19 +56,19 @@ final class MessageComposerStore: Store {
         case setConfirmLoading(Bool)
         case presentAlert(AlertModel?)
         case presentToast(String?)
-        case close
+        case close(isSuccess: Bool)
     }
 
     @Published var state: State
 
     private let createMessageUseCase: CreateMessageUseCase
 
-    private let onClose: () -> Void
+    private let onClose: (Bool) -> Void
 
     init(
         userLocation: Coordinate,
         createMessage: CreateMessageUseCase,
-        onClose: @escaping () -> Void
+        onClose: @escaping (Bool) -> Void
     ) {
         self.state = State(userLocation: userLocation)
         self.createMessageUseCase = createMessage
@@ -84,7 +84,7 @@ final class MessageComposerStore: Store {
 
             case .resetDraft:
                 continuation.yield(.updateMessage(""))
-                continuation.yield(.close)
+                continuation.yield(.close(isSuccess: false))
 
             case .tapPlaceField:
                 continuation.yield(.presentPlaceSearch(true))
@@ -147,8 +147,8 @@ final class MessageComposerStore: Store {
         case .presentToast(let message):
             newState.toastMessage = message
 
-        case .close:
-            onClose()
+        case .close(let isSuccess):
+            onClose(isSuccess)
         }
         return newState
     }
@@ -165,10 +165,7 @@ extension MessageComposerStore {
 
             do {
                 try await createMessageUseCase.execute(makeCreateMessageRequest())
-
-                continuation.yield(.presentToast("메시지가 등록되었어요."))
-                try await Task.sleep(nanoseconds: 700_000_000)
-                continuation.yield(.close)
+                continuation.yield(.close(isSuccess: true))
 
             } catch let error as CreateMessageError {
                 continuation.yield(mapCreateMessageErrorToAlertAction(error))

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -370,16 +370,13 @@ extension MessageComposerStore {
         }
     }
 
-    private func makeCreateMessageRequest() -> CreateMessageRequestDTO? {
-        guard let latitude = state.startLocation?.latitude,
-              let longitude = state.startLocation?.longitude
-        else { return nil }
+    private func makeCreateMessageRequest() -> CreateMessageRequest? {
+        guard let startLocation = state.startLocation else { return nil }
 
-        return CreateMessageRequestDTO(
+        return CreateMessageRequest(
             content: state.message,
-            latitude: latitude,
-            longitude: longitude,
-            place: nil
+            coordinate: startLocation,
+            place: state.selectedPlace
         )
     }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -28,6 +28,7 @@ final class MessageComposerStore: Store {
         case idle
         case sending
         case success
+        case fail
     }
 
     // 위치 이탈 상태에서 사용자의 선택을 반영하기 위한 상태
@@ -357,9 +358,10 @@ extension MessageComposerStore {
                 locationProvider.stopContinuous()
                 continuation.yield(.close(isSuccess: true))
             } catch let error as CreateMessageError {
+                continuation.yield(.setConfirmStatus(.fail))
                 continuation.yield(mapCreateMessageErrorToAlertAction(error))
-
             } catch {
+                continuation.yield(.setConfirmStatus(.fail))
                 continuation.yield(.presentAlert(.init(
                     title: "네트워크에 연결할 수 없어요.",
                     message: "네트워크 상태를 확인하고 다시 시도해 주세요."

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -14,6 +14,12 @@ enum EditorPolicy {
 }
 
 final class MessageComposerStore: Store {
+    enum ConfirmStatus: Equatable {
+        case idle
+        case sending
+        case success
+    }
+
     struct State: Equatable {
         var userLocation: Coordinate
         var message: String = ""
@@ -23,12 +29,13 @@ final class MessageComposerStore: Store {
         var alert: AlertModel?
         var toastMessage: String?
 
-        var isConfirmLoading: Bool = false
+//        var isConfirmLoading: Bool = false
+        var confirmStatus: ConfirmStatus = .idle
         var isConfirmEnabled: Bool {
             message
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty == false
-            && isConfirmLoading == false
+            && confirmStatus != .sending
         }
     }
 
@@ -53,7 +60,7 @@ final class MessageComposerStore: Store {
         case updatePlace(String)
         case clearPlace
 
-        case setConfirmLoading(Bool)
+        case setConfirmStatus(ConfirmStatus)
         case presentAlert(AlertModel?)
         case presentToast(String?)
         case close(isSuccess: Bool)
@@ -138,8 +145,8 @@ final class MessageComposerStore: Store {
         case .clearPlace:
             newState.placeText = ""
 
-        case .setConfirmLoading(let isLoading):
-            newState.isConfirmLoading = isLoading
+        case .setConfirmStatus(let status):
+            newState.confirmStatus = status
 
         case .presentAlert(let alertState):
             newState.alert = alertState
@@ -157,14 +164,15 @@ final class MessageComposerStore: Store {
 extension MessageComposerStore {
     private func createMessage(continuation: AsyncStream<Action>.Continuation) {
         Task {
-            continuation.yield(.setConfirmLoading(true))
+            continuation.yield(.setConfirmStatus(.sending))
             defer {
-                continuation.yield(.setConfirmLoading(false))
                 continuation.finish()
             }
 
             do {
                 try await createMessageUseCase.execute(makeCreateMessageRequest())
+                continuation.yield(.setConfirmStatus(.success))
+                try await Task.sleep(nanoseconds: 1_000_000_000)
                 continuation.yield(.close(isSuccess: true))
 
             } catch let error as CreateMessageError {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -56,6 +56,8 @@ struct MessageComposerView: View {
 
             if store.state.isConfirmLoading {
                 LoadingOverlayView(message: Constants.loadingMessage)
+                    .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+                    .zIndex(1000)
             }
         }
     }
@@ -213,6 +215,8 @@ extension MessageComposerView {
                 ]
             )))
         }
+        .disabled(store.state.isConfirmLoading)
+        .opacity(store.state.isConfirmLoading ? 0.4 : 1.0)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -12,6 +12,7 @@ fileprivate enum Constants {
     static let textEditorTitle = "이 말은 잠시 머물 거에요."
     static let textEditorPlaceholder = "지금 느낌 어때요?"
     static let placeContainerPlaceholder = "지금 어디에 있나요?"
+    static let loadingMessage = "머문 흔적을 남기고 있어요"
 }
 
 struct MessageComposerView: View {
@@ -51,6 +52,10 @@ struct MessageComposerView: View {
                 )
                 .transition(.opacity.combined(with: .scale(scale: 0.98)))
                 .zIndex(999)
+            }
+
+            if store.state.isConfirmLoading {
+                LoadingOverlayView(message: Constants.loadingMessage)
             }
         }
     }
@@ -118,6 +123,7 @@ extension MessageComposerView {
         ConfirmButton(action: { send(.tapConfirm) })
         .disabled(!store.state.isConfirmEnabled)
         .opacity(store.state.isConfirmEnabled ? 1.0 : 0.4)
+        .animation(.default, value: store.state.isConfirmLoading)
     }
 
     private var backgroundView: some View {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -15,6 +15,7 @@ fileprivate enum Constants {
     static let placeContainerPlaceholderWhenBlocked = "선택한 장소와 너무 멀어요."
     static let loadingMessage = "머문 흔적을 남기고 있어요."
     static let successMessage = "머문 흔적을 남겼어요."
+    static let failMessage = "머문 흔적 남기기에 실패했어요."
 }
 
 struct MessageComposerView: View {
@@ -57,7 +58,8 @@ struct MessageComposerView: View {
                 .zIndex(999)
             }
 
-            if store.state.confirmStatus != .idle {
+            // TODO: alert 수정할 때 같이 수정해야됨. fail 경우도 추가하기
+            if store.state.confirmStatus == .sending || store.state.confirmStatus == .success {
                 LoadingOverlayView(
                     mode: store.state.confirmStatus == .success ? .success : .loading,
                     message: store.state.confirmStatus == .sending ? Constants.loadingMessage :

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -32,6 +32,7 @@ struct MessageComposerView: View {
     var body: some View {
         ZStack {
             content
+                .disabled(store.state.isConfirmLoading || store.state.isPlaceSearchPresented)
 
             if store.state.isPlaceSearchPresented {
                 PlaceSearchOverlayView(

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -12,7 +12,7 @@ fileprivate enum Constants {
     static let textEditorTitle = "이 말은 잠시 머물 거에요."
     static let textEditorPlaceholder = "지금 느낌 어때요?"
     static let placeContainerPlaceholder = "지금 어디에 있나요?"
-    static let loadingMessage = "머문 흔적을 남기고 있어요"
+    static let loadingMessage = "머문 흔적을 남기고 있어요."
 }
 
 struct MessageComposerView: View {
@@ -234,7 +234,7 @@ extension MessageComposerView {
                 createMessage: CreateMessageUseCaseImpl(
                     messageRepository: MessageRepositoryImpl()
                 ),
-                onClose: {
+                onClose: { _ in
                     print("close")
                 }
             )

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -13,6 +13,7 @@ fileprivate enum Constants {
     static let textEditorPlaceholder = "지금 느낌 어때요?"
     static let placeContainerPlaceholder = "지금 어디에 있나요?"
     static let loadingMessage = "머문 흔적을 남기고 있어요."
+    static let successMessage = "머문 흔적을 남겼어요."
 }
 
 struct MessageComposerView: View {
@@ -32,7 +33,7 @@ struct MessageComposerView: View {
     var body: some View {
         ZStack {
             content
-                .disabled(store.state.isConfirmLoading || store.state.isPlaceSearchPresented)
+                .disabled(store.state.confirmStatus == .sending || store.state.isPlaceSearchPresented)
 
             if store.state.isPlaceSearchPresented {
                 PlaceSearchOverlayView(
@@ -55,8 +56,11 @@ struct MessageComposerView: View {
                 .zIndex(999)
             }
 
-            if store.state.isConfirmLoading {
-                LoadingOverlayView(message: Constants.loadingMessage)
+            if store.state.confirmStatus != .idle {
+                LoadingOverlayView(
+                    mode: store.state.confirmStatus == .success ? .success : .loading,
+                    message: store.state.confirmStatus == .sending ? Constants.loadingMessage :
+                        Constants.successMessage)
                     .transition(.opacity.animation(.easeInOut(duration: 0.2)))
                     .zIndex(1000)
             }
@@ -126,7 +130,6 @@ extension MessageComposerView {
         ConfirmButton(action: { send(.tapConfirm) })
         .disabled(!store.state.isConfirmEnabled)
         .opacity(store.state.isConfirmEnabled ? 1.0 : 0.4)
-        .animation(.default, value: store.state.isConfirmLoading)
     }
 
     private var backgroundView: some View {
@@ -216,8 +219,8 @@ extension MessageComposerView {
                 ]
             )))
         }
-        .disabled(store.state.isConfirmLoading)
-        .opacity(store.state.isConfirmLoading ? 0.4 : 1.0)
+        .disabled(store.state.confirmStatus == .sending)
+        .opacity(store.state.confirmStatus == .sending ? 0.4 : 1.0)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 fileprivate enum Constants {
     static let navigationTitle = "잠시 남겨놓기"
     static let textEditorTitle = "이 말은 잠시 머물 거에요."
-    static let textEditorPlaceholder = "지금 어디에 있나요?"
+    static let textEditorPlaceholder = "지금 느낌 어때요?"
+    static let placeContainerPlaceholder = "지금 어디에 있나요?"
 }
 
 struct MessageComposerView: View {
@@ -87,8 +88,12 @@ extension MessageComposerView {
             .foregroundStyle(Color.meomunSecondaryColor)
             .frame(maxWidth: .infinity, alignment: .leading)
 
-        MessageTextEditor(text: messageBinding)
-        .focused($isFocused)
+        MessageTextEditor(
+            text: messageBinding,
+            isFocused: $isFocused,
+            maxCount: EditorPolicy.maxCount,
+            placeholder: Constants.textEditorPlaceholder
+        )
     }
 
     private var placeSection: some View {
@@ -98,7 +103,7 @@ extension MessageComposerView {
                     isFocused = false
                     send(.tapPlaceField)
                 } label: {
-                    Text(store.state.placeText.isEmpty ? Constants.textEditorPlaceholder : store.state.placeText)
+                    Text(store.state.placeText.isEmpty ? Constants.placeContainerPlaceholder : store.state.placeText)
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(store.state.placeText.isEmpty ? Color(.placeholderText) : Color.tabActive)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -176,6 +181,7 @@ extension MessageComposerView {
                 return
             }
 
+            isFocused = false
             let trimmed = store.state.message.trimmingCharacters(in: .whitespacesAndNewlines)
             guard trimmed.isEmpty == false else {
                 dismiss()

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
@@ -60,7 +60,7 @@ final class PlaceSearchStore: Store {
     init(
         searchPlaces: SearchNearbyPlaceUseCase,
         userLocation: Coordinate?,
-        radiusMeters: Double = 60,
+        radiusMeters: Double = 600,
         onSelect: @escaping (Place) -> Void,
         onDismiss: @escaping () -> Void
     ) {

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
@@ -14,6 +14,7 @@ final class SpaceStore: Store {
         case onAppear(placeID: PlaceID)
         case tapWriteButton
         case dismissAddMessage
+        case setToast(String?)
     }
 
     enum Action {
@@ -23,6 +24,7 @@ final class SpaceStore: Store {
         case setUserLocation(Coordinate)
         case setShowAddMessage(Bool)
         case setCurrentPlaceID(PlaceID)
+        case setToastMessage(String?)
     }
 
     struct State {
@@ -32,6 +34,7 @@ final class SpaceStore: Store {
         var userLocation: Coordinate? = nil     // TODO: - 지도 > 공간 진입 시점 좌표 넘겨주고, 옵셔널 지우기
         var isShowingAddMessage: Bool = false
         var currentPlaceID: PlaceID?
+        var toastMessage: String?
     }
 
     @Published var state: State
@@ -96,6 +99,10 @@ final class SpaceStore: Store {
             case .dismissAddMessage:
                 continuation.yield(.setShowAddMessage(false))
                 continuation.finish()
+
+            case .setToast(let message):
+                continuation.yield(.setToastMessage(message))
+                continuation.finish()
             }
         }
     }
@@ -121,6 +128,9 @@ final class SpaceStore: Store {
 
         case .setCurrentPlaceID(let placeID):
             newState.currentPlaceID = placeID
+
+        case .setToastMessage(let message):
+            newState.toastMessage = message
         }
 
         return newState

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -8,10 +8,6 @@
 import RealityKit
 import SwiftUI
 
-fileprivate enum Constants {
-    static let successMessage = "머문 흔적을 남겼어요."
-}
-
 struct SpaceView: View {
 
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -94,10 +90,6 @@ struct SpaceView: View {
                             onClose: { isSuccess in
                                 Task {
                                     await store.send(intent: .dismissAddMessage)
-
-                                    if isSuccess {
-                                        await store.send(intent: .setToast(Constants.successMessage))
-                                    }
                                 }
                             }
                         )

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -8,6 +8,10 @@
 import RealityKit
 import SwiftUI
 
+fileprivate enum Constants {
+    static let successMessage = "머문 흔적을 남겼어요."
+}
+
 struct SpaceView: View {
 
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -87,8 +91,14 @@ struct SpaceView: View {
                             createMessage: CreateMessageUseCaseImpl(
                                 messageRepository: MessageRepositoryImpl()
                             ),
-                            onClose: {
-                                Task { await store.send(intent: .dismissAddMessage) }
+                            onClose: { isSuccess in
+                                Task {
+                                    await store.send(intent: .dismissAddMessage)
+
+                                    if isSuccess {
+                                        await store.send(intent: .setToast(Constants.successMessage))
+                                    }
+                                }
                             }
                         )
                     )


### PR DESCRIPTION
## 배경
- closed #225
- closed #237 
- closed #244 

## 작업 요약

- [x]  Store에 메시지 정규화(글자수 및 개행 정책 적용) 로직 추가
- [x]  메시지 에디터 포커스 파편화 이슈
- [x]  키 입력 시 한글 분리 이슈
- [x]  메시지 작성 요청 로딩 뷰
- [x]  메시지 작성 완료 시 토스트 출력 책임을 자식 뷰(작성 화면)에서 부모 뷰(지도 화면)로 위임하여 UX 개선

## 작업 내용

### Store 메시지 정규화(글자수 및 개행 정책 적용) 로직 추가

- Store에서 즉각적인 작업 처리할 경우 UI 업데이트 밀림 등 현상이 발생할 수 있음
    - 따라서 컴포넌트와 스토어 양쪽에서 모두 검증하는 것이 안전하다는 판단하에 store에도 정책 검증 로직을 추가

#### 컴포넌트 (MessageTextEditor): UX 가드

- **즉각적인 피드백**: 사용자가 글자를 입력하자마자 줄바꿈이 사라지거나 글자 수가 잘리는 것을 보여주어, 사용자가 "아, 여기선 줄바꿈이 안 되는구나"라고 즉시 인지하게 함
- **입력 제어**: 키보드 상태(`isFocused`)를 직접 제어하여 엔터를 눌렀을 때 키보드를 내리는 등 UI 흐름을 매끄럽게 만듦

#### 스토어 (MessageComposerStore): 데이터 가드

- **최종 정합성**: 컴포넌트뿐만 아니라 다른 경로(예: 초기 데이터 로드, 외부 주입 등)를 통해 데이터가 들어오더라도 비즈니스 로직에 맞는 깨끗한 상태를 유지
- **API 준비**: 서버에 데이터를 보내기 직전, `makeCreateMessageRequest` 등에서 다시 한번 공백을 제거하거나 형식을 맞추어 에러 발생 가능성 최소화

```swift
// Issue-Case
    case .setMessage(let message):
        let normalized = state.message
            .replacingOccurrences(of: "\n", with: "")
            .replacingOccurrences(of: "\r", with: "")

        let finalMessage = String(normalized.prefix(EditorPolicy.maxCount))

        if finalMessage != state.message {
            continuation.yield(.updateMessage(finalMessage))
        }
```

- 처음에는 setMessage에서 진행하려 했으나 아래와 같은 이슈가 발생
  - 키보드 엔터(Done) 키 입력 시 키보드 안내려감 + Caps(Shift) 키가 활성화되는 현상
  - 글자 타이핑이 씹히는 문제

1. **사용자 입력**: 사용자가 엔터를 누르면 `\n`이 입력됩니다.
2. **컴포넌트의 대응**: `MessageTextEditor`의 `onChange`에서 `\n`을 제거하고 `isFocused = false`를 호출합니다.
3. **스토어의 대응**: 동시에 스토어의 `action`에서 줄바꿈이 제거된 `finalMessage`를 다시 `newState`로 보냅니다.
4. **충돌**: `TextEditor`는 이미 줄바꿈이 없는 텍스트를 가지고 있는데, 스토어로부터 **"똑같은 내용의 새로운 텍스트"**를 다시 전달받습니다.
5. **키보드 오작동**: 이때 iOS 시스템은 텍스트가 외부에서 프로그램적으로 수정되었다고 판단하여 텍스트 필드를 초기화하거나 커서 위치를 재조정합니다. 이 과정에서 **자동 대문자 설정(Auto-Capitalization)** 기능이 작동하여 "새 문장의 시작"으로 인식하고 Shift 키를 활성화하는 것입니다.


**결론**
- 실시간 처리는 컴포넌트에 맡기고 메시지 전송 버튼 클릭시 검증하도록 수정

```swift
    case .tapConfirm:
        let normalized = state.message
            .replacingOccurrences(of: "\n", with: "")
            .replacingOccurrences(of: "\r", with: "")

        let finalMessage = String(normalized.prefix(EditorPolicy.maxCount))

        if finalMessage != state.message {
            continuation.yield(.updateMessage(finalMessage))
        }

        createMessage(continuation: continuation)
        return
```

### 코드래빗) 메시지 에디터 포커스 파편화 이슈

- `MessageComposerView`와 `MessageTextEditor`가 각각 별개의 `@FocusState` 변수를 가지고 있어 데이터 불일치 발생 가능성 존재
- 이를 해결하기 위해 `FocusState<Bool>.Binding`을 사용하여 부모의 포커스 상태를 자식에게 직접 주입하는 방식으로 수정

```swift
// As-is
    @FocusState private var isFocused: Bool
    
// To-be
    @FocusState.Binding private var isFocused: Bool
```

```swift
//As-is
	  MessageTextEditor(
        text: messageBinding,
        maxCount: EditorPolicy.maxCount,
        placeholder: Constants.textEditorPlaceholder
    )
    .focused($isFocused)

// To-be
    MessageTextEditor(
        text: messageBinding,
        isFocused: $isFocused,
        maxCount: EditorPolicy.maxCount,
        placeholder: Constants.textEditorPlaceholder
  )
```

### 키 입력 시 한글 분리 이슈

- 원인: IME(입력기) 조합 흐름 끊김
    - 한글은 자음과 모음이 합쳐져 하나의 글자를 만드는 **조합형 문자**
    - iOS의 입력기(IME)는 사용자가 'ㅇ', 'ㅏ'를 입력하는 동안 이들을 임시 버퍼에 들고 있으면서 '아'라는 글자로 합치는 과정을 거침
    - **Store와 View 사이의 데이터 순환**에서 문제 발생:
        1. 사용자가 'ㅇ'을 입력
        2. `onChange`가 동작하고 **Store로 데이터** 보냄
        3. Store에서 새로운 `State`를 생성하고 다시 **View로 데이터**를 내려줌
        4. `TextEditor`는 Store로부터 **새로운 문자열**을 주입받음
        5. 이때 시스템은 **외부에서 텍스트가 수정**되었다고 판단하여, 입력기가 관리하던 **조합 버퍼를 초기화**
        6. 결국 조합 중이던 글자가 확정되어 버리고, 다음 글자는 새로운 글자로 시작되어 자음과 모음이 낱개로 나열
- 해결: 로컬 상태(localText) 도입
    - 내부에 로컬 @State를 두어 Store 상태와 TextEditor의 입력 상태를 직접 연결하지 않게 함

```swift
struct MessageTextEditor: View {
    @Binding private var text: Strin
    @State private var localText: String = ""

    init(text: Binding<String>, ...) {
        self._text = text
        // 초기값을 로컬 상태에 복사
        self._localText = State(initialValue: text.wrappedValue)
    }

    var body: some View {
        // TextEditor는 로컬 상태인 $localText를 직접 바인딩
        TextEditor(text: $localText)
            .onChange(of: localText) { _, newValue in
                // 3. 줄바꿈 및 글자수 로직은 로컬에서 먼저 처리
                let filtered = newValue.replacingOccurrences(of: "\n", with: "")
                
                if filtered.count > maxCount {
                    localText = String(filtered.prefix(maxCount))
                } else {
                    localText = filtered
                }
                
                // 4. 최종 정제된 값을 Store(부모 바인딩)로 전달
                // Store에서 값이 돌아오더라도 TextEditor는 localText를 보고 있으므로 
                // IME 조합이 끊기지 않음
                text = localText
                
                // 엔터 처리 (키보드 내리기)
                if newValue.contains("\n") {
                    isFocused.wrappedValue = false
                }
            }
            // 5. 외부(Store)에서 데이터가 변경되었을 때(예: 삭제 버튼)만 로컬 상태 동기화
            .onChange(of: text) { _, newValue in
                if newValue != localText {
                    localText = newValue
                }
            }
    }

```

### 메시지 작성 완료 토스트 책임 이관

- MessageComposerStore (자식 스토어) : onClose 콜백의 시그니처를 변경하여, 화면이 닫힐 때 작업 성공 여부를 부모에게 전달하도록 수정

```swift
final class MessageComposerStore: Store {
    // [변경] onClose 타입 변경: 단순 종료 알림 -> 성공 여부(Bool) 전달
    private let onClose: (Bool) -> Void
    
    enum Action {
        case close(isSuccess: Bool) // [변경] Action에도 성공 여부 포함
    }

    // ...

    private func createMessage(...) {
        // ...
        do {
            try await createMessageUseCase.execute(...)
            // [변경] 직접 토스트를 띄우지 않고, 성공(true) 신호와 함께 종료 요청
            continuation.yield(.close(isSuccess: true))
        } catch {
            // ...
        }
    }
}
```

- Map/SpaceStore (부모 스토어) : 지도 화면에서 토스트를 제어할 수 있도록 상태(State)와 인텐트(Intent) 추가

```swift
final class MapStore: Store {
    struct State {
        var toastMessage: String? // [추가] 토스트 메시지 상태 관리
        // ...
    }

    enum Intent {
        case setToast(String?) // [추가] 토스트 제어 인텐트
        // ...
    }
    
    // ... reduce 로직에서 toastMessage 상태 업데이트 구현
}
```

- Map/SpaceView (부모 뷰) : 자식 뷰(MessageComposerView)가 닫힐 때 성공 신호를 받으면 MapStore에 토스트 출력을 요청하도록 연결

```swift
struct MapView: View {
    // ...
    MessageComposerView(
        store: MessageComposerStore(
            // ...
            onClose: { isSuccess in
                Task {
                    // 1. 작성 화면 닫기
                    await store.send(intent: .dismissAddMessage)
                    
                    // 2. 성공 시 부모 뷰(Map)에서 토스트 출력 요청
                    if isSuccess {
                        await store.send(intent: .setToast("메시지가 등록되었어요."))
                    }
                }
            }
        )
    )
    // [추가] MapView 레벨에 토스트 바인딩 연결
    .toast(Binding(
        get: { store.state.toastMessage },
        set: { store.send(intent: .setToast($0)) }
    ))
}
```


## 스크린샷

#### [Fix] 한글 입력 분리 이슈

https://github.com/user-attachments/assets/b6a3988f-ae54-4b67-abe8-8dd0afb6c819

#### [Feat] 메시지 작성 요청 로딩 뷰

https://github.com/user-attachments/assets/784a5692-dc3b-4cad-962b-bdedd8f078f0

#### [Refactor] 메시지 작성 완료 토스트 책임 변경

https://github.com/user-attachments/assets/4b4ba6f5-5858-4072-a654-86eda6ef8d52


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen loading overlay with loading/success states and messages
  * App-wide toast notifications integrated into map and space flows
  * Composer notifies caller of success/failure when closed

* **UI Updates**
  * Enforced message length and newline handling; improved editor focus behavior
  * Updated editor/placeholder texts and disabled/faded interactions while sending
  * Success feedback shown via overlay; dismissal behavior adjusted

* **Chores**
  * Simplified preview UI by removing an unused text editor component

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->