### PR TITLE
위치 권한이 없을 경우 요청 & 설정 화면 이동 플로우 구현

### DIFF
--- a/Meomun/Meomun.xcodeproj/project.pbxproj
+++ b/Meomun/Meomun.xcodeproj/project.pbxproj
@@ -411,7 +411,7 @@
 				INFOPLIST_FILE = Meomun/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "머문";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 사용하시겠습니까?";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고, 해당 위치에 메시지를 남기기 위해 위치 정보가 필요합니다.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -461,7 +461,7 @@
 				INFOPLIST_FILE = Meomun/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "머문";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 사용하시겠습니까?";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고, 해당 위치에 메시지를 남기기 위해 위치 정보가 필요합니다.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Meomun/Meomun/Domain/Entity/Coordinate.swift
+++ b/Meomun/Meomun/Domain/Entity/Coordinate.swift
@@ -14,6 +14,9 @@ struct Coordinate: Sendable, Equatable, Hashable {
     // 소수점 5자리 정밀도 (약 1.1m 오차)
     private static let precision: Double = 100_000
 
+    /// 서울 시청
+    static let seoulCity: Coordinate = .init(latitude: 37.5665, longitude: 126.9780)
+
     private var normalizedLatitude: Int {
         Int((latitude * Self.precision).rounded())
     }

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -42,7 +42,7 @@ struct LocationGateView: View {
                     }
 
             case .denied, .restricted:
-                permissionDeniedView
+                permissionRequestView
 
             case .notDetermined:
                 EmptyView()
@@ -60,7 +60,7 @@ struct LocationGateView: View {
 }
 
 extension LocationGateView {
-    private var permissionDeniedView: some View {
+    private var permissionRequestView: some View {
         VStack(spacing: 16) {
             Image(systemName: Constants.locationImage)
                 .font(.largeTitle)

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -22,6 +22,7 @@ fileprivate enum Constants {
 struct LocationGateView: View {
     @EnvironmentObject private var locationProvider: LocationProvider
     @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
 
     private let onReady: (Coordinate) -> Void
 
@@ -50,8 +51,10 @@ struct LocationGateView: View {
                 EmptyView()
             }
         }
-        .task {
-            locationProvider.requestAuthorizationIfNeeded()
+        .onChange(of: scenePhase) { _, newPhase in      // "다음번에 묻기 또는 내가 공유할 때" 선택 후 앱 진입 시 얼럿을 다시 띄우기 위함.
+            if newPhase == .active {
+                locationProvider.requestAuthorizationIfNeeded()
+            }
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -13,6 +13,7 @@ fileprivate enum Constants {
     static let loadingMessage = "현재 위치 불러오는 중..."
     static let permissionTitle = "위치 권한 필요"
     static let permissionMessage = "머문에서 위치를 사용할 수 없습니다.\n위치 권한을 허용해주세요."
+    static let settingsButtonTitle = "위치 권한 설정하기"
 
     // Image
     static let locationImage = "location.slash.fill"
@@ -20,6 +21,7 @@ fileprivate enum Constants {
 
 struct LocationGateView: View {
     @EnvironmentObject private var locationProvider: LocationProvider
+    @Environment(\.openURL) private var openURL
 
     private let onReady: (Coordinate) -> Void
 
@@ -72,6 +74,17 @@ extension LocationGateView {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
+
+            Button {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    openURL(url)
+                }
+            } label: {
+                Text(Constants.settingsButtonTitle)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
         }
         .padding()
         .padding(.horizontal)

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -8,39 +8,72 @@
 import SwiftUI
 import CoreLocation
 
+fileprivate enum Constants {
+    // Title
+    static let loadingMessage = "현재 위치 불러오는 중..."
+    static let permissionTitle = "위치 권한 필요"
+    static let permissionMessage = "머문에서 위치를 사용할 수 없습니다.\n위치 권한을 허용해주세요."
+
+    // Image
+    static let locationImage = "location.slash.fill"
+}
+
 struct LocationGateView: View {
     @EnvironmentObject private var locationProvider: LocationProvider
-    @State private var didSendReady = false
-    let onReady: (Coordinate) -> Void
+
+    private let onReady: (Coordinate) -> Void
+
+    init(onReady: @escaping (Coordinate) -> Void) {
+        self.onReady = onReady
+    }
 
     var body: some View {
         Group {
             switch locationProvider.authorizationStatus {
-            case .notDetermined:
-                Text("위치 권한을 요청 중...")
+            case .authorizedWhenInUse, .authorizedAlways:
+                ProgressView(Constants.loadingMessage)
+                    .task(id: locationProvider.current) {
+                        if let coordinate = locationProvider.current {
+                            onReady(coordinate)
+                        }
+                    }
 
             case .denied, .restricted:
-                // 설정으로 이동 안내 화면
+                permissionDeniedView
+
+            case .notDetermined:
                 EmptyView()
 
-            case .authorizedWhenInUse, .authorizedAlways:
-                if let current = locationProvider.current {
-                    Color.clear
-                        .task {
-                            guard !didSendReady else { return }
-                            didSendReady = true
-                            onReady(current)
-                        }
-                } else {
-                    ProgressView("현재 위치 불러오는 중...")
-                }
-
             @unknown default:
-                Text("알 수 없는 권한 상태")
+                EmptyView()
             }
         }
         .task {
             locationProvider.requestAuthorizationIfNeeded()
         }
+    }
+}
+
+extension LocationGateView {
+    private var permissionDeniedView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: Constants.locationImage)
+                .font(.largeTitle)
+                .imageScale(.large)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 6) {
+                Text(Constants.permissionTitle)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                Text(Constants.permissionMessage)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding()
+        .padding(.horizontal)
     }
 }

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -11,12 +11,20 @@ import CoreLocation
 fileprivate enum Constants {
     // Title
     static let loadingMessage = "현재 위치 불러오는 중..."
-    static let permissionTitle = "위치 권한 필요"
-    static let permissionMessage = "머문에서 위치를 사용할 수 없습니다.\n위치 권한을 허용해주세요."
+    static let permissionTitle = "위치 권한이 필요해요"
+    static let permissionMessage = "위치 접근을 허용하고 지도 위에 기록을 남겨봐요!"
     static let settingsButtonTitle = "위치 권한 설정하기"
 
     // Image
     static let locationImage = "location.slash.fill"
+
+    // UI
+    static let dimOpacity: Double = 0.4
+    static let popupCornerRadius: CGFloat = 16
+    static let popupInset: CGFloat = 24
+    static let popupHorizontalPadding: CGFloat = 32
+    static let popupContentSpacing: CGFloat = 20
+    static let descriptionSpacing: CGFloat = 6
 }
 
 struct LocationGateView: View {
@@ -42,12 +50,15 @@ struct LocationGateView: View {
                     }
 
             case .denied, .restricted:
-                permissionRequestView
+                ZStack {
+                    Color.black.opacity(Constants.dimOpacity)
+                        .ignoresSafeArea()
 
-            case .notDetermined:
-                EmptyView()
+                    permissionRequestView
 
-            @unknown default:
+                }
+
+            default:
                 EmptyView()
             }
         }
@@ -61,15 +72,15 @@ struct LocationGateView: View {
 
 extension LocationGateView {
     private var permissionRequestView: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: Constants.popupContentSpacing) {
             Image(systemName: Constants.locationImage)
                 .font(.largeTitle)
                 .imageScale(.large)
                 .foregroundStyle(.secondary)
 
-            VStack(spacing: 6) {
+            VStack(spacing: Constants.descriptionSpacing) {
                 Text(Constants.permissionTitle)
-                    .font(.title2)
+                    .font(.title3)
                     .fontWeight(.semibold)
 
                 Text(Constants.permissionMessage)
@@ -89,7 +100,8 @@ extension LocationGateView {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
         }
-        .padding()
-        .padding(.horizontal)
+        .padding(Constants.popupInset)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: Constants.popupCornerRadius))
+        .padding(.horizontal, Constants.popupHorizontalPadding)
     }
 }

--- a/Meomun/Meomun/Presentation/Root/LocationProvider.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationProvider.swift
@@ -23,6 +23,11 @@ final class LocationProvider: NSObject, ObservableObject {
     private var oneShotContinuations: [CheckedContinuation<Coordinate, Error>] = []
     private var isRequestingOneShot = false
 
+    // 위치 권한 허용 여부
+    var hasAuthorized: Bool {
+        authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways
+    }
+
     override init() {
         super.init()
         manager.delegate = self

--- a/Meomun/Meomun/Presentation/Root/RootView.swift
+++ b/Meomun/Meomun/Presentation/Root/RootView.swift
@@ -15,17 +15,16 @@ struct RootView: View {
 
     var body: some View {
         Group {
-            #if DEBUG
-            MainTabShellView(userLocation: .init(latitude: 37.5665, longitude: 126.9780))
-            #else
             if let userLocation {
                 MainTabShellView(userLocation: userLocation)
             } else {
-                LocationGateView { coordinate in
-                    self.userLocation = coordinate
-                }
+                MainTabShellView(userLocation: .seoulCity)
+                    .overlay {
+                        LocationGateView { coordinate in
+                            self.userLocation = coordinate
+                        }
+                    }
             }
-            #endif
         }
         .environmentObject(locationProvider)
         .ignoresSafeArea(.keyboard)


### PR DESCRIPTION
# 배경
- closed #146 
- closed #148 
- closed #150 

# 작업 요약
- LocationGateView UI 수정
- 설정 앱으로 전환
- 위치 접근 허용 권한 별 케이스 대응

# 작업 내용
**`CLAuthorizationStatus`의 권한 케이스**  
|케이스|설명|  
|---|---|
| `notDetermined` | 앱 설치 후 첫 실행 시 초기 값|  
| `authorizedWhenInUse` | 사용할 때만 허용 |  
|  `authorizedAlways` | 항상 허용 |  
| `denied` | 권한 x |  
| `restricted` | 사용자가 아닌 시스템에 의해 위치 서비스가 제한된 상태 (자녀 보호 기능, MDM(기업 관리) 등) |  

## 1. LocationGateView UI 수정
<img width=30% alt="IMG_3223" src="https://github.com/user-attachments/assets/d64c9806-16a7-4e24-ba3c-4b6c6d88e5a7" />

기존에 임시로 구현되어 있던 `LocationGateView` UI를 위 사진과 같이 수정하였습니다.  
- `CLAuthorizationStatus`의 상태가 `denied`, `restricted` 일 때 표시됩니다.

## 2. 위치 접근 허용 권한 별 케이스 대응
### **1. 앱 설치 후 첫 실행**
- (1) 얼럿 표시 -> 허용(`한 번 허용 / 앱을 사용하는 동안 허용`) 선택 -> 지도 화면 이동
- (2) 얼럿 표시 -> 허용 안함 선택 -> `LocationGateView`의 권한 요청 뷰 표시 -> 허용 -> 지도 화면 이동

|(1)|(2)|  
|---|---|  
|![해피패스](https://github.com/user-attachments/assets/2e895583-c80f-4c94-b0b3-11811cb8ec62)|![안함- 이동- 허용](https://github.com/user-attachments/assets/245cbae3-030b-456f-85bb-a49f4e6982fc)|

### **2. 위치 접근 허용 권한 중 `다음번에 묻기 또는 내가 공유할 때` 인 경우**  

|AS-IS|TO-BE|  
|---|---|  
|![Simulator Screen Recording - iPhone 17 Pro - 2026-01-22 at 01 35 48](https://github.com/user-attachments/assets/031b19c2-f077-41ef-b82c-d7e231764113) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-01-22 at 01 27 25](https://github.com/user-attachments/assets/4d93567a-1ff6-4e25-8641-84e65da8ef24) |



**발생한 문제**
`다음번에 묻기 또는 내가 공유할 때`를 선택할 경우 `CLAuthorizationStatus  == notDetermined`로 설정됩니다.  
기존에는 `locationProvider.requestAuthorizationIfNeeded()`를 `LocationGateView`의 `task`에서 호출하였기 때문에  
`앱 -> 설정 화면 -> 앱` 시나리오에서 `EmptyView`만 보이게 되었습니다.  

**해결책**
[관련 커밋 - e0ed965](https://github.com/boostcampwm2025/ios04-ChanaPing/pull/258/commits/e0ed9656a561a02db9579d25f93a1ddcd736da57)

따라서 `scenePhase`가 변경될 때 마다 `locationProvider.requestAuthorizationIfNeeded()`를 호출하여 항상 얼럿이 뜨도록 수정하였습니다.

## 스크린샷
첨부한 실행 영상 참고 부탁드립니다!  

| iOS 26 이전 |iOS 26+ 위치 허용 얼럿(실기기)|   
|---|---|
|<img width=100% alt="Simulator Screenshot - iPhone 16 - 2026-01-22 at 01 31 03" src="https://github.com/user-attachments/assets/e1ead865-555f-4762-8de0-dd23dc22edad" />|<img width=100% alt="IMG_3225" src="https://github.com/user-attachments/assets/e6a8e054-b3a6-44bb-906b-b83c8ca04e0b" />|

## 리뷰 요구사항
- 권한 허용 뷰의 문구 괜찮은지 봐주세요~

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated permission prompt UI with a button to open app settings.
  * Introduced a sensible default location (Seoul) shown until a real location is obtained, with an overlay to capture coordinates.

* **Bug Fixes**
  * Shows a loading state when location is authorized and auto-triggers readiness once a coordinate is available.
  * Re-requests location permission when the app returns to the foreground.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->