### PR TITLE
알럿 경쟁상태 해소, 로딩 뷰 크기 조정

### DIFF
--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -7,17 +7,12 @@
 
 import SwiftUI
 
-enum Mode {
-    case loading
-    case success
-}
-
 struct LoadingOverlayView: View {
-    let mode: Mode
+    let status: LoadingStatus
     let message: String?
 
-    init(mode: Mode = .loading, message: String? = nil) {
-        self.mode = mode
+    init(status: LoadingStatus = .loading, message: String? = nil) {
+        self.status = status
         self.message = message
     }
 
@@ -28,7 +23,7 @@ struct LoadingOverlayView: View {
 
             VStack(spacing: 16) {
                 Group {
-                    if mode == .loading {
+                    if status == .loading {
                         ProgressView()
                             .controlSize(.large)
                             .tint(.meomunPointColor)
@@ -54,7 +49,7 @@ struct LoadingOverlayView: View {
                     .shadow(color: .black.opacity(0.05), radius: 0, x: 1, y: 1)
             )
         }
-        .animation(.spring(duration: 0.3), value: mode)
+        .animation(.spring(duration: 0.3), value: status)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -9,15 +9,16 @@ import SwiftUI
 
 private enum Layout {
     static let iconSize: CGFloat = 40
-    static let textMaxWidth: CGFloat = 150
+    static let textMaxWidth: CGFloat = 160
     static let textMaxHeight: CGFloat = 38
 
     static let cardSideNoMessage: CGFloat = 100
-    static let cardWidthWithMessage: CGFloat = 200
+    static let cardWidthWithMessage: CGFloat = 210
     static let cardHeightWithMessage: CGFloat = 150
 
     static let iconToTextSpacing: CGFloat = 15
-    static let horizontalPadding: CGFloat = 20
+    static let topPadding: CGFloat = 20
+    static let bottomPadding: CGFloat = 10
     static let verticalPadding: CGFloat = 10
 }
 
@@ -91,7 +92,7 @@ private extension LoadingOverlayView {
         VStack(spacing: Layout.iconToTextSpacing) {
             statusIcon
                 .frame(width: Layout.iconSize, height: Layout.iconSize)
-                .padding(.top, Layout.horizontalPadding)
+                .padding(.top, Layout.topPadding)
 
             Text(message ?? "")
                 .font(.subheadline.bold())
@@ -100,7 +101,7 @@ private extension LoadingOverlayView {
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: false)
                 .frame(maxWidth: Layout.textMaxWidth, maxHeight: Layout.textMaxHeight)
-                .padding(.bottom, Layout.horizontalPadding)
+                .padding(.bottom, Layout.bottomPadding)
         }
     }
 
@@ -125,6 +126,7 @@ private extension LoadingOverlayView {
 
     VStack(alignment: .center) {
         LoadingOverlayView()
+        LoadingOverlayView(status: .loading, message: loadingMessage)
         LoadingOverlayView(status: .success, message: successMessage )
         LoadingOverlayView(status: .fail, message: failMessage)
     }

--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -7,6 +7,20 @@
 
 import SwiftUI
 
+private enum Layout {
+    static let iconSize: CGFloat = 40
+    static let textMaxWidth: CGFloat = 150
+    static let textMaxHeight: CGFloat = 38
+
+    static let cardSideNoMessage: CGFloat = 100
+    static let cardWidthWithMessage: CGFloat = 200
+    static let cardHeightWithMessage: CGFloat = 150
+
+    static let iconToTextSpacing: CGFloat = 15
+    static let horizontalPadding: CGFloat = 20
+    static let verticalPadding: CGFloat = 10
+}
+
 struct LoadingOverlayView: View {
     let status: LoadingStatus
     let message: String?
@@ -21,38 +35,97 @@ struct LoadingOverlayView: View {
             Color.black.opacity(0.15)
                 .ignoresSafeArea()
 
-            VStack(spacing: 16) {
-                Group {
-                    if status == .loading {
-                        ProgressView()
-                            .controlSize(.large)
-                            .tint(.meomunPointColor)
-                    } else {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 40))
-                            .foregroundStyle(Color.meomunPointColor)
-                            .transition(.scale.combined(with: .opacity))
-                    }
-                }
-
-                if let message {
-                    Text(message)
-                        .font(.subheadline.bold())
-                        .foregroundStyle(Color.meomunPrimaryColor)
-                }
-            }
-            .padding(30)
-            .background(
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(.white.opacity(0.8))
-                    .shadow(color: .black.opacity(0.05), radius: 2)
-                    .shadow(color: .black.opacity(0.05), radius: 0, x: 1, y: 1)
-            )
+            content
+                .frame(width: cardSize.width, height: cardSize.height)
+                .background(cardBackground)
         }
         .animation(.spring(duration: 0.3), value: status)
     }
 }
 
+private extension LoadingOverlayView {
+    @ViewBuilder var statusIcon: some View {
+        switch status {
+        case .loading:
+            ProgressView()
+                .controlSize(.large)
+                .tint(.meomunPointColor)
+        case .success:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: Layout.iconSize))
+                .foregroundStyle(Color.meomunPointColor)
+                .transition(.scale.combined(with: .opacity))
+        case .fail:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: Layout.iconSize))
+                .foregroundStyle(Color.red)
+                .transition(.scale.combined(with: .opacity))
+        case .idle:
+            EmptyView()
+        }
+    }
+}
+
+private extension LoadingOverlayView {
+    var hasMessage: Bool {
+        guard let message else { return false }
+        return !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    @ViewBuilder
+    var content: some View {
+        if hasMessage {
+            messageContent
+        } else {
+            centeredIconContent
+        }
+    }
+
+    var centeredIconContent: some View {
+        statusIcon
+            .frame(width: Layout.iconSize, height: Layout.iconSize)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    var messageContent: some View {
+        VStack(spacing: Layout.iconToTextSpacing) {
+            statusIcon
+                .frame(width: Layout.iconSize, height: Layout.iconSize)
+                .padding(.top, Layout.horizontalPadding)
+
+            Text(message ?? "")
+                .font(.subheadline.bold())
+                .foregroundStyle(Color.meomunPrimaryColor)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: false)
+                .frame(maxWidth: Layout.textMaxWidth, maxHeight: Layout.textMaxHeight)
+                .padding(.bottom, Layout.horizontalPadding)
+        }
+    }
+
+    var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 16)
+            .fill(.white.opacity(0.8))
+            .shadow(color: .black.opacity(0.05), radius: 2)
+            .shadow(color: .black.opacity(0.05), radius: 0, x: 1, y: 1)
+    }
+
+    var cardSize: CGSize {
+        hasMessage
+        ? CGSize(width: Layout.cardWidthWithMessage, height: Layout.cardHeightWithMessage)
+        : CGSize(width: Layout.cardSideNoMessage, height: Layout.cardSideNoMessage)
+    }
+}
+
 #Preview {
-    LoadingOverlayView()
+    let loadingMessage = "머문 흔적을 남기고 있어요."
+    let successMessage = "머문 흔적을 남겼어요."
+    let failMessage = "머문 흔적 남기기에 실패했어요."
+
+    VStack(alignment: .center) {
+        LoadingOverlayView()
+        LoadingOverlayView(status: .success, message: successMessage )
+        LoadingOverlayView(status: .fail, message: failMessage)
+    }
 }

--- a/Meomun/Meomun/Presentation/Common/LoadingStatus.swift
+++ b/Meomun/Meomun/Presentation/Common/LoadingStatus.swift
@@ -1,0 +1,13 @@
+//
+//  LoadingStatus.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/22/26.
+//
+
+enum LoadingStatus: Equatable {
+    case idle
+    case loading
+    case success
+    case fail
+}

--- a/Meomun/Meomun/Presentation/Common/Modifier/CustomAlertModifier.swift
+++ b/Meomun/Meomun/Presentation/Common/Modifier/CustomAlertModifier.swift
@@ -17,9 +17,7 @@ struct CustomAlertModifier<AlertModel>: ViewModifier {
     func body(content: Content) -> some View {
         let isPresented = Binding<Bool>(
             get: { alert != nil },
-            set: { newValue in
-                if !newValue { alert = nil }
-            }
+            set: { if !$0 { alert = nil } }
         )
 
         content.alert(
@@ -30,7 +28,7 @@ struct CustomAlertModifier<AlertModel>: ViewModifier {
             let configs = Array(buttons(alert))
 
             if configs.isEmpty {
-                Button("확인", role: .cancel) {}
+                Button("확인") {}
             } else {
                 ForEach(Array(configs.enumerated()), id: \.offset) { _, config in
                     makeButton(config)
@@ -44,8 +42,6 @@ struct CustomAlertModifier<AlertModel>: ViewModifier {
     @ViewBuilder
     private func makeButton(_ config: AlertButtonConfig) -> some View {
         let action: () -> Void = {
-            alert = nil
-
             Task { @MainActor in
                 config.action?()
             }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -15,13 +15,6 @@ enum EditorPolicy {
 }
 
 final class MessageComposerStore: Store {
-    enum ConfirmStatus: Equatable {
-        case idle
-        case sending
-        case success
-        case fail
-    }
-
     struct State: Equatable {
         var startLocation: Coordinate?  // TODO: 생성자 주입 고려
 
@@ -32,13 +25,13 @@ final class MessageComposerStore: Store {
         var alert: AlertModel?
         var toastMessage: String?
 
-        var confirmStatus: ConfirmStatus = .idle
+        var confirmStatus: LoadingStatus = .idle
 
         var isConfirmEnabled: Bool {
             message
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty == false
-            && confirmStatus != .sending
+            && confirmStatus != .loading
         }
     }
 
@@ -67,7 +60,7 @@ final class MessageComposerStore: Store {
         case updatePlace(Place)
         case clearPlace
 
-        case setConfirmStatus(ConfirmStatus)
+        case setConfirmStatus(LoadingStatus)
         case presentAlert(AlertModel?)
         case presentToast(String?)
         case close(isSuccess: Bool)
@@ -185,7 +178,7 @@ final class MessageComposerStore: Store {
 extension MessageComposerStore {
     private func createMessage(continuation: AsyncStream<Action>.Continuation) {
         Task {
-            continuation.yield(.setConfirmStatus(.sending))
+            continuation.yield(.setConfirmStatus(.loading))
             defer {
                 continuation.finish()
             }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -42,7 +42,7 @@ struct MessageComposerView: View {
     var body: some View {
         ZStack {
             content
-                .disabled(store.state.confirmStatus == .loading || store.state.isPlaceSearchPresented)
+                .disabled(isInteractionDisabled)
 
             if store.state.isPlaceSearchPresented {
                 placeSearchOverlay

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -22,9 +22,11 @@ struct MessageComposerView: View {
     @Environment(\.dismiss) private var dismiss
 
     @StateObject private var store: MessageComposerStore
+    @State private var presentedAlert: AlertModel?
 
     init(store: MessageComposerStore) {
         _store = StateObject(wrappedValue: store)
+        _presentedAlert = State(initialValue: store.state.alert)
     }
 
     private func send(_ intent: MessageComposerStore.Intent) {
@@ -69,6 +71,14 @@ struct MessageComposerView: View {
         }
         .onAppear { send(.onAppear) }
         .onDisappear { send(.onDisappear) }
+        .onChange(of: store.state.alert) { newValue in
+            guard presentedAlert != newValue else { return }
+            presentedAlert = newValue
+        }
+        .onChange(of: presentedAlert) { newValue in
+            guard store.state.alert != newValue else { return }
+            send(.setAlert(newValue))
+        }
     }
 }
 
@@ -89,7 +99,7 @@ extension MessageComposerView {
         .navigationBarBackButtonHidden()
         .toolbar { toolbarContent }
         .customAlert(
-            alertBinding,
+            $presentedAlert,
             title: { $0.title },
             message: { $0.message },
             buttons: { $0.buttons }
@@ -151,15 +161,6 @@ extension MessageComposerView {
             get: { store.state.message },
             set: { message in
                 send(.setMessage(message))
-            }
-        )
-    }
-
-    private var alertBinding: Binding<AlertModel?> {
-        Binding(
-            get: { store.state.alert },
-            set: { alert in
-                send(.setAlert(alert))
             }
         )
     }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -36,7 +36,7 @@ struct MessageComposerView: View {
     var body: some View {
         ZStack {
             content
-                .disabled(store.state.confirmStatus == .sending || store.state.isPlaceSearchPresented)
+                .disabled(store.state.confirmStatus == .loading || store.state.isPlaceSearchPresented)
 
             if store.state.isPlaceSearchPresented {
                 PlaceSearchOverlayView(
@@ -59,11 +59,10 @@ struct MessageComposerView: View {
                 .zIndex(999)
             }
 
-            // TODO: alert 수정할 때 같이 수정해야됨. fail 경우도 추가하기
-            if store.state.confirmStatus == .sending || store.state.confirmStatus == .success {
+            if store.state.confirmStatus != .idle {
                 LoadingOverlayView(
-                    mode: store.state.confirmStatus == .success ? .success : .loading,
-                    message: store.state.confirmStatus == .sending ? Constants.loadingMessage :
+                    status: store.state.confirmStatus == .success ? .success : .loading,
+                    message: store.state.confirmStatus == .loading ? Constants.loadingMessage :
                         Constants.successMessage)
                     .transition(.opacity.animation(.easeInOut(duration: 0.2)))
                     .zIndex(1000)
@@ -227,6 +226,7 @@ extension MessageComposerView {
                     )
                 ]
             )))
+            return
         }
         .disabled(store.state.confirmStatus == .sending)
         .opacity(store.state.confirmStatus == .sending ? 0.4 : 1.0)

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -12,9 +12,15 @@ fileprivate enum Constants {
     static let textEditorTitle = "이 말은 잠시 머물 거에요."
     static let textEditorPlaceholder = "지금 느낌 어때요?"
     static let placeContainerPlaceholder = "지금 어디에 있나요?"
+
     static let loadingMessage = "머문 흔적을 남기고 있어요."
     static let successMessage = "머문 흔적을 남겼어요."
     static let failMessage = "머문 흔적 남기기에 실패했어요."
+
+    static let exitAlertTitle = "지금 작성 중인 말이 있어요."
+    static let exitAlertMessage = "지금 나가면 작성 중인 내용이 사라져요. 그대로 나갈까요?"
+    static let exitAlertPrimaryButtonTitle = "그대로 나가기"
+    static let exitAlertSecondaryButtonTitle = "머무르기"
 }
 
 struct MessageComposerView: View {
@@ -39,50 +45,33 @@ struct MessageComposerView: View {
                 .disabled(store.state.confirmStatus == .loading || store.state.isPlaceSearchPresented)
 
             if store.state.isPlaceSearchPresented {
-                PlaceSearchOverlayView(
-                    store: PlaceSearchStore(
-                        searchPlaces: SearchNearbyPlaceUseCaseImpl(
-                            placeRepository: NaverPlaceSearchRepositoryImpl(
-                                network: NetworkClientImpl()
-                            )
-                        ),
-                        userLocation: store.state.startLocation,
-                        onSelect: { selected in
-                            send(.selectPlace(selected))
-                        },
-                        onDismiss: {
-                            send(.dismissPlaceSearch)
-                        }
-                    )
-                )
-                .transition(.opacity.combined(with: .scale(scale: 0.98)))
-                .zIndex(999)
+                placeSearchOverlay
+                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
+                    .zIndex(999)
             }
 
             if store.state.confirmStatus != .idle {
-                LoadingOverlayView(
-                    status: store.state.confirmStatus == .success ? .success : .loading,
-                    message: store.state.confirmStatus == .loading ? Constants.loadingMessage :
-                        Constants.successMessage)
+                loadingOverlay
                     .transition(.opacity.animation(.easeInOut(duration: 0.2)))
                     .zIndex(1000)
             }
         }
         .onAppear { send(.onAppear) }
         .onDisappear { send(.onDisappear) }
-        .onChange(of: store.state.alert) { newValue in
+        .onChange(of: store.state.alert) { _, newValue in
             guard presentedAlert != newValue else { return }
             presentedAlert = newValue
         }
-        .onChange(of: presentedAlert) { newValue in
+        .onChange(of: presentedAlert) { _, newValue in
             guard store.state.alert != newValue else { return }
             send(.setAlert(newValue))
         }
     }
 }
 
-extension MessageComposerView {
-    private var content: some View {
+// MARK: Subviews
+private extension MessageComposerView {
+    var content: some View {
         VStack(alignment: .center, spacing: 12) {
             Spacer()
             editorSection
@@ -107,7 +96,7 @@ extension MessageComposerView {
     }
 
     @ViewBuilder
-    private var editorSection: some View {
+    var editorSection: some View {
         Text(Constants.textEditorTitle)
             .font(.headline.bold())
             .foregroundStyle(Color.meomunSecondaryColor)
@@ -121,19 +110,13 @@ extension MessageComposerView {
         )
     }
 
-    private var placeSection: some View {
+    var placeSection: some View {
         HStack(spacing: 8) {
             PlaceSearchContainerView {
-                Button {
-                    isFocused = false
-                    send(.tapPlaceField)
-                } label: {
-                    let isPlaceSelected = store.state.selectedPlace != nil
-                    let placeName = store.state.selectedPlace?.name ?? ""
-
-                    Text(isPlaceSelected ? placeName : Constants.placeContainerPlaceholder)
+                Button(action: onTapPlaceField) {
+                    Text(placeFieldText)
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(isPlaceSelected ? Color.tabActive : Color(.placeholderText))
+                    .foregroundStyle(placeFieldColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
@@ -142,39 +125,90 @@ extension MessageComposerView {
         }
     }
 
-    private var confirmSection: some View {
+    var confirmSection: some View {
         ConfirmButton(action: { send(.tapConfirm) })
         .disabled(!store.state.isConfirmEnabled)
         .opacity(store.state.isConfirmEnabled ? 1.0 : 0.4)
     }
 
-    private var backgroundView: some View {
+    var backgroundView: some View {
         Image(.background)
             .resizable()
             .scaledToFill()
             .ignoresSafeArea()
     }
 
-    private var messageBinding: Binding<String> {
+    var placeSearchOverlay: some View {
+        PlaceSearchOverlayView(
+            store: PlaceSearchStore(
+                searchPlaces: SearchNearbyPlaceUseCaseImpl(
+                    placeRepository: NaverPlaceSearchRepositoryImpl(
+                        network: NetworkClientImpl()
+                    )
+                ),
+                userLocation: store.state.startLocation,
+                onSelect: { send(.selectPlace($0)) },
+                onDismiss: { send(.dismissPlaceSearch) }
+            )
+        )
+    }
+
+    var loadingOverlay: some View {
+        LoadingOverlayView(
+            status: store.state.confirmStatus,
+            message: loadingOverlayMessage)
+    }
+}
+
+// MARK: Stored property
+private extension MessageComposerView {
+    var placeFieldText: String {
+        store.state.selectedPlace?.name ?? Constants.placeContainerPlaceholder
+    }
+
+    var placeFieldColor: Color {
+        store.state.selectedPlace == nil ? Color(.placeholderText) : Color.tabActive
+    }
+
+    var loadingOverlayMessage: String {
+        switch store.state.confirmStatus {
+        case .loading: return Constants.loadingMessage
+        case .success: return Constants.successMessage
+        case .fail: return Constants.failMessage
+        case .idle: return ""
+        }
+    }
+
+    var isInteractionDisabled: Bool {
+        store.state.confirmStatus == .loading || store.state.isPlaceSearchPresented
+    }
+
+    var isDraftEmpty: Bool {
+        store.state.message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+// MARK: Bindings
+private extension MessageComposerView {
+    var messageBinding: Binding<String> {
         Binding(
             get: { store.state.message },
-            set: { message in
-                send(.setMessage(message))
-            }
+            set: { send(.setMessage($0)) }
         )
     }
 
-    private var toastBinding: Binding<String?> {
+    var toastBinding: Binding<String?> {
         Binding(
             get: { store.state.toastMessage },
-            set: { message in
-                send(.setToast(message))
-            }
+            set: { send(.setToast($0)) }
         )
     }
+}
 
+// MARK: Toolbar / Actions
+private extension MessageComposerView {
     @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
+    var toolbarContent: some ToolbarContent {
         if #available(iOS 26.0, *) {
             ToolbarItem(placement: .topBarLeading) {
                 backToolbarButton
@@ -193,43 +227,50 @@ extension MessageComposerView {
         }
     }
 
-    private var backToolbarButton: some View {
-        BackButton {
-            if store.state.isPlaceSearchPresented {
-                send(.dismissPlaceSearch)
-                return
-            }
+    var backToolbarButton: some View {
+        BackButton(action: onTapBackButton)
+        .disabled(store.state.confirmStatus == .loading)
+        .opacity(store.state.confirmStatus == .loading ? 0.4 : 1.0)
+    }
 
-            isFocused = false
-            let trimmed = store.state.message.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.isEmpty == false else {
-                send(.onDisappear)
-                dismiss()
-                return
-            }
+    func onTapPlaceField() {
+        isFocused = false
+        send(.tapPlaceField)
+    }
 
-            send(.setAlert(AlertModel(
-                title: "작성 중인 말이 있어요",
-                message: "지금 나가면 작성 중인 내용이 사라져요. 그대로 나갈까요?",
-                buttons: [
-                    AlertButtonConfig(
-                        title: "그대로 나가기",
-                        role: .destructive,
-                        action: {
-                            send(.resetDraft)
-                        }
-                    ),
-                    AlertButtonConfig(
-                        title: "머무르기",
-                        role: .cancel,
-                        action: nil
-                    )
-                ]
-            )))
+    func onTapBackButton() {
+        if store.state.isPlaceSearchPresented {
+            send(.dismissPlaceSearch)
             return
         }
-        .disabled(store.state.confirmStatus == .sending)
-        .opacity(store.state.confirmStatus == .sending ? 0.4 : 1.0)
+
+        isFocused = false
+
+        guard !isDraftEmpty else {
+            dismiss()
+            return
+        }
+
+        send(.setAlert(exitAlert))
+    }
+
+    var exitAlert: AlertModel {
+        AlertModel(
+            title: Constants.exitAlertTitle,
+            message: Constants.exitAlertMessage,
+            buttons: [
+                AlertButtonConfig(
+                    title: Constants.exitAlertPrimaryButtonTitle,
+                    role: .destructive,
+                    action: { send(.resetDraft) }
+                ),
+                AlertButtonConfig(
+                    title: Constants.exitAlertSecondaryButtonTitle,
+                    role: .cancel,
+                    action: nil
+                )
+            ]
+        )
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -160,7 +160,7 @@ private extension MessageComposerView {
     }
 }
 
-// MARK: Stored property
+// MARK: Computed property
 private extension MessageComposerView {
     var placeFieldText: String {
         store.state.selectedPlace?.name ?? Constants.placeContainerPlaceholder


### PR DESCRIPTION
## 배경
- closed #238 
- closed #255 
- closed #256 

## 작업 요약

- [x]  SwiftUI 알럿이 **다시 나타났다 자동으로 사라지는 레이스 컨디션 현상 원인 분석**
- [x]  알럿 표시 상태의 소유권을 View로 단일화(SSOT)하여 경합 문제 해결
- [x]  로딩 오버레이 뷰 **가로/세로 크기 고정 및 상태별 레이아웃 안정화**
- [x]  MessageComposerView **UI/상태/액션 로직 분리**로 가독성 개선

## 작업 내용

### **알럿 레이스 컨디션 발생 원인 분석**

#### 문제 상황

- 메시지 작성 중 뒤로가기 버튼 클릭 시 알럿 표시
- `머무르기 / 그대로 나가기` 선택 후
    - 알럿이 다시 나타났다가 즉시 사라지는 현상 발생

#### 원인 분석

**알럿 표시 상태를 두 시스템이 동시에 제어**하고 있는 상태

- Store: `state.alert`
- SwiftUI: `.customAlert`에 전달되는 `Binding`

이로 인해 다음과 같은 경합이 발생함:

1. Store에서 `state.alert = AlertModel` 설정 → 알럿 표시
2. 사용자가 버튼 클릭 → SwiftUI가 Binding을 `nil`로 설정하며 알럿 dismiss
3. 거의 동시에 Store 내부에서 `resetDraft`, `onClose`, `onDisappear` 등 상태 변경 발생
4. Store의 `alert` 상태가 아직 살아있거나 다시 설정됨
5. SwiftUI가 다음 렌더 사이클에서 알럿을 다시 표시
6. dismiss 타이밍과 충돌하여 즉시 사라지는 현상 발생

**⇒ 알럿 ON/OFF를 Store와 SwiftUI가 동시에 관리하면서 상태 경합(Race Condition)이 발생**

#### 이해를 돕기 위한 동작 흐름도

```mermaid
sequenceDiagram
    participant U as 사용자 (User)
    participant V as MessageComposerView
    participant M as CustomAlertModifier
    participant S as MessageComposerStore (State)

    Note over U, V: [1단계: 알럿 띄우기]
    U->>V: backToolbarButton 클릭
    V->>S: send(.setAlert(AlertModel))
    S->>S: reduce: state.alert = Model
    S-->>V: State 변경 알림 (View Re-render)
    V->>M: alertBinding을 통해 데이터 전달
    M-->>U: 알럿 화면 표시

    Note over U, M: [2단계: 머무르기 클릭]
    U->>M: "머무르기" 버튼 클릭
    M->>M: SwiftUI 내부: isPresented를 false로 변경 시도
    M->>V: alertBinding.set(nil) 호출
    V->>S: send(.setAlert(nil)) [비동기 Task 시작]
    
    Note over V, S: 문제 발생 지점: Store가 상태를 바꾸기 전에 View가 다시 그려짐
    V->>V: State가 아직 변경되지 않음 (state.alert != nil)
    V->>M: 이전 state.alert를 다시 주입
    M->>M: SwiftUI: "데이터가 아직 있네?" -> 알럿 다시 표시
    
    S->>S: (약간의 시차 뒤) reduce: state.alert = nil
    S-->>V: State 변경 알림
    V->>M: alertBinding.set(nil) 반영
    M-->>U: 알럿 최종 소멸
```

---

### **View State + onChange를 이용한 경합 문제 해결**

#### 해결 전략

- 알럿 표시의 **단일 소스(Single Source of Truth)** 를 View로 이동
- Store는 “알럿이 필요하다”는 신호만 전달
- 실제 표시/해제는 View의 `@State`가 전담

#### 1) View에 알럿 전용 State 추가

```swift
@Stateprivatevar presentedAlert:AlertModel?
```

- SwiftUI 알럿 표시 여부는 `presentedAlert`만 기준으로 판단

#### 2) Store → View 동기화 (onChange #1)

```swift
.onChange(of: store.state.alert) { newValuein
guard presentedAlert!= newValueelse { return }
    presentedAlert= newValue
}
```

- Store에서 알럿이 새로 설정될 때만 View 상태로 복사
- 동일한 값일 경우 전파하지 않아 중복 갱신 방지

#### 3) View → Store 동기화 (onChange #2)

```swift
.onChange(of: presentedAlert) { newValuein
guard store.state.alert!= newValueelse { return }
    send(.setAlert(newValue))
}
```

- SwiftUI가 알럿을 dismiss하여 `presentedAlert = nil`이 되면
    
    → Store에도 최종 상태를 반영
    
- dismiss 결과를 “최종 상태”로만 전달하여 재발 방지

#### 결과

- 알럿 표시/해제의 책임이 View 하나로 고정됨
- SwiftUI dismiss 타이밍과 Store 상태 변경이 충돌하지 않음
- 알럿 재등장 및 자동 dismiss 현상 완전히 해소

#### 이해를 돕기 위한 동작 흐름도

```mermaid
sequenceDiagram
    participant U as 사용자 (User)
    participant V as MessageComposerView (@State)
    participant M as CustomAlertModifier
    participant S as MessageComposerStore (State)

    Note over U, S: [1단계: 알럿 표시]
    S->>V: store.state.alert 변경
    V->>V: .onChange(of: store.state.alert) 감지
    V->>V: presentedAlert = newValue (업데이트)
    V->>M: $presentedAlert 바인딩 전달
    M-->>U: 알럿 화면 표시

    Note over U, S: [2단계: 알럿 닫기 (머무르기 클릭)]
    U->>M: "머무르기" 클릭
    M->>V: $presentedAlert.set(nil) 호출
    
    Note right of V: [핵심] @State이므로 즉시 nil로 변경됨
    V->>V: 리렌더링 실행 (presentedAlert가 nil이므로 알럿 소멸)
    
    par 동기화 과정
        V->>V: .onChange(of: presentedAlert) 실행
        V->>S: send(.setAlert(nil)) [비동기 호출]
    end

    Note over V, S: Store가 아직 nil이 아니더라도 <br/>View는 이미 @State(nil)을 보고 있어 안전함
    
    S->>S: (잠시 후) state.alert = nil
    S->>V: State 변경 알림
    V->>V: .onChange(of: store.state.alert) 실행
    V->>V: guard presentedAlert != newValue (이미 nil이므로 중단)
```

---

### 로딩 오버레이 뷰 **가로/세로 크기 고정 및 상태별 레이아웃 안정화**

#### 기존 문제점

- 텍스트 길이, 줄 수에 따라 카드 크기가 미세하게 변함
- 상태 전환 시 UI가 튀는 느낌을 줌

#### 개선 방향

- 카드 크기를 **상태 기준으로 명시적으로 고정**
    - 메시지 없음: 정사각형 카드
    - 메시지 있음: 가로가 넓은 직사각형 카드
- 카드 크기 계산을 `cardSize`로 추출

### MessageComposerView 가독성 개선

#### View 책임 정리: UI 구성 vs 액션 처리 vs 파생 상태(stored) 분리

```swift
// As-is

var body: some View {
    ZStack {
        content
            .disabled(store.state.confirmStatus == .sending || store.state.isPlaceSearchPresented)

        if store.state.isPlaceSearchPresented {
            PlaceSearchOverlayView(
                store: PlaceSearchStore(
                    searchPlaces: SearchNearbyPlaceUseCaseImpl(
                        placeRepository: NaverPlaceSearchRepositoryImpl(
                            network: NetworkClientImpl()
                        )
                    ),
                    userLocation: store.state.startLocation,
                    onSelect: { selected in
                        send(.selectPlace(selected))
                    },
                    onDismiss: {
                        send(.dismissPlaceSearch)
                    }
                )
            )
            .transition(.opacity.combined(with: .scale(scale: 0.98)))
            .zIndex(999)
        }

        if store.state.confirmStatus == .sending || store.state.confirmStatus == .success {
            LoadingOverlayView(
                mode: store.state.confirmStatus == .success ? .success : .loading,
                message: store.state.confirmStatus == .sending ? Constants.loadingMessage :
                    Constants.successMessage)
    }
```

```swift
// To-be

var body: some View {
    ZStack {
        content
            .disabled(isInteractionDisabled)

        if store.state.isPlaceSearchPresented {
            placeSearchOverlay
                .transition(.opacity.combined(with: .scale(scale: 0.98)))
                .zIndex(999)
        }

        if store.state.confirmStatus != .idle {
            loadingOverlay
                .transition(.opacity.animation(.easeInOut(duration: 0.2)))
                .zIndex(1000)
        }
    }
}

// MARK: Computed property
private extension MessageComposerView {
    var placeFieldText: String {
        store.state.selectedPlace?.name ?? Constants.placeContainerPlaceholder
    }

    var placeFieldColor: Color {
        store.state.selectedPlace == nil ? Color(.placeholderText) : Color.tabActive
    }

    var loadingOverlayMessage: String {
        switch store.state.confirmStatus {
        case .loading: return Constants.loadingMessage
        case .success: return Constants.successMessage
        case .fail: return Constants.failMessage
        case .idle: return ""
        }
    }

    var isInteractionDisabled: Bool {
        store.state.confirmStatus == .loading || store.state.isPlaceSearchPresented
    }

    var isDraftEmpty: Bool {
        store.state.message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
    }
}
```

- 기존 코드에서는 `store.state.xxx`가 곳곳에서 직접 사용됨
    - 조건식이 길어지고
    - 왜 disabled인지 / 왜 overlay가 뜨는지 등을 한눈에 파악하기 어려움
- 개선 방향
    1. `body`에는 화면 구조(레이어링)만 남기고
    2. 조건식/표시 문구/스타일 등은 **computed property로 분리**

## 스크린샷

#### 알럿 경쟁상태 해소

https://github.com/user-attachments/assets/b9740b34-bb3d-4585-95ea-042443ecc79d

#### 로딩 뷰 크기 조정

<img width="382" height="774" alt="image" src="https://github.com/user-attachments/assets/e99bbc26-03a8-4a98-ae8a-27d6950c24ab" />

https://github.com/user-attachments/assets/4f80484d-f32c-4d57-8c7e-e4ae81f5298c

## 리뷰 요구사항


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced loading overlay to support additional states: success, fail, and idle modes for improved user feedback.

* **Improvements**
  * Refactored message composer with improved alert handling and interaction feedback.
  * Streamlined state management for better consistency across loading workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->