### PR TITLE
MessageBubble 레이아웃 조정 및 구성 요소 변경

### DIFF
--- a/Meomun/Meomun/Data/DTO/NearbyMessageDTO.swift
+++ b/Meomun/Meomun/Data/DTO/NearbyMessageDTO.swift
@@ -38,6 +38,7 @@ extension NearbyMessageResponseDTO {
                 latitude: latitude,
                 longitude: longitude
             ),
+            address: "address",
             placeTag: place.map {
                 Place(
                     id: PlaceID(value: $0.placeId),

--- a/Meomun/Meomun/Data/DTO/PlaceMessagesDTO.swift
+++ b/Meomun/Meomun/Data/DTO/PlaceMessagesDTO.swift
@@ -45,6 +45,7 @@ extension PlaceMessageResponseDTO {
             createdAt: createdAt,
             content: content,
             coordinate: coordinate,
+            address: "address",
             placeTag: placeTag
         )
     }

--- a/Meomun/Meomun/Domain/Entity/Message.swift
+++ b/Meomun/Meomun/Domain/Entity/Message.swift
@@ -12,9 +12,30 @@ struct Message: Identifiable, Sendable {
     let createdAt: Date
     let content: String
     let coordinate: Coordinate
+    let address: String?
     let placeTag: Place?
 
     func isRecent(recentInterval: TimeInterval = 60 * 20) -> Bool {
         Date().timeIntervalSince(createdAt) <= recentInterval
+    }
+}
+
+extension Message {
+    var displayLocationName: String? {
+        // placeTag가 있다면 name
+        if let tagName = placeTag?.name, !tagName.isEmpty {
+            return tagName
+        }
+        // 없다면 address (동부터? 그 뒤부터? 하여튼 포매팅)
+        if let address, !address.isEmpty {
+            return address
+        }
+        return nil
+    }
+
+    var displayDateString: String { // 같은 날이면 시간, 다른 날이면 날짜로 보여지게 하기
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy.MM.dd"
+        return formatter.string(from: createdAt)
     }
 }

--- a/Meomun/Meomun/Presentation/Common/Component/MaxHeightClamp.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MaxHeightClamp.swift
@@ -1,0 +1,56 @@
+//
+//  MaxHeightClamp.swift
+//  Meomun
+//
+//  Created by 지연 on 1/22/26.
+//
+
+import SwiftUI
+
+/// 1. HeightKey: 뷰의 실제 높이 측정
+/// 2. MaxHeightClamp: 측정한 실제 높이와 maxHeight 중 더 작은 값으로 최종 높이를 강제로 결정
+
+struct HeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+struct MaxHeightClamp: ViewModifier {
+    let maxHeight: CGFloat                      // 최대 허용 높이
+    @State private var measured: CGFloat = 0    // 실제 측정된 콘텐츠 높이
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                // GeometryReader: 자신이 차지한 실제 레이아웃 크기를 알려줌.
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(
+                            key: HeightKey.self,
+                            value: proxy.size.height
+                        )
+                }
+            )
+            // 높이 바뀔 때마다 호출 -> 다시 계산
+            .onPreferenceChange(HeightKey.self) { height in
+                let rounded = (height * 2).rounded() / 2
+                if abs(rounded - measured) > 0.5 {
+                    measured = rounded
+                } else if measured == 0 {
+                    measured = rounded
+                }
+            }
+            // 측정 높이와 maxHeight 비교 -> 더 작은 값으로 높이 고정
+            .frame(height: min(measured == 0 ? maxHeight : measured, maxHeight))
+    }
+}
+
+// MARK: - View 확장 모디파이어
+
+extension View {
+    func clampMaxHeight(_ maxHeight: CGFloat) -> some View {
+        modifier(MaxHeightClamp(maxHeight: maxHeight))
+    }
+}

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -13,64 +13,77 @@ enum BubbleLayout {
 }
 
 struct MessageBubble<Content: View>: View {
-    let placeName: String?
-    let createdAt: Date?
+    let message: Message
     let layout: BubbleLayout
-    let content: Content
+    let content: (Message) -> Content
 
     var maxWidth: CGFloat = 210
 
     init(
-        placeName: String?,
-        createdAt: Date = .init(timeIntervalSince1970: 0),
+        message: Message,
         layout: BubbleLayout,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: @escaping (Message) -> Content = {
+            BubbleText(
+                text: $0.content
+            )
+        }
     ) {
-        self.placeName = placeName
-        self.createdAt = createdAt
+        self.message = message
         self.layout = layout
-        self.content = content()
+        self.content = content
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 5) {
             // 장소 태그 (옵셔널)
-            if let placeName, !placeName.isEmpty {
+            if let locationName = message.displayLocationName {
                 HStack(spacing: 4) {
                     Image(systemName: "mappin.and.ellipse")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(Color(hex: "#53808C"))
 
-                    Text(placeName)
+                    Text(locationName)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(Color.gray.opacity(0.8))
                 }
             }
 
-            if case .fixedSize = layout {
-                content
-                    .frame(height: 36, alignment: .center)
-                    .clipped()
-            } else {
-                content
-            }
+            bodyPart
 
-            Text("25.02.01")
+            Divider()
+                .background(Color.black.opacity(0.8))
+                .padding(.top, 2)
+
+            Text(message.displayDateString)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.gray.opacity(0.8))
                 .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.top, -2)
         }
-        .padding(.vertical, 15)
-        .padding(.horizontal, 15)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
         .applyLayout(
             layout,
-            maxWidth: maxWidth,
-            background: bubbleBackground
+            maxWidth: maxWidth
         )
+        .background(bubbleBackground)
     }
 }
 
 private extension MessageBubble {
+    @ViewBuilder
+    var bodyPart: some View {
+        let bodyView = content(message)
+
+        if case .fixedSize = layout {
+            bodyView
+                .frame(height: 36, alignment: .center)
+                .clipped()
+        } else {
+            bodyView
+        }
+    }
+
     var bubbleBackground: some View {
         RoundedRectangle(cornerRadius: 22, style: .continuous)
             .fill(Color.white)
@@ -83,7 +96,7 @@ private extension MessageBubble {
 
 struct BubbleText: View {
     let text: String
-    var maxWidth: CGFloat? = 190
+    var maxWidth: CGFloat? = 180
 
     var body: some View {
         // 본문 (최대 2줄)
@@ -98,7 +111,7 @@ struct BubbleText: View {
                 maxWidth: maxWidth,
                 alignment: .leading
             )
-            .clampMaxHeight(50)
+            .clampMaxHeight(56)
     }
 }
 
@@ -106,7 +119,7 @@ struct BubbleText: View {
 
 private extension View {
     @ViewBuilder
-    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat, background: some View) -> some View {
+    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat) -> some View {
         Group {
             switch layout {
             case .flexible:
@@ -121,65 +134,106 @@ private extension View {
                 self
                     .frame(
                         width: fixedSize,
-                        height: 98,
+                        height: 103,
                         alignment: .leading
                     )
             }
         }
-        .background(background)
     }
 }
 
 // MARK: - Preview
 
 #Preview {
+    let placeMessage = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "[한줄] 오늘 좀 춥다🫥🍃",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: nil,
+        placeTag: Place(
+            id: PlaceID(value: ""),
+            name: "장소 이름",
+            coordinate: .init(
+                latitude: 0,
+                longitude: 0
+            )
+        )
+    )
+
+    let longMessage = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: nil,
+        placeTag: Place(
+            id: PlaceID(value: ""),
+            name: "장소 이름",
+            coordinate: .init(
+                latitude: 0,
+                longitude: 0
+            )
+        )
+    )
+
+    let longMessage2 = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "sdcfvvfvfvffvfvfvfvfvfvfvfvfff",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: nil,
+        placeTag: Place(
+            id: PlaceID(value: ""),
+            name: "장소 이름",
+            coordinate: .init(
+                latitude: 0,
+                longitude: 0
+            )
+        )
+    )
+
+    let noPlaceMessage = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "dkfdkkdlsjkd",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: "어딘가의 주소",
+        placeTag: nil
+    )
+
     ZStack {
         Color.gray.opacity(0.15).ignoresSafeArea()
 
         VStack(alignment: .leading, spacing: 12) {
             Text(".flexible (단일 버블)")
-            MessageBubble(
-                placeName: "장소 이름",
-                layout: .flexible
-            ) {
-                BubbleText(text: "[한줄] 오늘 좀 춥다🫥🍃")
-            }
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: placeMessage,
                 layout: .flexible
-            ) {
-                BubbleText(text: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃")
-            }
+            )
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: longMessage,
                 layout: .flexible
-            ) {
-                BubbleText(text: "[두줄] 이건 30자 메시지에요 재밌죠 나는 자고싶어요")
-            }
+            )
+
+            MessageBubble(
+                message: longMessage2,
+                layout: .flexible
+            )
 
             Text(".fixedSize(170) (회전 버블)")
-            MessageBubble(
-                placeName: "장소 이름",
-                layout: .fixedSize(170)
-            ) {
-                BubbleText(text: "🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥")
-            }
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: placeMessage,
                 layout: .fixedSize(170)
-            ) {
-                BubbleText(text: "dkfdkkdkdksdjkfskdlsjkd")
-            }
+            )
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: noPlaceMessage,
                 layout: .fixedSize(170)
-            ) {
-                BubbleText(text: "dkfdkkdlsjkd")
-            }
+            )
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -53,13 +53,6 @@ struct MessageBubble<Content: View>: View {
     }
 
     var body: some View {
-        //        HStack(alignment: .top, spacing: 10) {
-        // 왼쪽 세로 라인
-        //            Capsule()
-        //                .fill(statusIndicatorColor)
-        //                .frame(width: 3)
-        //                .padding(.vertical, 11)
-
         VStack(alignment: .leading, spacing: 6) {
             // 장소 태그 (옵셔널)
             if let placeName, !placeName.isEmpty {
@@ -95,9 +88,6 @@ struct MessageBubble<Content: View>: View {
             background: bubbleBackground
         )
     }
-
-//        )
-//    }
 }
 
 private extension MessageBubble {

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -36,9 +36,7 @@ struct MessageBubble<Content: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             locationPart
-
             bodyPart
-
             datePart
         }
         .padding(.vertical, 9)

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -74,12 +74,18 @@ struct MessageBubble<Content: View>: View {
                 }
             }
 
-            content
+            if case .fixedSize = layout {
+                content
+                    .frame(height: 36, alignment: .center)
+                    .clipped()
+            } else {
+                content
+            }
 
             Text("25.02.01")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.gray.opacity(0.8))
-                .frame(alignment: .trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(.vertical, 15)
         .padding(.horizontal, 15)

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -7,13 +7,6 @@
 
 import SwiftUI
 
-/// 1) 버블 내부 텍스트 rotate 기능 지원 X 시
-///     - placeName 있을 수도 / 없을 수도
-///     - 좌측 라인 visible
-/// 2) 버블 내부 텍스트 rotate 기능 지원 O 시
-///     - placeName 항상 있음
-///     - 좌측 라인 invisible
-
 enum MessageStatusIndicator {
     case none
     case recent
@@ -22,11 +15,12 @@ enum MessageStatusIndicator {
 
 enum BubbleLayout {
     case flexible      // 단일 메시지
-    case fixedWidth(CGFloat)    // 회전 메시지
+    case fixedSize(CGFloat)    // 회전 메시지
 }
 
 struct MessageBubble<Content: View>: View {
     let placeName: String?
+    let createdAt: Date?
     let statusIndicator: MessageStatusIndicator
     let layout: BubbleLayout
     let content: Content
@@ -35,11 +29,13 @@ struct MessageBubble<Content: View>: View {
 
     init(
         placeName: String?,
+        createdAt: Date = .init(timeIntervalSince1970: 0),
         statusIndicator: MessageStatusIndicator,
         layout: BubbleLayout,
         @ViewBuilder content: () -> Content
     ) {
         self.placeName = placeName
+        self.createdAt = createdAt
         self.statusIndicator = statusIndicator
         self.layout = layout
         self.content = content()
@@ -57,46 +53,61 @@ struct MessageBubble<Content: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            // 왼쪽 세로 라인
-            Capsule()
-                .fill(statusIndicatorColor)
-                .frame(width: 3)
-                .padding(.vertical, 11)
+        //        HStack(alignment: .top, spacing: 10) {
+        // 왼쪽 세로 라인
+        //            Capsule()
+        //                .fill(statusIndicatorColor)
+        //                .frame(width: 3)
+        //                .padding(.vertical, 11)
 
-            VStack(alignment: .leading, spacing: 6) {
-                // 장소 태그 (옵셔널)
-                if let placeName, !placeName.isEmpty {
-                    HStack(spacing: 4) {
-                        Image(systemName: "mappin.and.ellipse")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#53808C"))
+        VStack(alignment: .leading, spacing: 6) {
+            // 장소 태그 (옵셔널)
+            if let placeName, !placeName.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#53808C"))
 
-                        Text(placeName)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(Color.gray.opacity(0.8))
-                    }
+                    Text(placeName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.gray.opacity(0.8))
                 }
-
-                content
             }
-            .padding(.vertical, 13)
-            .padding(.trailing, 13)
+
+            content
+
+            Text("25.02.01")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.gray.opacity(0.8))
+                .frame(alignment: .trailing)
         }
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color.white)
-                .shadow(color: .black.opacity(0.06),
-                        radius: 12,
-                        x: 0,
-                        y: 6)
+        .padding(.vertical, 15)
+        .padding(.horizontal, 15)
+        .applyLayout(
+            layout,
+            maxWidth: maxWidth,
+            background: bubbleBackground
         )
-        .applyLayout(layout, maxWidth: maxWidth)
+    }
+
+//        )
+//    }
+}
+
+private extension MessageBubble {
+    var bubbleBackground: some View {
+        RoundedRectangle(cornerRadius: 22, style: .continuous)
+            .fill(Color.white)
+            .shadow(color: .black.opacity(0.06),
+                    radius: 12,
+                    x: 0,
+                    y: 6)
     }
 }
 
 struct BubbleText: View {
     let text: String
+    var maxWidth: CGFloat? = 190
 
     var body: some View {
         // 본문 (최대 2줄)
@@ -106,6 +117,12 @@ struct BubbleText: View {
             .lineLimit(2)
             .multilineTextAlignment(.leading)
             .fixedSize(horizontal: false, vertical: true)
+            .frame(
+                idealWidth: nil,
+                maxWidth: maxWidth,
+                alignment: .leading
+            )
+            .clampMaxHeight(50)
     }
 }
 
@@ -113,47 +130,85 @@ struct BubbleText: View {
 
 private extension View {
     @ViewBuilder
-    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat) -> some View {
-        switch layout {
-        case .flexible:
-            self
-                .frame(maxWidth: maxWidth, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
+    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat, background: some View) -> some View {
+        Group {
+            switch layout {
+            case .flexible:
+                self
+                    .frame(
+                        maxWidth: maxWidth,
+                        alignment: .leading
+                    )
+                    .fixedSize(horizontal: true, vertical: false)
 
-        case .fixedWidth(let fixedSize):
-            self
-                .frame(width: fixedSize, height: 82, alignment: .leading)
+            case .fixedSize(let fixedSize):
+                self
+                    .frame(
+                        width: fixedSize,
+                        height: 98,
+                        alignment: .leading
+                    )
+            }
         }
+        .background(background)
     }
 }
+
+// MARK: - Preview
 
 #Preview {
     ZStack {
         Color.gray.opacity(0.15).ignoresSafeArea()
 
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(".flexible (단일 버블)")
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .normal,
+                statusIndicator: .none,
                 layout: .flexible
             ) {
-                BubbleText(text: "오늘 좀 춥다🫥🍃")
+                BubbleText(text: "[한줄] 오늘 좀 춥다🫥🍃")
             }
 
             MessageBubble(
                 placeName: "장소 이름",
                 statusIndicator: .none,
-                layout: .fixedWidth(170)
+                layout: .flexible
+            ) {
+                BubbleText(text: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃")
+            }
+
+            MessageBubble(
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .flexible
+            ) {
+                BubbleText(text: "[두줄] 이건 30자 메시지에요 재밌죠 나는 자고싶어요")
+            }
+
+            Text(".fixedSize(170) (회전 버블)")
+            MessageBubble(
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .fixedSize(170)
             ) {
                 BubbleText(text: "🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥")
             }
 
             MessageBubble(
-                placeName: nil,
-                statusIndicator: .recent,
-                layout: .flexible
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .fixedSize(170)
             ) {
-                BubbleText(text: "최근에 남긴 따끈따끈한 메시지라서 주황색 라인으로 표시")
+                BubbleText(text: "dkfdkkdkdksdjkfskdlsjkd")
+            }
+
+            MessageBubble(
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .fixedSize(170)
+            ) {
+                BubbleText(text: "dkfdkkdlsjkd")
             }
         }
     }

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -7,12 +7,6 @@
 
 import SwiftUI
 
-enum MessageStatusIndicator {
-    case none
-    case recent
-    case normal
-}
-
 enum BubbleLayout {
     case flexible      // 단일 메시지
     case fixedSize(CGFloat)    // 회전 메시지
@@ -21,7 +15,6 @@ enum BubbleLayout {
 struct MessageBubble<Content: View>: View {
     let placeName: String?
     let createdAt: Date?
-    let statusIndicator: MessageStatusIndicator
     let layout: BubbleLayout
     let content: Content
 
@@ -30,26 +23,13 @@ struct MessageBubble<Content: View>: View {
     init(
         placeName: String?,
         createdAt: Date = .init(timeIntervalSince1970: 0),
-        statusIndicator: MessageStatusIndicator,
         layout: BubbleLayout,
         @ViewBuilder content: () -> Content
     ) {
         self.placeName = placeName
         self.createdAt = createdAt
-        self.statusIndicator = statusIndicator
         self.layout = layout
         self.content = content()
-    }
-
-    private var statusIndicatorColor: Color {
-        switch statusIndicator {
-        case .none:
-            return .clear
-        case .recent:
-            return .orange
-        case .normal:
-            return .blue
-        }
     }
 
     var body: some View {
@@ -160,7 +140,6 @@ private extension View {
             Text(".flexible (단일 버블)")
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .flexible
             ) {
                 BubbleText(text: "[한줄] 오늘 좀 춥다🫥🍃")
@@ -168,7 +147,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .flexible
             ) {
                 BubbleText(text: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃")
@@ -176,7 +154,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .flexible
             ) {
                 BubbleText(text: "[두줄] 이건 30자 메시지에요 재밌죠 나는 자고싶어요")
@@ -185,7 +162,6 @@ private extension View {
             Text(".fixedSize(170) (회전 버블)")
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .fixedSize(170)
             ) {
                 BubbleText(text: "🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥")
@@ -193,7 +169,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .fixedSize(170)
             ) {
                 BubbleText(text: "dkfdkkdkdksdjkfskdlsjkd")
@@ -201,7 +176,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .fixedSize(170)
             ) {
                 BubbleText(text: "dkfdkkdlsjkd")

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -35,42 +35,41 @@ struct MessageBubble<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            // 장소 태그 (옵셔널)
-            if let locationName = message.displayLocationName {
-                HStack(spacing: 4) {
-                    Image(systemName: "mappin.and.ellipse")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color(hex: "#53808C"))
-
-                    Text(locationName)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color.gray.opacity(0.8))
-                }
-            }
+            locationPart
 
             bodyPart
 
-            Divider()
-                .background(Color.black.opacity(0.8))
-                .padding(.top, 2)
-
-            Text(message.displayDateString)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.gray.opacity(0.8))
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .padding(.top, -2)
+            datePart
         }
-        .padding(.vertical, 10)
+        .padding(.vertical, 9)
         .padding(.horizontal, 12)
         .applyLayout(
             layout,
             maxWidth: maxWidth
         )
         .background(bubbleBackground)
+        .overlay(alignment: .bottomLeading) {
+            dividerOverlay
+        }
     }
 }
 
 private extension MessageBubble {
+    @ViewBuilder
+    var locationPart: some View {
+        if let locationName = message.displayLocationName {
+            HStack(spacing: 4) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#53808C"))
+
+                Text(locationName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.gray.opacity(0.8))
+            }
+        }
+    }
+
     @ViewBuilder
     var bodyPart: some View {
         let bodyView = content(message)
@@ -84,6 +83,14 @@ private extension MessageBubble {
         }
     }
 
+    var datePart: some View {
+        Text(message.displayDateString)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Color.gray.opacity(0.8))
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.top, 5)
+    }
+
     var bubbleBackground: some View {
         RoundedRectangle(cornerRadius: 22, style: .continuous)
             .fill(Color.white)
@@ -91,6 +98,14 @@ private extension MessageBubble {
                     radius: 12,
                     x: 0,
                     y: 6)
+    }
+
+    var dividerOverlay: some View {
+        Rectangle()
+            .fill(Color.black.opacity(0.8))
+            .frame(height: 1 / UIScreen.main.scale)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 29)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/RotatingTextStack.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/RotatingTextStack.swift
@@ -17,7 +17,7 @@ struct RotatingTextStack: View {
     private let movingArea: CGFloat = 16    // 움직일 거리
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack(alignment: .center) {
             if progress > 0 {
                 BubbleText(text: nextText)
                     .opacity(progress)
@@ -28,7 +28,7 @@ struct RotatingTextStack: View {
                 .opacity(1 - progress)
                 .offset(y: -progress * movingArea)
         }
-        .frame(maxHeight: textAreaHeight, alignment: .top)
+        .frame(maxHeight: textAreaHeight, alignment: .center)
         .clipped()
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
@@ -35,7 +35,8 @@ extension MapStore {
             coordinate: .init(
                 latitude: 37.5720,
                 longitude: 126.9760
-            )
+            ),
+            address: "서판교로29"
         )
 
         let group1 = [
@@ -44,6 +45,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-3 * 60),
                 content: "따뜻한 바람 지나가요🍃",
                 coordinate: .init(latitude: 37.5720, longitude: 126.9760),
+                address: "서판교로29",
                 placeTag: place1
             ),
             Message(
@@ -51,6 +53,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-12 * 60),
                 content: "공연 리허설 소리 들린다🎻",
                 coordinate: .init(latitude: 37.5720, longitude: 126.9760),
+                address: "서판교로29",
                 placeTag: place1
             )
         ]
@@ -63,7 +66,8 @@ extension MapStore {
             coordinate: .init(
                 latitude: 37.5712,
                 longitude: 126.9780
-            )
+            ),
+            address: "서판교로29"
         )
 
         let group2 = [
@@ -72,6 +76,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-8 * 60),
                 content: "햇살이 광장 위에 내려앉았어요☀️",
                 coordinate: .init(latitude: 37.5712, longitude: 126.9780),
+                address: "서판교로29",
                 placeTag: place2
             ),
             Message(
@@ -79,6 +84,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-50 * 60),
                 content: "차분한 아침 분위기 좋다",
                 coordinate: .init(latitude: 37.5712, longitude: 126.9780),
+                address: "서판교로29",
                 placeTag: place2
             )
         ]
@@ -90,7 +96,8 @@ extension MapStore {
             coordinate: .init(
                 latitude: 37.5730,
                 longitude: 126.9770
-            )
+            ),
+            address: "서판교로29"
         )
 
         let group3 = [
@@ -99,6 +106,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-6 * 60),
                 content: "벽에 스치는 바람 소리가 좋다🍃",
                 coordinate: .init(latitude: 37.5730, longitude: 126.9770),
+                address: "서판교로29",
                 placeTag: place3
             ),
             Message(
@@ -106,6 +114,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-2 * 60 * 60),
                 content: "발자국 소리가 멀리 울려요",
                 coordinate: .init(latitude: 37.5730, longitude: 126.9770),
+                address: "서판교로29",
                 placeTag: place3
             )
         ]
@@ -117,6 +126,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-40 * 60),
                 content: "벤치에 앉아 잠깐 쉬어요",
                 coordinate: .init(latitude: 37.5698, longitude: 126.9775),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -124,6 +134,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-1 * 60 * 60),
                 content: "따뜻한 커피 향이 지나간다☕️",
                 coordinate: .init(latitude: 37.5704, longitude: 126.9766),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -131,6 +142,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-3 * 60 * 60),
                 content: "멀리서 버스 브레이크 소리🚍",
                 coordinate: .init(latitude: 37.5718, longitude: 126.9792),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -138,6 +150,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-20 * 60),
                 content: "바닥에 그림자가 길게 늘어져요🌒",
                 coordinate: .init(latitude: 37.5728, longitude: 126.9756),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -145,6 +158,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-15 * 60),
                 content: "누군가 웃는 소리 지나갔다🙂",
                 coordinate: .init(latitude: 37.5709, longitude: 126.9786),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -152,6 +166,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-10 * 60 * 60),
                 content: "새벽 공기가 차갑고 맑다🌙",
                 coordinate: .init(latitude: 37.5692, longitude: 126.9798),
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -183,7 +198,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case1] Place1 NoPlace0",
-            coordinate: .init(latitude: lat, longitude: lng)
+            coordinate: .init(latitude: lat, longitude: lng),
+            address: "서판교로29"
         )
 
         return [
@@ -192,6 +208,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-5 * 60),
                 content: "[Case1] Place 1개만 있는 단일 UI",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             )
         ]
@@ -209,6 +226,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-25 * 60),
                 content: "[Case2] NoPlace 1개만 있는 단일 UI",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -223,7 +241,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case3] Place2+ NoPlace0",
-            coordinate: .init(latitude: lat, longitude: lng)
+            coordinate: .init(latitude: lat, longitude: lng),
+            address: "서판교로29"
         )
 
         return [
@@ -232,6 +251,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-3 * 60),
                 content: "[Case3] Place 로테이션 메시지 1",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -239,6 +259,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-10 * 60),
                 content: "[Case3] Place 로테이션 메시지 2",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -246,6 +267,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-20 * 60),
                 content: "[Case3] Place 로테이션 메시지 3",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             )
         ]
@@ -264,6 +286,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-7 * 60),
                 content: "[Case4] NoPlace 스택 메시지 1",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -271,6 +294,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-30 * 60),
                 content: "[Case4] NoPlace 스택 메시지 2",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -278,6 +302,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-45 * 60),
                 content: "[Case4] NoPlace 스택 메시지 3",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -293,7 +318,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case5] Place1 NoPlace1",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -302,6 +328,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-4 * 60),
                 content: "[Case5] Place 단일 메시지",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -309,6 +336,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-35 * 60),
                 content: "[Case5] NoPlace 단일 메시지 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -324,7 +352,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case6] Place2 NoPlace1",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -333,6 +362,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-2 * 60),
                 content: "[Case6] Place 로테이션 1",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -340,6 +370,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-18 * 60),
                 content: "[Case6] Place 로테이션 2",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -347,6 +378,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-55 * 60),
                 content: "[Case6] NoPlace 단일 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -362,7 +394,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case7] Place1 NoPlace2+",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -371,6 +404,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-9 * 60),
                 content: "[Case7] Place 단일 메시지",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -378,6 +412,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-22 * 60),
                 content: "[Case7] NoPlace 스택 1 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -385,6 +420,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-48 * 60),
                 content: "[Case7] NoPlace 스택 2 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -392,6 +428,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-1.5 * 60 * 60),
                 content: "[Case7] NoPlace 스택 3 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -407,7 +444,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case8] Place2+ NoPlace2+",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -417,6 +455,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-6 * 60),
                 content: "[Case8] Place 로테이션 1",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -424,6 +463,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-28 * 60),
                 content: "[Case8] Place 로테이션 2",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -431,6 +471,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-1 * 60 * 60),
                 content: "[Case8] Place 로테이션 3",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             // NoPlace 메시지들 (스택)
@@ -439,6 +480,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-14 * 60),
                 content: "[Case8] NoPlace 스택 1 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -446,6 +488,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-38 * 60),
                 content: "[Case8] NoPlace 스택 2 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -453,9 +496,9 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-2 * 60 * 60),
                 content: "[Case8] NoPlace 스택 3 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
     }
 }
-

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
@@ -131,6 +131,14 @@ extension MapStore {
             ),
             Message(
                 id: MessageID(value: UUID()),
+                createdAt: Date().addingTimeInterval(-40 * 60),
+                content: "페이드인 되고 있어?",
+                coordinate: .init(latitude: 37.5665, longitude: 126.9780),
+                address: "서판교로29",
+                placeTag: nil
+            ),
+            Message(
+                id: MessageID(value: UUID()),
                 createdAt: Date().addingTimeInterval(-1 * 60 * 60),
                 content: "따뜻한 커피 향이 지나간다☕️",
                 coordinate: .init(latitude: 37.5704, longitude: 126.9766),

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -297,6 +297,15 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         self.onCameraChangedByLocation = onCameraChangedByLocation
     }
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator {
+        var lastMessagesSnapshot: Int?
+        var didInitialLoad = false
+    }
+
     func makeUIViewController(context: Context) -> MapViewController {
         let viewController = MapViewController(
             messageMarkerManager: messageMarkerManager,
@@ -306,13 +315,33 @@ struct MapViewWrapper: UIViewControllerRepresentable {
             onCameraChangedByLocation: onCameraChangedByLocation
         )
 
+        // 초기 1회 loadMessages() 호출
         viewController.loadMessages(messages)
         viewController.updateUserLocation(userLocation)
+
+        context.coordinator.lastMessagesSnapshot = messagesSnapshot(messages)
+        context.coordinator.didInitialLoad = true
 
         return viewController
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
+        let snap = messagesSnapshot(messages)
+
+        // 동일 메시지인 경우 loadMessages() 호출 X
+        guard context.coordinator.lastMessagesSnapshot != snap else { return }
+
+        context.coordinator.lastMessagesSnapshot = snap
         uiViewController.loadMessages(messages)
+    }
+
+    private func messagesSnapshot(_ messages: [Message]) -> Int {
+        var hasher = Hasher()
+
+        for message in messages {
+            hasher.combine(message.id)
+        }
+
+        return hasher.finalize()
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -31,7 +31,6 @@ final class BubbleImageRenderer {
     ) -> UIImage {
         let bubble = MessageBubble(
             placeName: message.placeTag?.name,
-            statusIndicator: showsAccentLine ? (message.isRecent() ? .recent : .normal) : .none,
             layout: showsAccentLine ? .flexible : .fixedSize(rotatingBubbleWidth)
         ) {
             BubbleText(text: message.content)
@@ -54,7 +53,6 @@ final class BubbleImageRenderer {
     ) -> UIImage {
         let bubble = MessageBubble(
             placeName: current.placeTag?.name,
-            statusIndicator: .none,
             layout: .fixedSize(rotatingBubbleWidth)
         ) {
             RotatingTextStack(

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -26,15 +26,13 @@ final class BubbleImageRenderer {
     func renderSingleBubble(
         message: Message,
         scale: CGFloat? = nil
-    ) -> UIImage {
+    ) async -> UIImage {
         let bubble = MessageBubble(
             message: message,
             layout: .flexible
         )
 
-        print("renderSingleBubble: \(message.content)")
-
-        return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
+        return await render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
 
     /// 애니메이션 진행도에 따른 회전 버블의 이미지를 렌더링합니다.
@@ -60,9 +58,7 @@ final class BubbleImageRenderer {
             )
         }
 
-        print("renderRotatingBubble: \(current.content)")
-
-        return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
+        return await render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
 
     /// 스택 버블 이미지를 렌더링합니다.
@@ -72,15 +68,17 @@ final class BubbleImageRenderer {
     func renderStackBubble(
         messages: [Message],
         scale: CGFloat? = nil
-    ) -> UIImage {
+    ) async -> UIImage {
         // TODO: MessageStackBubble 구현 후 교체
         guard let first = messages.first else { return UIImage() }
-        return renderSingleBubble(message: first, scale: scale)
+        return await renderSingleBubble(message: first, scale: scale)
     }
 }
 
 extension BubbleImageRenderer {
-    private func render<V: View>(view: V, scale: CGFloat) -> UIImage {
+    private func render<V: View>(view: V, scale: CGFloat) async -> UIImage {
+        await Task.yield()
+
         let renderer = ImageRenderer(content: view)
         renderer.scale = scale
         renderer.isOpaque = false

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -46,7 +46,7 @@ final class BubbleImageRenderer {
         next: Message,
         progress: Double,
         scale: CGFloat? = nil
-    ) -> UIImage {
+    ) async -> UIImage {
         let bubble = MessageBubble(
             message: current,
             layout: .fixedSize(rotatingBubbleWidth)

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -22,19 +22,17 @@ final class BubbleImageRenderer {
     /// 단일 메시지 버블 이미지를 렌더링합니다.
     /// - Parameters:
     ///   - message: 렌더링할 메시지
-    ///   - showsAccentLine: 좌측 상태 라인 표시 여부
     ///   - scale: 렌더링 스케일 (nil이면 화면 스케일 사용)
     func renderSingleBubble(
         message: Message,
-        showsAccentLine: Bool,
         scale: CGFloat? = nil
     ) -> UIImage {
         let bubble = MessageBubble(
-            placeName: message.placeTag?.name,
-            layout: showsAccentLine ? .flexible : .fixedSize(rotatingBubbleWidth)
-        ) {
-            BubbleText(text: message.content)
-        }
+            message: message,
+            layout: .flexible
+        )
+
+        print("renderSingleBubble: \(message.content)")
 
         return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
@@ -52,15 +50,17 @@ final class BubbleImageRenderer {
         scale: CGFloat? = nil
     ) -> UIImage {
         let bubble = MessageBubble(
-            placeName: current.placeTag?.name,
+            message: current,
             layout: .fixedSize(rotatingBubbleWidth)
-        ) {
+        ) { _ in
             RotatingTextStack(
                 currentText: current.content,
                 nextText: next.content,
                 progress: progress
             )
         }
+
+        print("renderRotatingBubble: \(current.content)")
 
         return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
@@ -75,7 +75,7 @@ final class BubbleImageRenderer {
     ) -> UIImage {
         // TODO: MessageStackBubble 구현 후 교체
         guard let first = messages.first else { return UIImage() }
-        return renderSingleBubble(message: first, showsAccentLine: true, scale: scale)
+        return renderSingleBubble(message: first, scale: scale)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -32,7 +32,7 @@ final class BubbleImageRenderer {
         let bubble = MessageBubble(
             placeName: message.placeTag?.name,
             statusIndicator: showsAccentLine ? (message.isRecent() ? .recent : .normal) : .none,
-            layout: showsAccentLine ? .flexible : .fixedWidth(rotatingBubbleWidth)
+            layout: showsAccentLine ? .flexible : .fixedSize(rotatingBubbleWidth)
         ) {
             BubbleText(text: message.content)
         }
@@ -55,7 +55,7 @@ final class BubbleImageRenderer {
         let bubble = MessageBubble(
             placeName: current.placeTag?.name,
             statusIndicator: .none,
-            layout: .fixedWidth(rotatingBubbleWidth)
+            layout: .fixedSize(rotatingBubbleWidth)
         ) {
             RotatingTextStack(
                 currentText: current.content,

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -366,7 +366,7 @@ extension MessageMarkerManager {
         switch markerType {
         case .singleBubble(let message):
             // 메시지 1개: 최신 표시 accent line + 단일 버블
-            image = bubbleImageRenderer.renderSingleBubble(message: message, showsAccentLine: true)
+            image = bubbleImageRenderer.renderSingleBubble(message: message)
 
         case .rotatingBubble(let messages), .stackBubble(let messages):
             // 메시지 2개 이상: 첫 번째 메시지로 초기 이미지
@@ -377,7 +377,7 @@ extension MessageMarkerManager {
                 break
             }
 
-            image = bubbleImageRenderer.renderSingleBubble(message: firstMessage, showsAccentLine: false)
+            image = bubbleImageRenderer.renderSingleBubble(message: firstMessage)
         }
 
         marker.iconImage = NMFOverlayImage(image: image)

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -9,6 +9,20 @@ import UIKit
 
 import NMapsMap
 
+enum MarkerPlaceholder {
+    static let transparent1px: UIImage = {
+        let size = CGSize(width: 1, height: 1)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        defer { UIGraphicsEndImageContext() }
+
+        return UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
+    }()
+
+    static let overlayImage: NMFOverlayImage = {
+        NMFOverlayImage(image: transparent1px)
+    }()
+}
+
 // MARK: - MessageMarkerManager
 
 /// 지도 위 메시지 마커의 생성, 업데이트, 애니메이션을 관리하는 객체입니다.
@@ -19,13 +33,16 @@ import NMapsMap
 /// noPlaceMessagesByCoord: [좌표: [장소 태그가 없는 메시지들]]
 /// markers: [마커키: 네이버맵 마커]
 /// animationStates: [마커키: 애니메이션 상태]
+/// renderTasks: [마커키: 렌더링 Task] (누적 방지, 최신만 반영)
+/// fadeTasks:   [마커키: 페이드 Task] (페이드 애니메이션 중복 방지)
+/// hasFadedIn:  Set<마커키> (마커별 최초 1회 페이드 적용 여부)
 /// ```
 ///
 /// ## 사용 흐름
 /// ```
 /// 1. loadMessages() -> 초기 메시지 로딩 (전체 마커 생성)
-/// 2. handleEvent() -> 실시간 이벤트 처리 (해당 좌표만 업데이트)
-/// 3. updateAnimations() -> 매 프레임 애니메이션 업데이트 (60fps)
+/// 2. handleEvent() -> 실시간 이벤트 처리 (해당 좌표의 마커/상태 갱신 + 필요 시 아이콘 재렌더)
+/// 3. updateAnimations() -> 애니메이션 대상 마커는 매 프레임 iconImage 갱신 (60fps)
 /// ```
 @MainActor
 final class MessageMarkerManager {
@@ -44,6 +61,15 @@ final class MessageMarkerManager {
 
     /// 한 마커에 표시할 최대 메시지 수 (기본값: 10)
     private let displayLimit: Int
+
+    /// 마커별 렌더링 Task (누적 방지, 최신만 반영)
+    private var renderTasks: [MarkerGroupKey: Task<Void, Never>] = [:]
+
+    /// 페이드 관리용 Task
+    private var fadeTasks: [MarkerGroupKey: Task<Void, Never>] = [:]
+
+    /// 마커 페이드인 여부 상태 플래그
+    private var hasFadedIn: Set<MarkerGroupKey> = []
 
     // MARK: - Dependencies
 
@@ -65,11 +91,17 @@ final class MessageMarkerManager {
 
 extension MessageMarkerManager {
     /// 네이버맵 마커 객체를 생성합니다.
+    ///  - 기본 핀 깜빡임 방지를 위해 투명 placeholder icon을 먼저 세팅하고,
+    ///  - 최초 1회는 렌더링 완료 후 페이드 인, 이후 갱신은 alpha = 1 유지한 채 iconImage만 교체
     private func makeMarker(at position: NMGLatLng, mapView: NMFMapView) -> NMFMarker {
         let marker = NMFMarker(position: position)
         marker.anchor = CGPoint(x: 0.5, y: 1.0)   // 마커 하단 중앙이 좌표 위치
         marker.zIndex = 1000                      // 다른 오버레이보다 위에 표시
         marker.isFlat = false                     // 3D 틸트 시에도 수직 유지
+
+        marker.iconImage = MarkerPlaceholder.overlayImage
+        marker.alpha = 0.0
+
         marker.mapView = mapView                  // 지도에 마커 표시
         return marker
     }
@@ -110,6 +142,8 @@ extension MessageMarkerManager {
         // 5. 저장된 메시지 기반으로 모든 마커 생성
         rebuildAllMarkers(mapView: mapView, onTapPlace: onTapPlace, onTapNoPlace: onTapNoPlace)
     }
+
+    // TODO: - handleEvent 정리 (실시간 이벤트 없으므로)
 
     /// 실시간 이벤트 처리 (메시지 추가/삭제 시 호출)
     /// - Parameters:
@@ -213,6 +247,9 @@ extension MessageMarkerManager {
     /// - 마커 딕셔너리 초기화
     /// - 애니메이션 상태 초기화
     /// - 메시지 저장소 초기화
+    /// - 진행 중인 렌더링 Task 취소 (누적 방지)
+    /// - fadeTasks 취소
+    /// - hasFadedIn 초기화
     private func clearAll() {
         // 지도에서 마커 제거
         for (_, marker) in markers {
@@ -222,6 +259,13 @@ extension MessageMarkerManager {
         animationStates.removeAll()
         placeMessagesByCoord.removeAll()
         noPlaceMessagesByCoord.removeAll()
+
+        for (_, task) in renderTasks { task.cancel() }
+        renderTasks.removeAll()
+
+        for (_, task) in fadeTasks { task.cancel() }
+        fadeTasks.removeAll()
+        hasFadedIn.removeAll()
     }
 }
 
@@ -291,7 +335,9 @@ extension MessageMarkerManager {
         )
     }
 
-    /// 단일 마커를 생성하거나 업데이트합니다.
+    /// 단일 마커가 없으면 생성하거나 있으면 재사용하고,
+    /// 메시지 상태에 따라 아이콘을 비동기로 렌더링하여 갱신합니다.
+    /// (메시지가 없으면 markerType이 nil이므로 아이콘 갱신 없이 종료됩니다.)
     private func updateMarker(
         coord: Coordinate,
         isPlace: Bool,
@@ -301,20 +347,28 @@ extension MessageMarkerManager {
         // 마커 식별 키 생성
         let key = MarkerGroupKey(coordinate: coord, isPlace: isPlace)
 
-        // 1. 기존 마커 제거 (있다면)
-        removeMarker(for: key)
+        AppLog.debug("updateMarker key=\(key) count(place)=\(placeMessagesByCoord[coord]?.count ?? 0) count(noPlace)=\(noPlaceMessagesByCoord[coord]?.count ?? 0)", category: .location)
+
+        // 1. 기존 마커가 있다면 그대로 쓰고, 없으면 새로 만들기
+        let marker: NMFMarker
+        if let existing = markers[key] {
+            marker = existing
+        } else {
+            marker = createMarker(at: coord, mapView: mapView)
+            markers[key] = marker
+        }
 
         // 2. 메시지 조회 (최신 displayLimit개만)
         let messagesInCoord = isPlace ? placeMessagesByCoord[coord] : noPlaceMessagesByCoord[coord]
         let messages = Array((messagesInCoord ?? []).suffix(displayLimit))
 
         // 3. MarkerType 결정 (메시지가 없으면 nil -> 마커 생성 안 함)
-        guard let markerType = MarkerType.from(messages: messages, isPlace: isPlace) else { return }
+        guard let markerType = MarkerType.from(messages: messages, isPlace: isPlace) else {
+            removeMarker(for: key)
+            return
+        }
 
-        // 4. 마커 생성 (타입에 맞는 이미지로)
-        let marker = createMarker(for: markerType, at: coord, mapView: mapView)
-
-        // 5. 탭 핸들러 등록
+        // 4. 탭 핸들러 등록 (위에서 만든 마커 재사용)
         // - 탭 시점의 최신 메시지를 조회하여 콜백에 전달
         marker.touchHandler = { [weak self] _ in
             guard let self else { return true }
@@ -323,10 +377,10 @@ extension MessageMarkerManager {
             return true
         }
 
-        // 6. 마커 저장
-        markers[key] = marker
+        // 5. 초기 이미지 렌더 (key 기준 검증 + Task 누적 방지)
+        scheduleInitialRender(for: key, marker: marker, markerType: markerType)
 
-        // 7. 회전 애니메이션 상태 등록 (rotatingBubble 또는 stackBubble인 경우)
+        // 6. 회전 애니메이션 상태 등록 (rotatingBubble 또는 stackBubble인 경우)
         switch markerType {
         case .rotatingBubble, .stackBubble:
             let messagesProvider: () -> [Message] = { [weak self] in
@@ -349,39 +403,59 @@ extension MessageMarkerManager {
         markers[key]?.mapView = nil           // 지도에서 제거
         markers.removeValue(forKey: key)      // 마커 딕셔너리에서 삭제
         animationStates.removeValue(forKey: key)  // 애니메이션 상태 삭제
+
+        renderTasks[key]?.cancel()
+        renderTasks.removeValue(forKey: key)
+
+        fadeTasks[key]?.cancel()
+        fadeTasks.removeValue(forKey: key)
+
+        hasFadedIn.remove(key)
     }
 
     /// MarkerType에 맞는 마커를 생성하고 이미지를 설정합니다.
     private func createMarker(
-        for markerType: MarkerType,
         at coord: Coordinate,
         mapView: NMFMapView
     ) -> NMFMarker {
         let position = NMGLatLng(lat: coord.latitude, lng: coord.longitude)
-        let marker = makeMarker(at: position, mapView: mapView)
+        return makeMarker(at: position, mapView: mapView)
+    }
 
-        // MarkerType에 따라 다른 이미지 렌더링
-        let image: UIImage
+    private func scheduleInitialRender(
+        for key: MarkerGroupKey,
+        marker: NMFMarker,
+        markerType: MarkerType
+    ) {
+        // 기존 렌더 작업 취소 (최신만 반영)
+        renderTasks[key]?.cancel()
 
-        switch markerType {
-        case .singleBubble(let message):
-            // 메시지 1개: 최신 표시 accent line + 단일 버블
-            image = bubbleImageRenderer.renderSingleBubble(message: message)
+        renderTasks[key] = Task { @MainActor in
+            let image: UIImage
 
-        case .rotatingBubble(let messages), .stackBubble(let messages):
-            // 메시지 2개 이상: 첫 번째 메시지로 초기 이미지
-            // 악센트 라인 없음 (회전 중에는 표시 안 함)
-            // stackBubble도 임시로 rotatingBubble과 동일하게 처리 (추후 별도 UI 구현 예정)
-            guard let firstMessage = messages.first else {
-                image = UIImage()
-                break
+            switch markerType {
+            case .singleBubble(let message):
+                image = await bubbleImageRenderer.renderSingleBubble(message: message)
+
+            case .rotatingBubble(let messages), .stackBubble(let messages):
+                guard let first = messages.first else { return }
+                image = await bubbleImageRenderer.renderSingleBubble(message: first)
             }
 
-            image = bubbleImageRenderer.renderSingleBubble(message: firstMessage)
-        }
+            // 취소되었으면 적용 X
+            guard !Task.isCancelled else { return }
 
-        marker.iconImage = NMFOverlayImage(image: image)
-        return marker
+            // 아직 이 key의 현재 마커가 이 marker인지 확인
+            guard markers[key] === marker else { return }
+
+            if hasFadedIn.contains(key) {
+                marker.iconImage = NMFOverlayImage(image: image)
+                marker.alpha = 1.0
+            } else {
+                hasFadedIn.insert(key)
+                applyIconWithFade(image, to: marker, key: key)
+            }
+        }
     }
 }
 
@@ -391,8 +465,8 @@ extension MessageMarkerManager {
 
     /// 회전 애니메이션 상태를 업데이트합니다.
     ///
-    /// MapViewController의 타이머에서 매 프레임(60fps) 호출됩니다.
-    /// rotatingBubble 타입의 마커들에 대해 애니메이션을 처리합니다.
+    /// MapViewController의 타이머/디스플레이 링크에서 주기적으로(예: 60fps 주기) 호출됩니다.
+    /// rotatingBubble / stackBubble 타입(다중 메시지)의 마커들에 대해 애니메이션을 처리합니다.
     ///
     /// ## 애니메이션 흐름
     /// 1. 대기 중 -> rotationInterval(3초) 후 애니메이션 시작
@@ -417,12 +491,25 @@ extension MessageMarkerManager {
                 // 현재/다음 메시지로 회전 이미지 렌더링
                 if let current = state.currentMessage,
                     let next = state.nextMessage {
-                    let image = bubbleImageRenderer.renderRotatingBubble(
-                        current: current,
-                        next: next,
-                        progress: state.animationProgress
-                    )
-                    marker.iconImage = NMFOverlayImage(image: image)
+
+                    // 기존 렌더 취소 (프레임 누적 방지)
+                    renderTasks[groupKey]?.cancel()
+
+                    renderTasks[groupKey] = Task { @MainActor in
+                        // marker는 Task 안에서 다시 가져오도록 하기 (교체될 수 있으므로)
+                        guard let marker = self.markers[groupKey] else { return }
+
+                        let image = await bubbleImageRenderer.renderRotatingBubble(
+                            current: current,
+                            next: next,
+                            progress: state.animationProgress
+                        )
+
+                        guard !Task.isCancelled else { return }
+                        guard self.markers[groupKey] === marker else { return }
+
+                        marker.iconImage = NMFOverlayImage(image: image)
+                    }
                 }
             } else {
                 // 대기 중: 시작 시간 확인 후 애니메이션 시작
@@ -432,6 +519,35 @@ extension MessageMarkerManager {
             }
 
             animationStates[groupKey] = state
+        }
+    }
+
+    private func applyIconWithFade(
+        _ image: UIImage,
+        to marker: NMFMarker,
+        key: MarkerGroupKey,
+        duration: TimeInterval = 0.5,
+        fps: Double = 60
+    ) {
+        // 기존 페이드 작업 취소
+        fadeTasks[key]?.cancel()
+
+        // 아이콘은 먼저 교체
+        marker.iconImage = NMFOverlayImage(image: image)
+
+        // 시작은 투명
+        marker.alpha = 0.0
+
+        let totalFrames = max(1, Int(duration * fps))
+        let frameNanos = UInt64(1_000_000_000 / fps)
+
+        fadeTasks[key] = Task { @MainActor in
+            for i in 0...totalFrames {
+                if Task.isCancelled { return }
+                marker.alpha = CGFloat(Double(i) / Double(totalFrames))
+                try? await Task.sleep(nanoseconds: frameNanos)
+            }
+            marker.alpha = 1.0
         }
     }
 }


### PR DESCRIPTION
## 배경
- closed #261

## 작업 요약
- MessageBubble 레이아웃 조정
  - BubbleLayout.fixedWidth -> fixedSize로 네이밍 수정
  - 단일 버블(`.flexible`): 버블 자체 가로, 세로 길이 동적 변경 지원
  - 회전 버블(`.fixedSize`):
    - 버블 자체 가로, 세로 길이 고정
    - 텍스트 영역 높이 고정
- MessageBubble 구성 요소 변경
  - 최신 여부 인디케이터 제거
  - 장소 태그가 없을 경우에는 주소로 표시
  - 우측 하단에 메시지 작성 일시 텍스트 추가
  - 텍스트 영역과 하단 일시 텍스트 사이에 Divider 추가
- 마커 렌더링 이슈 일부 해결 (나머지 해결은 다음 PR에)

## 작업 내용
### 1. MessageBubble 레이아웃 조정
#### 1) AS-IS
- 단일 버블(`.flexible`), 회전 버블(`.fixedSize`)의 **동적/고정 레이아웃이 흔들려서** 여백이 많아지거나, 시각적으로 가독성이 떨어졌음.

#### 2) 버블 종류 정리
<img width="596" height="280" alt="버블 형태 정리" src="https://github.com/user-attachments/assets/57fd7dba-d421-4b9f-9063-2f0a6227eb24" />

* **단일 버블 (`.flexible`)**
  * 버블 **가로/세로 크기가 콘텐츠에 따라 동적으로 변함**.
  * (짧은 메시지 → 작은 버블, 긴 메시지(최대 2줄) → 더 큰 버블)
* **회전 버블 (`.fixedSize(CGFloat)`)**
  * 버블 **가로/세로 크기 고정**
  * 본문 텍스트 영역의 높이도 고정
    * 텍스트가 1줄이든 2줄이든 상단(placeName) / 하단(date)과의 간격이 시각적으로 안정적으로 유지되도록 함.

#### 3) TO-BE
- 단일 버블(`.flexible`)
  - 버블 크기가 콘텐츠에 맞게 줄어들거나 커진다.
  * 폭은 maxWidth(기본 210)를 상한으로 두고, 내용이 짧으면 더 줄어들 수 있다.
  ```swift
  .frame(maxWidth: maxWidth, alignment: .leading)
  .fixedSize(horizontal: true, vertical: false)
  ```
  * fixedSize(horizontal: true)로 **짧은 텍스트일 때 폭이 불필요하게 늘어나지 않도록** 함.
- 회전 버블(`.fixedSize`)
  - 회전 UI에서 카드(버블) 사이즈가 매번 달라지면 흔들려 보임.
  * 따라서 버블 외곽 크기를 고정하고, 내부에서 텍스트 영역도 고정해서 안정감을 준다.
    1. **버블 전체 크기 고정**
       ```swift
       .frame(width: fixedSize, height: 98, alignment: .leading)
       ```
    2. **본문(content) 영역 높이 고정**
       ```swift
       content
       .frame(height: 36, alignment: .center)
       .clipped()
       ```
       - MessageBubble 내부에서 `.fixedSize`인 경우에만 본문 영역을 항상 동일한 높이(36으로 유지)
       - 텍스트가 1줄이면 영역 내부에서 여백이 생기고, 2줄이면 꽉차게 됨.
       - 1줄인 경우 텍스트는 세로의 중앙에 위치하게 된다.

<img width="300" alt="메시지버블 예시" src="https://github.com/user-attachments/assets/94d7c2ca-6bb2-40e7-9ce1-cfdf7266c5ff" />

https://github.com/user-attachments/assets/d1365673-ba9c-4a7b-88b7-f9e3f716c5df

---
### MaxHeightClamp 사용
#### 목적
- BubbleText(텍스트 영역 컴포넌트)는 `lineLimit(2)`로 줄 수는 제한하지만, 특정 상황(폰트 렌더링/라인 높이/레이아웃 제안)에 따라 예상보다 높이가 커질 수 있어서 **텍스트 영역의 최대 높이를 보조적으로 제한하기 위해** clampMaxHeight를 사용한다.
- 사용하지 않고 maxHeight로 조정할 경우 해당 인자로 넘겨준 값(CGFloat)으로 높이가 고정되어 버리는 현상 발생

#### 구조
1) **HeightKey: 실제 높이 전달용 PreferenceKey**
   ```swift
   struct HeightKey: PreferenceKey {
    static var defaultValue: CGFloat = 0
    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
        value = max(value, nextValue())
    }
   }
   ```
   - SwiftUI는 기본적으로 자식 뷰의 실제 크기를 부모가 직접 알기 어렵다.
   * PreferenceKey를 쓰면 **자식 → 부모 방향으로 값 전달**이 가능하다.
   * reduce에서 max를 쓰는 이유는 동일 key가 여러 번 올라올 때 가장 큰 값을 대표로 쓰기 위함.
   
2) **MaxHeightClamp: 측정값을 기반으로 높이를 clamp**
   ```swift
   struct MaxHeightClamp: ViewModifier {
    let maxHeight: CGFloat
    @State private var measured: CGFloat = 0
   
    func body(content: Content) -> some View {
        content
            .background(
                GeometryReader { proxy in
                    Color.clear
                        .preference(key: HeightKey.self, value: proxy.size.height)
                }
            )
            .onPreferenceChange(HeightKey.self) { height in
                let rounded = (height * 2).rounded() / 2
                if abs(rounded - measured) > 0.5 {
                    measured = rounded
                } else if measured == 0 {
                    measured = rounded
                }
            }
            .frame(height: min(measured == 0 ? maxHeight : measured, maxHeight))
    }
   }
   ```
   - 동작 순서:
     1. GeometryReader로 현재 콘텐츠가 차지한 실제 높이(proxy.size.height)를 측정
     2. 측정값을 HeightKey를 통해 Preference로 전달
     3. .onPreferenceChange로 높이 변화를 수신
     4. 높이가 아주 미세하게 흔들리는 경우(소수점 단위 변화)로 인한 무한 업데이트를 막기 위해 0.5 단위로 반올림
     5. 최종 height는
        * 측정 전(0): maxHeight를 사용
        * 측정 후: min(measured, maxHeight)로 clamp

3) **View 확장: clampMaxHeight 사용 편의**
   ```swift
   extension View {
    func clampMaxHeight(_ maxHeight: CGFloat) -> some View {
        modifier(MaxHeightClamp(maxHeight: maxHeight))
    }
   }
   ```
   - 어디서든 `.clampMaxHeight(50)` 형태로 재사용 가능하도록 확장 제공

#### 현재 상황에서 사용 방식
BubbleText에서 Text 뷰에 대한 모디파이어로 `.clampMaxHeight(50)`를 사용하여 **동적 높이를 보장**할 수 있도록 함.
---

### 2. MessageBubble 구성 요소 변경
#### 1) MessageBubble에 Message 자체를 넘기도록 수정
```swift
struct MessageBubble<Content: View>: View {
    let message: Message
    let layout: BubbleLayout
    let content: (Message) -> Content

    var maxWidth: CGFloat = 210

    init(
        message: Message,
        layout: BubbleLayout,
        @ViewBuilder content: @escaping (Message) -> Content = {
            BubbleText(
                text: $0.content
            )
        }
    ) {
        self.message = message
        self.layout = layout
        self.content = content
    }
	...
```
- 회전 버블의 경우 RotatingTextStack이 들어갈 것을 고려하여 **content는 유지**하되, 단일 버블에 대응하는 **기본값** 주입

#### 2) 구성 요소 변경
- 최신 여부 인디케이터 제거
- 장소 태그가 없을 경우에는 **주소로 표시**
- 우측 하단에 **메시지 작성 일시 텍스트 추가**
- 텍스트 영역과 하단 일시 텍스트 사이에 **Divider 추가**

---
### MessageBubble Divider 이슈 (SwiftUI)
#### 문제
- 배경
  - MessageBubble에 텍스트 영역과 하단 일시 텍스트 사이에 구분선을 넣고자 VStack 내부에 Divider()를 추가함.
- 발생한 문제
  - 지도 위에 렌더링되어 배치되는 버블 중 텍스트 영역이 한 줄 높이로 보여지는 버블의 경우 구분선이 사라졌다.

#### 시도했던 해결 (실패)
* `Divider()` → `Rectangle().frame(height: 1px)` 로 변경
  * → 동일 (여전히 레이아웃 요소라 공간을 요구함)
* `layoutPriority(1)` 적용
  * → 동일 (Divider가 사라지는 근본 원인이 ‘공간 부족’ + ‘최종 높이 확정 과정’이라 우선순위로 해결되지 않음)

#### 발견한 원인
Divider/Rectangle을 VStack 내부에 삽입하면 해당 뷰는 **레이아웃 계산 대상**이 된다.

텍스트가 짧은 메시지 버블이 렌더링될 경우 텍스트 영역이 최소 높이(한 줄)로 확정되고, VStack이 그 높이에 맞춰 수축하게 되면서 **Divider가 들어갈 추가 높이가 확보되지 않는 문제**가 생겼다.

#### 해결 방법
Divider를 레이아웃 계산에서 제외시키기 위하여 VStack 내부 요소가 아닌 **overlay**로 올리는 방식으로 변경하였다.

```swift
// 배치 방식
.overlay(alignment: .bottomLeading) {
	dividerOverlay
}

// 구현 방식
var dividerOverlay: some View {
	Rectangle()
		.fill(Color.black.opacity(0.8))
		.frame(height: 1 / UIScreen.main.scale)
		.padding(.horizontal, 12)
		.padding(.bottom, 29)
}
```

#### 결과
- 텍스트 줄 수에 관계없이 Divider가 안정적으로 노출됨.
---

### 3. 마커 렌더링 이슈 해결 (1)

> 과정으로 나열해서 순서대로 따라가주시면 됩니다.

#### 1) 렌더 타이밍 이슈 발생
위와 같이 수정한 MessageBubble을 그대로 이미지로 렌더링(BubbleImageRenderer)했을 때 다음과 같은 렌더링 타이밍 이슈가 생김.

- **한 줄짜리 단일 버블이 두 줄 높이로 계산되는 현상**
- 텍스트 높이를 clamp로 제한해도, **렌더 시점에서 clamp가 반영되기 전에** 이미지가 만들어짐.
- 결과적으로 동적 높이 조절이 적용되지 않는 것처럼 보임.

#### 2) BubbleImageRenderer를 비동기 렌더링으로 수정
- **변경 내용**
  - BubbleImageRenderer의 렌더 함수들을 async로 변경하고, 내부에서 **한 번 yield**하여 레이아웃 세팅을 기다리도록 수정
  ```swift
  private func render<V: View>(view: V, scale: CGFloat) async -> UIImage {
    	await Task.yield()
    	let renderer = ImageRenderer(content: view)
    	renderer.scale = scale
    	renderer.isOpaque = false
    	return renderer.uiImage ?? UIImage()
  }
  ```
- **의도**
  - SwiftUI 내부 레이아웃 계산이 끝난 후에 다음 프레임에서 렌더가 진행되도록 유도
  - clamp/lineLimit 등 뷰 레이아웃 결과가 이미지에 안정적으로 반영되게 함.

#### 3) 비동기 렌더 적용을 위한 호출부 변경
렌더 함수들이 async로 수정되면서 마커 이미지가 준비되기 전에 지연이 생기게 됨.
따라서 실제 버블 이미지가 준비될 때까지 **임시 표시 전략이 필요**해짐.

- MessageMarkerManager에서 렌더링을 Task로 감싸 적용
- 렌더 완료 전에는 기본 마커로 표시

#### 4) 네이버 기본 마커 깜빡임 발생 -> placeholder + fade-in으로 깜빡임 완화
- **현상**
  - 비동기 렌더 도입 후 실제 버블 이미지가 적용되기 전 잠깐동안 **네이버 기본 마커 핀이 한 번 보였다가 사라지는 깜빡임** 발생.
- **해결**
  - 마커 생성 시 기본 핀을 노출하지 않도록 최초 마커 생성 시 iconImage에 **투명 placeholder (1px)**를 먼저 삽입.
  - 실제 버블 이미지 적용 시 **fade-in 애니메이션 적용**
  ```swift
  marker.iconImage = MarkerPlaceholder.overlayImage
  marker.alpha = 0.0
  ```
  - 렌더 후 적용 시
    - 첫 적용: fade-in
    - 이후 갱신: alpha 유지 + icon만 교체

#### 5) 같은 key에 대해 updateMarker가 두 번씩 호출되는 문제 발생
- **현상**
  - 이 시점부터 마커 이미지가 렌더된 후에 두 번 깜빡이는 것으로 보임.
- **확인**
  - 로그를 찍어보니 동일 Key에 대해 updateMarker()가 연속으로 호출되고 있었고, 원인은 MessageMarkerManager가 아닌 상위 호출 루트였음.
  - 호출 루트: `SwiftUI -> UIViewControllerRepresentable.updateUIViewController -> MapViewController.loadMessages -> MessageMarkerManager.loadMessages -> rebuildAllMarkers -> updateMarkersForCoordinate -> updateMarker`
  - 즉, **updateUIViewController가 자주 호출되는 SwiftUI 특성** 때문에 **messages가 변하지 않아도 loadMessages가 반복**되며 전제 리빌드가 발생했던 것으로 확인됨.

#### 6) updateUIViewController에서 messages 변경 시에만 loadMessages를 호출하도록 차단
```swift
func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
	let snap = messagesSnapshot(messages)

	// 동일 메시지인 경우 loadMessages() 호출 X
	guard context.coordinator.lastMessagesSnapshot != snap else { return }

	context.coordinator.lastMessagesSnapshot = snap
	uiViewController.loadMessages(messages)
}
```
- Representable의 Coordinator에 **마지막 메시지 스냅샷을 저장**
  - 스냅샷 기준: 메시지의 id로 hash 생성 (렌더/좌표 그룹핑은 내부에서 처리)
- updateUIViewController에서 **동일하다고 판단될 시 리빌드(loadMessages) 호출을 막음**.

#### 요약
- **BubbleImageRenderer (async 렌더)**
  - renderSingleBubble, renderRotatingBubble, renderStackBubble → 모두 async
  * 내부 render에서 Task.yield()로 레이아웃 세팅 타이밍 보정
- **MessageMarkerManager (placeholder + fade + task 누적 방지)**
  - 마커 생성 시 placeholder icon + alpha 0
  - 렌더링은 Task로 수행하고, 같은 key 렌더 Task는 calcel하여 누적 방지
  - 첫 렌더만 fade-in, 이후는 alpha 유지
- **MapViewWrapper (Representable 중복 호출 차단)**
  - updateUIViewController에서 messages snapshot 비교
  - 동일 messages인 경우에는 loadMessages를 호출하지 않음 -> 중복 렌더/깜빡임 제거

## 스크린샷
(다음 pr에서 확인해주세요..)

## 리뷰 요구사항
현재 **지도 드래그/줌인아웃 제스처 시마다 메시지가 심하게 깜빡**거리며 재렌더되는 현상이 발생하고 있습니다.
이를 급하게 해결하기 위하여 리팩터링 기간에 적용하기로 했던 **메시지 버블 마커 업데이트 방식 수정(diff 방식 적용)을 진행**했고, 이는 (다음 pr)[https://github.com/boostcampwm2025/ios04-ChanaPing/pull/274]에 담았으니 참고 부탁드립니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Messages now display location names and formatted dates (yy.MM.dd format)
  * Enhanced map marker rendering with improved animations and fade-in effects

* **Improvements**
  * Optimized asynchronous marker rendering for better map performance
  * Refined message bubble layout and animation logic
  * Improved marker lifecycle management to prevent redundant updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->