### PR TITLE
메시지 작성 -> 조회 흐름을 위해 영속 저장소 추가 전 인메모리 저장소 구현

### DIFF
--- a/Meomun/Meomun/Data/DTO/MessageDTO.swift
+++ b/Meomun/Meomun/Data/DTO/MessageDTO.swift
@@ -1,0 +1,29 @@
+//
+//  MessageDTO.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/22/26.
+//
+
+import Foundation
+
+struct MessageResponseDTO {
+    let id: UUID
+    let createdAt: Date
+    let content: String
+    let latitude: Double
+    let longitude: Double
+    let place: PlaceDTO?
+}
+
+extension MessageResponseDTO {
+    func toDomain() -> Message {
+        .init(
+            id: .init(value: id),
+            createdAt: createdAt,
+            content: content,
+            coordinate: .init(latitude: latitude, longitude: longitude),
+            placeTag: place?.toDomain()
+        )
+    }
+}

--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -49,4 +49,8 @@ final class MessageRepositoryImpl: MessageRepository {
     func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message] {
         return []
     }
+
+    func fetchRecentMessages(page: Int, pageSize: Int) async throws -> [Message] {
+        []
+    }
 }

--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -9,6 +9,12 @@ import Foundation
 import Supabase
 
 final class MessageRepositoryImpl: MessageRepository {
+    private let storage: MessageStorage
+
+    init(storage: MessageStorage = MessageInMemoryStorage()) {
+        self.storage = storage
+    }
+
     func createMessage(_ request: CreateMessageRequest) async throws {
         let placeDTO: PlaceDTO? = request.place.map { place in
             PlaceDTO(
@@ -20,22 +26,14 @@ final class MessageRepositoryImpl: MessageRepository {
             )
         }
 
-        let dto: CreateMessageRequestDTO
-        if let placeDTO {
-            dto = CreateMessageRequestDTO(
-                content: request.content,
-                latitude: placeDTO.latitude,
-                longitude: placeDTO.longitude,
-                place: placeDTO
-            )
-        } else {
-            dto = CreateMessageRequestDTO(
+        return try await storage.create(
+            for: .init(
                 content: request.content,
                 latitude: request.coordinate.latitude,
                 longitude: request.coordinate.longitude,
                 place: placeDTO
             )
-        }
+        )
     }
 
     func deleteMessages(messageIDs: [MessageID]) async throws {
@@ -43,14 +41,17 @@ final class MessageRepositoryImpl: MessageRepository {
     }
 
     func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message] {
-        return []
+        try await storage.fetchNearby(at: location, limit: limit)
+            .map { $0.toDomain() }
     }
 
     func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message] {
-        return []
+        try await storage.fetchByPlace(at: placeID, limit: limit)
+            .map { $0.toDomain() }
     }
 
     func fetchRecentMessages(page: Int, pageSize: Int) async throws -> [Message] {
-        []
+        try await storage.fetchRecent(page: page, pageSize: pageSize)
+            .map { $0.toDomain() }
     }
 }

--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -38,15 +38,15 @@ final class MessageRepositoryImpl: MessageRepository {
         }
     }
 
-    func deleteMessage(messageID: MessageID) async throws {
+    func deleteMessages(messageIDs: [MessageID]) async throws {
         return
     }
 
-    func getNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message] {
+    func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message] {
         return []
     }
 
-    func getPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message] {
+    func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message] {
         return []
     }
 }

--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -11,7 +11,8 @@ import Supabase
 final class MessageRepositoryImpl: MessageRepository {
     private let storage: MessageStorage
 
-    init(storage: MessageStorage = MessageInMemoryStorage()) {
+    // TODO: MessageCoreDataStorage 구현 후 디폴트 파라미터 제거
+    init(storage: MessageStorage = MessageInMemoryStorage.shared) {
         self.storage = storage
     }
 

--- a/Meomun/Meomun/Data/Storage/CoreData/CoreDataStorage.swift
+++ b/Meomun/Meomun/Data/Storage/CoreData/CoreDataStorage.swift
@@ -1,0 +1,8 @@
+//
+//  CoreDataStorage.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/22/26.
+//
+
+// 코어 데이터 추가 시 해당 파일 삭제하셔도 됩니다~

--- a/Meomun/Meomun/Data/Storage/CoreData/MessageCoreDataStorage.swift
+++ b/Meomun/Meomun/Data/Storage/CoreData/MessageCoreDataStorage.swift
@@ -1,0 +1,7 @@
+//
+//  MessageCoreDataStorage.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/22/26.
+//
+

--- a/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
+++ b/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
@@ -9,11 +9,11 @@ import Foundation
 
 final class MessageInMemoryStorage: MessageStorage {
 
-    private var storage: [MessageResponseDTO]
+    private var storage: [MessageResponseDTO] = []
 
-    init(storage: [MessageResponseDTO] = []) {
-        self.storage = storage
-    }
+    static let shared = MessageInMemoryStorage()
+
+    private init() { }
 
     func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO] {
         // 인메모리 임시 구현이므로 반경 필터링 생략

--- a/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
+++ b/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
@@ -1,0 +1,62 @@
+//
+//  MessageInMemoryStorage.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/22/26.
+//
+
+import Foundation
+
+final class MessageInMemoryStorage: MessageStorage {
+
+    private var storage: [MessageResponseDTO]
+
+    init(storage: [MessageResponseDTO] = []) {
+        self.storage = storage
+    }
+
+    func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO] {
+        // 인메모리 임시 구현이므로 반경 필터링 생략
+        storage
+    }
+
+    func fetchByPlace(at placeID: PlaceID, limit: Int?) async throws -> [MessageResponseDTO] {
+        storage
+            .lazy
+            .filter { $0.place?.placeId == placeID.value }
+            .sorted { $0.createdAt > $1.createdAt }
+            .prefix(limit ?? Int.max)
+            .map { $0 }
+    }
+
+    func fetchRecent(page: Int, pageSize: Int) async throws -> [MessageResponseDTO] {
+        // 1. 최신순 정렬
+        let sorted = storage.sorted { $0.createdAt > $1.createdAt }
+
+        // 2. startIndex 계산
+        let startIndex = page * pageSize
+
+        guard startIndex < sorted.count else {
+            return []
+        }
+
+        // 4. 페이지 슬라이싱
+        let endIndex = min(startIndex + pageSize, sorted.count)
+        let pageData = Array(sorted[startIndex..<endIndex])
+
+        return pageData
+    }
+
+    func create(for message: CreateMessageRequestDTO) async throws {
+        let newMessage = MessageResponseDTO(
+            id: .init(),
+            createdAt: .init(),
+            content: message.content,
+            latitude: message.latitude,
+            longitude: message.longitude,
+            place: message.place
+        )
+
+        storage.append(newMessage)
+    }
+}

--- a/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
+++ b/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class MessageInMemoryStorage: MessageStorage {
+actor MessageInMemoryStorage: MessageStorage {
 
     private var storage: [MessageResponseDTO] = []
 

--- a/Meomun/Meomun/Data/Storage/Interface/MessageStorage.swift
+++ b/Meomun/Meomun/Data/Storage/Interface/MessageStorage.swift
@@ -1,0 +1,30 @@
+//
+//  MessageStorage.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/22/26.
+//
+
+protocol MessageStorage: Sendable {
+
+    /// 특정 좌표 기준 반경 내의 메시지를 거리순으로 반환합니다.
+    /// - Parameters:
+    ///   - coordinate: 검색 기준이 되는 중심 좌표
+    ///   - limit: 반환할 최대 메시지 개수. nil이면 모든 메시지를 반환합니다.
+    func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO]
+
+    /// 특정 장소의 메시지를 최신순으로 반환합니다.
+    /// - Parameters:
+    ///   - placeID: 조회할 장소 ID
+    ///   - limit: 반환할 최대 메시지 개수. nil이면 해당 장소의 모든 메시지를 반환합니다.
+    func fetchByPlace(at placeID: PlaceID, limit: Int?) async throws -> [MessageResponseDTO]
+
+    /// 최신순으로 정렬된 메시지를 페이지네이션하여 반환합니다.
+    /// - Parameters:
+    ///   - page: 페이지 번호 (0-based). 0이 첫 번째 페이지입니다.
+    ///   - pageSize: 한 페이지에 포함될 메시지 개수
+    func fetchRecent(page: Int, pageSize: Int) async throws -> [MessageResponseDTO]
+
+    func create(for message: CreateMessageRequestDTO) async throws
+
+}

--- a/Meomun/Meomun/Domain/Repository/MessageRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/MessageRepository.swift
@@ -13,4 +13,5 @@ protocol MessageRepository: Sendable {
 
     func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message]
     func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message]
+    func fetchRecentMessages(page: Int, pageSize: Int) async throws -> [Message]
 }

--- a/Meomun/Meomun/Domain/Repository/MessageRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/MessageRepository.swift
@@ -9,8 +9,8 @@ import Foundation
 
 protocol MessageRepository: Sendable {
     func createMessage(_ request: CreateMessageRequest) async throws
-    func deleteMessage(messageID: MessageID) async throws
+    func deleteMessages(messageIDs: [MessageID]) async throws
 
-    func getNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message]
-    func getPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message]
+    func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message]
+    func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message]
 }

--- a/Meomun/Meomun/Domain/UseCase/FetchPlaceMessagesUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/FetchPlaceMessagesUseCase.swift
@@ -31,7 +31,7 @@ struct FetchPlaceMessagesUseCaseImpl: FetchPlaceMessagesUseCase, Sendable {
     }
 
     func execute(placeID: PlaceID, limit: Int?) async throws -> [Message] {
-        let messages = try await messageRepository.getPlaceMessages(
+        let messages = try await messageRepository.fetchPlaceMessages(
             placeID: placeID,
             limit: limit
         )

--- a/Meomun/Meomun/Domain/UseCase/GetNearbyMessagesUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/GetNearbyMessagesUseCase.swift
@@ -17,6 +17,6 @@ final class GetNearbyMessagesUseCaseImpl: GetNearbyMessagesUseCase {
     }
 
     func execute(location: Coordinate, limit: Int?) async throws -> [Message] {
-        try await messageRepository.getNearbyMessages(location: location, limit: limit)
+        try await messageRepository.fetchNearbyMessages(location: location, limit: limit)
     }
 }


### PR DESCRIPTION
## 배경
- closed #262 

기획 변경에 따른 서버 제거로 인해 메시지 작성 시 지도 화면과 공간 화면에서 메시지 확인이 불가능했습니다.  
따라서 영속 저장소 구현 전 임시로 인메모리 저장소를 구현합니다.

## 작업 요약
- 인메모리 저장소 구현
- MessageRepository 메시지 fetch 메서드 추가
- MessageRepository의 delete 메서드 파라미터 타입 수정 (`Message` -> `[Message]`

## 작업 내용
### (1) Storage 구조
**클래스 다이어그램**
<img width="3833" height="1413" alt="image" src="https://github.com/user-attachments/assets/f5585d04-3b75-4a65-89f8-4ae9fb4d05c2" />

`Storage` 단의 구조는 위 사진과 같습니다.

-  `MessageStorage` 프로토콜로 Storage 단을 추상화하여, 영속 저장소 구현체 변경 시 Repository의 수정 없이 교체 가능하도록 설계했습니다.
- `Repository` <-> `Storage` 간의 데이터 전달은 DTO를 사용합니다.

**폴더링**
<img width="592" height="286" alt="스크린샷 2026-01-23 오전 1 20 14" src="https://github.com/user-attachments/assets/b44936a8-9a48-4c80-a84a-3e30afb44896" />

- `Storage` 내부 폴더링 예시로 `CoreData` 디렉토리 내부에 빈 파일을 두었습니다.
- 영속 저장소 결정 후 네이밍 수정이 필요합니다.

### (2) `MessageStorage`
```swift
protocol MessageStorage: Sendable {
    func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO]
    func fetchByPlace(at placeID: PlaceID, limit: Int?) async throws -> [MessageResponseDTO]
    func fetchRecent(page: Int, pageSize: Int) async throws -> [MessageResponseDTO]
    func create(for message: CreateMessageRequestDTO) async throws
}
```

| 화면 | 상황 | 사용 메서드 |
|---|---|---|
|지도 화면| 지도 카메라 좌표 기준 반경 내의 메시지 조회 | `fetchNearby(at:,limit:)` |  
|공간 화면| 해당 장소의 메시지 조회 | `fetchByPlace(at:,limit:)`  |  
|기록 화면| 최신순으로 정렬된 메시지 조회 -> 페이지네이션 필요 | `fetchRecent(page:,pageSize)` |  

메시지 조회 상황은 위 표와 같이 총 세가지가 존재할 것이라고 판단했습니다.  
따라서 각 특징에 맞는 메서드를 정의하였습니다.  

이에 따라 `MessageRepository`에도 메서드를 추가했습니다.

**`MessageInMemoryStorage`**
- 영속 저장소 추가 전 임시로 만든 인메모리 Storage입니다.
- 현재 `MessageRepositoryImpl` 인스턴스가 `Store`마다 생성되고 있어 싱글톤으로 구현했습니다.

### (3) `MessageRepository` 관련 변경 사항
1. **`deleteMessage` 파라미터 타입 / 메서드명 수정**
  - AS-IS: `deleteMessage(messageID: MessageID)`
  - TO-BE: `deleteMessages(messageIDs: [MessageID])`  
  - 이유: 
    - 단일 메시지 삭제, 다중 메시지 삭제 모두 대응하기 위해  

2. **조회 메시지 네이밍 수정**
  - AS-IS: `get...Messages`  
  - TO-BE:  `fetch...Messages`
  - 이유: 
    - 일반적으로 `get`은 동기적인 조회, `fetch`는 비동기적인 조회를 의미 (LLM 피셜..ㅎㅎ)  
    - 따라서 작업 비용, 데이터 출처, thorw 여부 등 특징이 다르다고 함.

3. **`func fetchRecentMessages(page: Int, pageSize: Int) async throws -> [Message]` 메서드 추가**
  - 이유: 기록 화면은 최신 메시지 순으로 페이지네이션 필요
    - 영속 DB에서 모든 메시지를 조회 할 경우 해당 메시지들이 모두 메모리에 올라가기 때문에 메모리 사용량 절감을 위해

### (4) 메시지 응답 DTO 통일
- AS-IS: `NearbyMessageResponseDTO`, `PlaceMessageResponseDTO`
- TO-BE: `MessageResponseDTO` 
- 이유: 
  - 기존에는 지도, 공간 화면에서 호출하는 API가 달라 DTO가 두개 필요했음.
  - 서버 제거로 인해 따로 분리 할 필요가 없다고 판단

## 스크린샷
https://github.com/user-attachments/assets/17a3ea89-86e4-4836-ad0a-3244d3977ddb

## 리뷰 요구사항
- 공간 화면에서도 `Store` 까지 데이터가 잘 내려와요. 드래그 안되는 이슈 때문에 확인은 아직 안됩니다ㅠ

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정
