### PR TITLE
마커 렌더링 시 깜빡임 해소 (마커 업데이트 diff 방식 적용)

### DIFF
--- a/Meomun/Meomun/Data/DTO/NearbyMessageDTO.swift
+++ b/Meomun/Meomun/Data/DTO/NearbyMessageDTO.swift
@@ -38,6 +38,7 @@ extension NearbyMessageResponseDTO {
                 latitude: latitude,
                 longitude: longitude
             ),
+            address: "address",
             placeTag: place.map {
                 Place(
                     id: PlaceID(value: $0.placeId),

--- a/Meomun/Meomun/Data/DTO/PlaceMessagesDTO.swift
+++ b/Meomun/Meomun/Data/DTO/PlaceMessagesDTO.swift
@@ -45,6 +45,7 @@ extension PlaceMessageResponseDTO {
             createdAt: createdAt,
             content: content,
             coordinate: coordinate,
+            address: "address",
             placeTag: placeTag
         )
     }

--- a/Meomun/Meomun/Domain/Entity/Message.swift
+++ b/Meomun/Meomun/Domain/Entity/Message.swift
@@ -12,9 +12,30 @@ struct Message: Identifiable, Sendable {
     let createdAt: Date
     let content: String
     let coordinate: Coordinate
+    let address: String?
     let placeTag: Place?
 
     func isRecent(recentInterval: TimeInterval = 60 * 20) -> Bool {
         Date().timeIntervalSince(createdAt) <= recentInterval
+    }
+}
+
+extension Message {
+    var displayLocationName: String? {
+        // placeTag가 있다면 name
+        if let tagName = placeTag?.name, !tagName.isEmpty {
+            return tagName
+        }
+        // 없다면 address (동부터? 그 뒤부터? 하여튼 포매팅)
+        if let address, !address.isEmpty {
+            return address
+        }
+        return nil
+    }
+
+    var displayDateString: String { // 같은 날이면 시간, 다른 날이면 날짜로 보여지게 하기
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy.MM.dd"
+        return formatter.string(from: createdAt)
     }
 }

--- a/Meomun/Meomun/Presentation/Common/Component/MaxHeightClamp.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MaxHeightClamp.swift
@@ -1,0 +1,56 @@
+//
+//  MaxHeightClamp.swift
+//  Meomun
+//
+//  Created by 지연 on 1/22/26.
+//
+
+import SwiftUI
+
+/// 1. HeightKey: 뷰의 실제 높이 측정
+/// 2. MaxHeightClamp: 측정한 실제 높이와 maxHeight 중 더 작은 값으로 최종 높이를 강제로 결정
+
+struct HeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+struct MaxHeightClamp: ViewModifier {
+    let maxHeight: CGFloat                      // 최대 허용 높이
+    @State private var measured: CGFloat = 0    // 실제 측정된 콘텐츠 높이
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                // GeometryReader: 자신이 차지한 실제 레이아웃 크기를 알려줌.
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(
+                            key: HeightKey.self,
+                            value: proxy.size.height
+                        )
+                }
+            )
+            // 높이 바뀔 때마다 호출 -> 다시 계산
+            .onPreferenceChange(HeightKey.self) { height in
+                let rounded = (height * 2).rounded() / 2
+                if abs(rounded - measured) > 0.5 {
+                    measured = rounded
+                } else if measured == 0 {
+                    measured = rounded
+                }
+            }
+            // 측정 높이와 maxHeight 비교 -> 더 작은 값으로 높이 고정
+            .frame(height: min(measured == 0 ? maxHeight : measured, maxHeight))
+    }
+}
+
+// MARK: - View 확장 모디파이어
+
+extension View {
+    func clampMaxHeight(_ maxHeight: CGFloat) -> some View {
+        modifier(MaxHeightClamp(maxHeight: maxHeight))
+    }
+}

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -13,64 +13,77 @@ enum BubbleLayout {
 }
 
 struct MessageBubble<Content: View>: View {
-    let placeName: String?
-    let createdAt: Date?
+    let message: Message
     let layout: BubbleLayout
-    let content: Content
+    let content: (Message) -> Content
 
     var maxWidth: CGFloat = 210
 
     init(
-        placeName: String?,
-        createdAt: Date = .init(timeIntervalSince1970: 0),
+        message: Message,
         layout: BubbleLayout,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: @escaping (Message) -> Content = {
+            BubbleText(
+                text: $0.content
+            )
+        }
     ) {
-        self.placeName = placeName
-        self.createdAt = createdAt
+        self.message = message
         self.layout = layout
-        self.content = content()
+        self.content = content
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 5) {
             // 장소 태그 (옵셔널)
-            if let placeName, !placeName.isEmpty {
+            if let locationName = message.displayLocationName {
                 HStack(spacing: 4) {
                     Image(systemName: "mappin.and.ellipse")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(Color(hex: "#53808C"))
 
-                    Text(placeName)
+                    Text(locationName)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(Color.gray.opacity(0.8))
                 }
             }
 
-            if case .fixedSize = layout {
-                content
-                    .frame(height: 36, alignment: .center)
-                    .clipped()
-            } else {
-                content
-            }
+            bodyPart
 
-            Text("25.02.01")
+            Divider()
+                .background(Color.black.opacity(0.8))
+                .padding(.top, 2)
+
+            Text(message.displayDateString)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.gray.opacity(0.8))
                 .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.top, -2)
         }
-        .padding(.vertical, 15)
-        .padding(.horizontal, 15)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
         .applyLayout(
             layout,
-            maxWidth: maxWidth,
-            background: bubbleBackground
+            maxWidth: maxWidth
         )
+        .background(bubbleBackground)
     }
 }
 
 private extension MessageBubble {
+    @ViewBuilder
+    var bodyPart: some View {
+        let bodyView = content(message)
+
+        if case .fixedSize = layout {
+            bodyView
+                .frame(height: 36, alignment: .center)
+                .clipped()
+        } else {
+            bodyView
+        }
+    }
+
     var bubbleBackground: some View {
         RoundedRectangle(cornerRadius: 22, style: .continuous)
             .fill(Color.white)
@@ -83,7 +96,7 @@ private extension MessageBubble {
 
 struct BubbleText: View {
     let text: String
-    var maxWidth: CGFloat? = 190
+    var maxWidth: CGFloat? = 180
 
     var body: some View {
         // 본문 (최대 2줄)
@@ -98,7 +111,7 @@ struct BubbleText: View {
                 maxWidth: maxWidth,
                 alignment: .leading
             )
-            .clampMaxHeight(50)
+            .clampMaxHeight(56)
     }
 }
 
@@ -106,7 +119,7 @@ struct BubbleText: View {
 
 private extension View {
     @ViewBuilder
-    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat, background: some View) -> some View {
+    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat) -> some View {
         Group {
             switch layout {
             case .flexible:
@@ -121,65 +134,106 @@ private extension View {
                 self
                     .frame(
                         width: fixedSize,
-                        height: 98,
+                        height: 103,
                         alignment: .leading
                     )
             }
         }
-        .background(background)
     }
 }
 
 // MARK: - Preview
 
 #Preview {
+    let placeMessage = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "[한줄] 오늘 좀 춥다🫥🍃",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: nil,
+        placeTag: Place(
+            id: PlaceID(value: ""),
+            name: "장소 이름",
+            coordinate: .init(
+                latitude: 0,
+                longitude: 0
+            )
+        )
+    )
+
+    let longMessage = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: nil,
+        placeTag: Place(
+            id: PlaceID(value: ""),
+            name: "장소 이름",
+            coordinate: .init(
+                latitude: 0,
+                longitude: 0
+            )
+        )
+    )
+
+    let longMessage2 = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "sdcfvvfvfvffvfvfvfvfvfvfvfvfff",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: nil,
+        placeTag: Place(
+            id: PlaceID(value: ""),
+            name: "장소 이름",
+            coordinate: .init(
+                latitude: 0,
+                longitude: 0
+            )
+        )
+    )
+
+    let noPlaceMessage = Message(
+        id: MessageID(value: UUID()),
+        createdAt: Date(),
+        content: "dkfdkkdlsjkd",
+        coordinate: .init(latitude: 0, longitude: 0),
+        address: "어딘가의 주소",
+        placeTag: nil
+    )
+
     ZStack {
         Color.gray.opacity(0.15).ignoresSafeArea()
 
         VStack(alignment: .leading, spacing: 12) {
             Text(".flexible (단일 버블)")
-            MessageBubble(
-                placeName: "장소 이름",
-                layout: .flexible
-            ) {
-                BubbleText(text: "[한줄] 오늘 좀 춥다🫥🍃")
-            }
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: placeMessage,
                 layout: .flexible
-            ) {
-                BubbleText(text: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃")
-            }
+            )
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: longMessage,
                 layout: .flexible
-            ) {
-                BubbleText(text: "[두줄] 이건 30자 메시지에요 재밌죠 나는 자고싶어요")
-            }
+            )
+
+            MessageBubble(
+                message: longMessage2,
+                layout: .flexible
+            )
 
             Text(".fixedSize(170) (회전 버블)")
-            MessageBubble(
-                placeName: "장소 이름",
-                layout: .fixedSize(170)
-            ) {
-                BubbleText(text: "🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥")
-            }
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: placeMessage,
                 layout: .fixedSize(170)
-            ) {
-                BubbleText(text: "dkfdkkdkdksdjkfskdlsjkd")
-            }
+            )
 
             MessageBubble(
-                placeName: "장소 이름",
+                message: noPlaceMessage,
                 layout: .fixedSize(170)
-            ) {
-                BubbleText(text: "dkfdkkdlsjkd")
-            }
+            )
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -53,13 +53,6 @@ struct MessageBubble<Content: View>: View {
     }
 
     var body: some View {
-        //        HStack(alignment: .top, spacing: 10) {
-        // 왼쪽 세로 라인
-        //            Capsule()
-        //                .fill(statusIndicatorColor)
-        //                .frame(width: 3)
-        //                .padding(.vertical, 11)
-
         VStack(alignment: .leading, spacing: 6) {
             // 장소 태그 (옵셔널)
             if let placeName, !placeName.isEmpty {
@@ -95,9 +88,6 @@ struct MessageBubble<Content: View>: View {
             background: bubbleBackground
         )
     }
-
-//        )
-//    }
 }
 
 private extension MessageBubble {

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -74,12 +74,18 @@ struct MessageBubble<Content: View>: View {
                 }
             }
 
-            content
+            if case .fixedSize = layout {
+                content
+                    .frame(height: 36, alignment: .center)
+                    .clipped()
+            } else {
+                content
+            }
 
             Text("25.02.01")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.gray.opacity(0.8))
-                .frame(alignment: .trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(.vertical, 15)
         .padding(.horizontal, 15)

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -7,13 +7,6 @@
 
 import SwiftUI
 
-/// 1) 버블 내부 텍스트 rotate 기능 지원 X 시
-///     - placeName 있을 수도 / 없을 수도
-///     - 좌측 라인 visible
-/// 2) 버블 내부 텍스트 rotate 기능 지원 O 시
-///     - placeName 항상 있음
-///     - 좌측 라인 invisible
-
 enum MessageStatusIndicator {
     case none
     case recent
@@ -22,11 +15,12 @@ enum MessageStatusIndicator {
 
 enum BubbleLayout {
     case flexible      // 단일 메시지
-    case fixedWidth(CGFloat)    // 회전 메시지
+    case fixedSize(CGFloat)    // 회전 메시지
 }
 
 struct MessageBubble<Content: View>: View {
     let placeName: String?
+    let createdAt: Date?
     let statusIndicator: MessageStatusIndicator
     let layout: BubbleLayout
     let content: Content
@@ -35,11 +29,13 @@ struct MessageBubble<Content: View>: View {
 
     init(
         placeName: String?,
+        createdAt: Date = .init(timeIntervalSince1970: 0),
         statusIndicator: MessageStatusIndicator,
         layout: BubbleLayout,
         @ViewBuilder content: () -> Content
     ) {
         self.placeName = placeName
+        self.createdAt = createdAt
         self.statusIndicator = statusIndicator
         self.layout = layout
         self.content = content()
@@ -57,46 +53,61 @@ struct MessageBubble<Content: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            // 왼쪽 세로 라인
-            Capsule()
-                .fill(statusIndicatorColor)
-                .frame(width: 3)
-                .padding(.vertical, 11)
+        //        HStack(alignment: .top, spacing: 10) {
+        // 왼쪽 세로 라인
+        //            Capsule()
+        //                .fill(statusIndicatorColor)
+        //                .frame(width: 3)
+        //                .padding(.vertical, 11)
 
-            VStack(alignment: .leading, spacing: 6) {
-                // 장소 태그 (옵셔널)
-                if let placeName, !placeName.isEmpty {
-                    HStack(spacing: 4) {
-                        Image(systemName: "mappin.and.ellipse")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#53808C"))
+        VStack(alignment: .leading, spacing: 6) {
+            // 장소 태그 (옵셔널)
+            if let placeName, !placeName.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#53808C"))
 
-                        Text(placeName)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(Color.gray.opacity(0.8))
-                    }
+                    Text(placeName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.gray.opacity(0.8))
                 }
-
-                content
             }
-            .padding(.vertical, 13)
-            .padding(.trailing, 13)
+
+            content
+
+            Text("25.02.01")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.gray.opacity(0.8))
+                .frame(alignment: .trailing)
         }
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color.white)
-                .shadow(color: .black.opacity(0.06),
-                        radius: 12,
-                        x: 0,
-                        y: 6)
+        .padding(.vertical, 15)
+        .padding(.horizontal, 15)
+        .applyLayout(
+            layout,
+            maxWidth: maxWidth,
+            background: bubbleBackground
         )
-        .applyLayout(layout, maxWidth: maxWidth)
+    }
+
+//        )
+//    }
+}
+
+private extension MessageBubble {
+    var bubbleBackground: some View {
+        RoundedRectangle(cornerRadius: 22, style: .continuous)
+            .fill(Color.white)
+            .shadow(color: .black.opacity(0.06),
+                    radius: 12,
+                    x: 0,
+                    y: 6)
     }
 }
 
 struct BubbleText: View {
     let text: String
+    var maxWidth: CGFloat? = 190
 
     var body: some View {
         // 본문 (최대 2줄)
@@ -106,6 +117,12 @@ struct BubbleText: View {
             .lineLimit(2)
             .multilineTextAlignment(.leading)
             .fixedSize(horizontal: false, vertical: true)
+            .frame(
+                idealWidth: nil,
+                maxWidth: maxWidth,
+                alignment: .leading
+            )
+            .clampMaxHeight(50)
     }
 }
 
@@ -113,47 +130,85 @@ struct BubbleText: View {
 
 private extension View {
     @ViewBuilder
-    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat) -> some View {
-        switch layout {
-        case .flexible:
-            self
-                .frame(maxWidth: maxWidth, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
+    func applyLayout(_ layout: BubbleLayout, maxWidth: CGFloat, background: some View) -> some View {
+        Group {
+            switch layout {
+            case .flexible:
+                self
+                    .frame(
+                        maxWidth: maxWidth,
+                        alignment: .leading
+                    )
+                    .fixedSize(horizontal: true, vertical: false)
 
-        case .fixedWidth(let fixedSize):
-            self
-                .frame(width: fixedSize, height: 82, alignment: .leading)
+            case .fixedSize(let fixedSize):
+                self
+                    .frame(
+                        width: fixedSize,
+                        height: 98,
+                        alignment: .leading
+                    )
+            }
         }
+        .background(background)
     }
 }
+
+// MARK: - Preview
 
 #Preview {
     ZStack {
         Color.gray.opacity(0.15).ignoresSafeArea()
 
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(".flexible (단일 버블)")
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .normal,
+                statusIndicator: .none,
                 layout: .flexible
             ) {
-                BubbleText(text: "오늘 좀 춥다🫥🍃")
+                BubbleText(text: "[한줄] 오늘 좀 춥다🫥🍃")
             }
 
             MessageBubble(
                 placeName: "장소 이름",
                 statusIndicator: .none,
-                layout: .fixedWidth(170)
+                layout: .flexible
+            ) {
+                BubbleText(text: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃")
+            }
+
+            MessageBubble(
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .flexible
+            ) {
+                BubbleText(text: "[두줄] 이건 30자 메시지에요 재밌죠 나는 자고싶어요")
+            }
+
+            Text(".fixedSize(170) (회전 버블)")
+            MessageBubble(
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .fixedSize(170)
             ) {
                 BubbleText(text: "🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥")
             }
 
             MessageBubble(
-                placeName: nil,
-                statusIndicator: .recent,
-                layout: .flexible
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .fixedSize(170)
             ) {
-                BubbleText(text: "최근에 남긴 따끈따끈한 메시지라서 주황색 라인으로 표시")
+                BubbleText(text: "dkfdkkdkdksdjkfskdlsjkd")
+            }
+
+            MessageBubble(
+                placeName: "장소 이름",
+                statusIndicator: .none,
+                layout: .fixedSize(170)
+            ) {
+                BubbleText(text: "dkfdkkdlsjkd")
             }
         }
     }

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -7,12 +7,6 @@
 
 import SwiftUI
 
-enum MessageStatusIndicator {
-    case none
-    case recent
-    case normal
-}
-
 enum BubbleLayout {
     case flexible      // 단일 메시지
     case fixedSize(CGFloat)    // 회전 메시지
@@ -21,7 +15,6 @@ enum BubbleLayout {
 struct MessageBubble<Content: View>: View {
     let placeName: String?
     let createdAt: Date?
-    let statusIndicator: MessageStatusIndicator
     let layout: BubbleLayout
     let content: Content
 
@@ -30,26 +23,13 @@ struct MessageBubble<Content: View>: View {
     init(
         placeName: String?,
         createdAt: Date = .init(timeIntervalSince1970: 0),
-        statusIndicator: MessageStatusIndicator,
         layout: BubbleLayout,
         @ViewBuilder content: () -> Content
     ) {
         self.placeName = placeName
         self.createdAt = createdAt
-        self.statusIndicator = statusIndicator
         self.layout = layout
         self.content = content()
-    }
-
-    private var statusIndicatorColor: Color {
-        switch statusIndicator {
-        case .none:
-            return .clear
-        case .recent:
-            return .orange
-        case .normal:
-            return .blue
-        }
     }
 
     var body: some View {
@@ -160,7 +140,6 @@ private extension View {
             Text(".flexible (단일 버블)")
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .flexible
             ) {
                 BubbleText(text: "[한줄] 오늘 좀 춥다🫥🍃")
@@ -168,7 +147,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .flexible
             ) {
                 BubbleText(text: "[두줄] 오늘 좀 asfrfrfasxscscscs춥다🫥🍃")
@@ -176,7 +154,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .flexible
             ) {
                 BubbleText(text: "[두줄] 이건 30자 메시지에요 재밌죠 나는 자고싶어요")
@@ -185,7 +162,6 @@ private extension View {
             Text(".fixedSize(170) (회전 버블)")
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .fixedSize(170)
             ) {
                 BubbleText(text: "🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥🫥")
@@ -193,7 +169,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .fixedSize(170)
             ) {
                 BubbleText(text: "dkfdkkdkdksdjkfskdlsjkd")
@@ -201,7 +176,6 @@ private extension View {
 
             MessageBubble(
                 placeName: "장소 이름",
-                statusIndicator: .none,
                 layout: .fixedSize(170)
             ) {
                 BubbleText(text: "dkfdkkdlsjkd")

--- a/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/MessageBubble.swift
@@ -35,42 +35,41 @@ struct MessageBubble<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            // 장소 태그 (옵셔널)
-            if let locationName = message.displayLocationName {
-                HStack(spacing: 4) {
-                    Image(systemName: "mappin.and.ellipse")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color(hex: "#53808C"))
-
-                    Text(locationName)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color.gray.opacity(0.8))
-                }
-            }
+            locationPart
 
             bodyPart
 
-            Divider()
-                .background(Color.black.opacity(0.8))
-                .padding(.top, 2)
-
-            Text(message.displayDateString)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.gray.opacity(0.8))
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .padding(.top, -2)
+            datePart
         }
-        .padding(.vertical, 10)
+        .padding(.vertical, 9)
         .padding(.horizontal, 12)
         .applyLayout(
             layout,
             maxWidth: maxWidth
         )
         .background(bubbleBackground)
+        .overlay(alignment: .bottomLeading) {
+            dividerOverlay
+        }
     }
 }
 
 private extension MessageBubble {
+    @ViewBuilder
+    var locationPart: some View {
+        if let locationName = message.displayLocationName {
+            HStack(spacing: 4) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#53808C"))
+
+                Text(locationName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.gray.opacity(0.8))
+            }
+        }
+    }
+
     @ViewBuilder
     var bodyPart: some View {
         let bodyView = content(message)
@@ -84,6 +83,14 @@ private extension MessageBubble {
         }
     }
 
+    var datePart: some View {
+        Text(message.displayDateString)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Color.gray.opacity(0.8))
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.top, 5)
+    }
+
     var bubbleBackground: some View {
         RoundedRectangle(cornerRadius: 22, style: .continuous)
             .fill(Color.white)
@@ -91,6 +98,14 @@ private extension MessageBubble {
                     radius: 12,
                     x: 0,
                     y: 6)
+    }
+
+    var dividerOverlay: some View {
+        Rectangle()
+            .fill(Color.black.opacity(0.8))
+            .frame(height: 1 / UIScreen.main.scale)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 29)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/RotatingTextStack.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/RotatingTextStack.swift
@@ -17,7 +17,7 @@ struct RotatingTextStack: View {
     private let movingArea: CGFloat = 16    // 움직일 거리
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack(alignment: .center) {
             if progress > 0 {
                 BubbleText(text: nextText)
                     .opacity(progress)
@@ -28,7 +28,7 @@ struct RotatingTextStack: View {
                 .opacity(1 - progress)
                 .offset(y: -progress * movingArea)
         }
-        .frame(maxHeight: textAreaHeight, alignment: .top)
+        .frame(maxHeight: textAreaHeight, alignment: .center)
         .clipped()
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
@@ -35,7 +35,8 @@ extension MapStore {
             coordinate: .init(
                 latitude: 37.5720,
                 longitude: 126.9760
-            )
+            ),
+            address: "서판교로29"
         )
 
         let group1 = [
@@ -44,6 +45,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-3 * 60),
                 content: "따뜻한 바람 지나가요🍃",
                 coordinate: .init(latitude: 37.5720, longitude: 126.9760),
+                address: "서판교로29",
                 placeTag: place1
             ),
             Message(
@@ -51,6 +53,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-12 * 60),
                 content: "공연 리허설 소리 들린다🎻",
                 coordinate: .init(latitude: 37.5720, longitude: 126.9760),
+                address: "서판교로29",
                 placeTag: place1
             )
         ]
@@ -63,7 +66,8 @@ extension MapStore {
             coordinate: .init(
                 latitude: 37.5712,
                 longitude: 126.9780
-            )
+            ),
+            address: "서판교로29"
         )
 
         let group2 = [
@@ -72,6 +76,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-8 * 60),
                 content: "햇살이 광장 위에 내려앉았어요☀️",
                 coordinate: .init(latitude: 37.5712, longitude: 126.9780),
+                address: "서판교로29",
                 placeTag: place2
             ),
             Message(
@@ -79,6 +84,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-50 * 60),
                 content: "차분한 아침 분위기 좋다",
                 coordinate: .init(latitude: 37.5712, longitude: 126.9780),
+                address: "서판교로29",
                 placeTag: place2
             )
         ]
@@ -90,7 +96,8 @@ extension MapStore {
             coordinate: .init(
                 latitude: 37.5730,
                 longitude: 126.9770
-            )
+            ),
+            address: "서판교로29"
         )
 
         let group3 = [
@@ -99,6 +106,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-6 * 60),
                 content: "벽에 스치는 바람 소리가 좋다🍃",
                 coordinate: .init(latitude: 37.5730, longitude: 126.9770),
+                address: "서판교로29",
                 placeTag: place3
             ),
             Message(
@@ -106,6 +114,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-2 * 60 * 60),
                 content: "발자국 소리가 멀리 울려요",
                 coordinate: .init(latitude: 37.5730, longitude: 126.9770),
+                address: "서판교로29",
                 placeTag: place3
             )
         ]
@@ -117,6 +126,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-40 * 60),
                 content: "벤치에 앉아 잠깐 쉬어요",
                 coordinate: .init(latitude: 37.5698, longitude: 126.9775),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -124,6 +134,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-1 * 60 * 60),
                 content: "따뜻한 커피 향이 지나간다☕️",
                 coordinate: .init(latitude: 37.5704, longitude: 126.9766),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -131,6 +142,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-3 * 60 * 60),
                 content: "멀리서 버스 브레이크 소리🚍",
                 coordinate: .init(latitude: 37.5718, longitude: 126.9792),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -138,6 +150,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-20 * 60),
                 content: "바닥에 그림자가 길게 늘어져요🌒",
                 coordinate: .init(latitude: 37.5728, longitude: 126.9756),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -145,6 +158,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-15 * 60),
                 content: "누군가 웃는 소리 지나갔다🙂",
                 coordinate: .init(latitude: 37.5709, longitude: 126.9786),
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -152,6 +166,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-10 * 60 * 60),
                 content: "새벽 공기가 차갑고 맑다🌙",
                 coordinate: .init(latitude: 37.5692, longitude: 126.9798),
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -183,7 +198,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case1] Place1 NoPlace0",
-            coordinate: .init(latitude: lat, longitude: lng)
+            coordinate: .init(latitude: lat, longitude: lng),
+            address: "서판교로29"
         )
 
         return [
@@ -192,6 +208,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-5 * 60),
                 content: "[Case1] Place 1개만 있는 단일 UI",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             )
         ]
@@ -209,6 +226,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-25 * 60),
                 content: "[Case2] NoPlace 1개만 있는 단일 UI",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -223,7 +241,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case3] Place2+ NoPlace0",
-            coordinate: .init(latitude: lat, longitude: lng)
+            coordinate: .init(latitude: lat, longitude: lng),
+            address: "서판교로29"
         )
 
         return [
@@ -232,6 +251,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-3 * 60),
                 content: "[Case3] Place 로테이션 메시지 1",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -239,6 +259,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-10 * 60),
                 content: "[Case3] Place 로테이션 메시지 2",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -246,6 +267,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-20 * 60),
                 content: "[Case3] Place 로테이션 메시지 3",
                 coordinate: .init(latitude: lat, longitude: lng),
+                address: "서판교로29",
                 placeTag: place
             )
         ]
@@ -264,6 +286,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-7 * 60),
                 content: "[Case4] NoPlace 스택 메시지 1",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -271,6 +294,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-30 * 60),
                 content: "[Case4] NoPlace 스택 메시지 2",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -278,6 +302,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-45 * 60),
                 content: "[Case4] NoPlace 스택 메시지 3",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -293,7 +318,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case5] Place1 NoPlace1",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -302,6 +328,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-4 * 60),
                 content: "[Case5] Place 단일 메시지",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -309,6 +336,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-35 * 60),
                 content: "[Case5] NoPlace 단일 메시지 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -324,7 +352,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case6] Place2 NoPlace1",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -333,6 +362,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-2 * 60),
                 content: "[Case6] Place 로테이션 1",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -340,6 +370,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-18 * 60),
                 content: "[Case6] Place 로테이션 2",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -347,6 +378,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-55 * 60),
                 content: "[Case6] NoPlace 단일 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -362,7 +394,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case7] Place1 NoPlace2+",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -371,6 +404,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-9 * 60),
                 content: "[Case7] Place 단일 메시지",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -378,6 +412,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-22 * 60),
                 content: "[Case7] NoPlace 스택 1 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -385,6 +420,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-48 * 60),
                 content: "[Case7] NoPlace 스택 2 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -392,6 +428,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-1.5 * 60 * 60),
                 content: "[Case7] NoPlace 스택 3 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
@@ -407,7 +444,8 @@ extension MapStore {
         let place = Place(
             id: .init(value: ""),
             name: "[Case8] Place2+ NoPlace2+",
-            coordinate: location
+            coordinate: location,
+            address: "서판교로29"
         )
 
         return [
@@ -417,6 +455,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-6 * 60),
                 content: "[Case8] Place 로테이션 1",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -424,6 +463,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-28 * 60),
                 content: "[Case8] Place 로테이션 2",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             Message(
@@ -431,6 +471,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-1 * 60 * 60),
                 content: "[Case8] Place 로테이션 3",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: place
             ),
             // NoPlace 메시지들 (스택)
@@ -439,6 +480,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-14 * 60),
                 content: "[Case8] NoPlace 스택 1 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -446,6 +488,7 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-38 * 60),
                 content: "[Case8] NoPlace 스택 2 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             ),
             Message(
@@ -453,9 +496,9 @@ extension MapStore {
                 createdAt: Date().addingTimeInterval(-2 * 60 * 60),
                 content: "[Case8] NoPlace 스택 3 (offset)",
                 coordinate: location,
+                address: "서판교로29",
                 placeTag: nil
             )
         ]
     }
 }
-

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore+dummy.swift
@@ -131,6 +131,14 @@ extension MapStore {
             ),
             Message(
                 id: MessageID(value: UUID()),
+                createdAt: Date().addingTimeInterval(-40 * 60),
+                content: "페이드인 되고 있어?",
+                coordinate: .init(latitude: 37.5665, longitude: 126.9780),
+                address: "서판교로29",
+                placeTag: nil
+            ),
+            Message(
+                id: MessageID(value: UUID()),
                 createdAt: Date().addingTimeInterval(-1 * 60 * 60),
                 content: "따뜻한 커피 향이 지나간다☕️",
                 coordinate: .init(latitude: 37.5704, longitude: 126.9766),

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -297,6 +297,15 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         self.onCameraChangedByLocation = onCameraChangedByLocation
     }
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator {
+        var lastMessagesSnapshot: Int?
+        var didInitialLoad = false
+    }
+
     func makeUIViewController(context: Context) -> MapViewController {
         let viewController = MapViewController(
             messageMarkerManager: messageMarkerManager,
@@ -306,13 +315,33 @@ struct MapViewWrapper: UIViewControllerRepresentable {
             onCameraChangedByLocation: onCameraChangedByLocation
         )
 
+        // 초기 1회 loadMessages() 호출
         viewController.loadMessages(messages)
         viewController.updateUserLocation(userLocation)
+
+        context.coordinator.lastMessagesSnapshot = messagesSnapshot(messages)
+        context.coordinator.didInitialLoad = true
 
         return viewController
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
+        let snap = messagesSnapshot(messages)
+
+        // 동일 메시지인 경우 loadMessages() 호출 X
+        guard context.coordinator.lastMessagesSnapshot != snap else { return }
+
+        context.coordinator.lastMessagesSnapshot = snap
         uiViewController.loadMessages(messages)
+    }
+
+    private func messagesSnapshot(_ messages: [Message]) -> Int {
+        var hasher = Hasher()
+
+        for message in messages {
+            hasher.combine(message.id)
+        }
+
+        return hasher.finalize()
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -31,7 +31,6 @@ final class BubbleImageRenderer {
     ) -> UIImage {
         let bubble = MessageBubble(
             placeName: message.placeTag?.name,
-            statusIndicator: showsAccentLine ? (message.isRecent() ? .recent : .normal) : .none,
             layout: showsAccentLine ? .flexible : .fixedSize(rotatingBubbleWidth)
         ) {
             BubbleText(text: message.content)
@@ -54,7 +53,6 @@ final class BubbleImageRenderer {
     ) -> UIImage {
         let bubble = MessageBubble(
             placeName: current.placeTag?.name,
-            statusIndicator: .none,
             layout: .fixedSize(rotatingBubbleWidth)
         ) {
             RotatingTextStack(

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -26,15 +26,13 @@ final class BubbleImageRenderer {
     func renderSingleBubble(
         message: Message,
         scale: CGFloat? = nil
-    ) -> UIImage {
+    ) async -> UIImage {
         let bubble = MessageBubble(
             message: message,
             layout: .flexible
         )
 
-        print("renderSingleBubble: \(message.content)")
-
-        return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
+        return await render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
 
     /// 애니메이션 진행도에 따른 회전 버블의 이미지를 렌더링합니다.
@@ -60,9 +58,7 @@ final class BubbleImageRenderer {
             )
         }
 
-        print("renderRotatingBubble: \(current.content)")
-
-        return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
+        return await render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
 
     /// 스택 버블 이미지를 렌더링합니다.
@@ -72,15 +68,17 @@ final class BubbleImageRenderer {
     func renderStackBubble(
         messages: [Message],
         scale: CGFloat? = nil
-    ) -> UIImage {
+    ) async -> UIImage {
         // TODO: MessageStackBubble 구현 후 교체
         guard let first = messages.first else { return UIImage() }
-        return renderSingleBubble(message: first, scale: scale)
+        return await renderSingleBubble(message: first, scale: scale)
     }
 }
 
 extension BubbleImageRenderer {
-    private func render<V: View>(view: V, scale: CGFloat) -> UIImage {
+    private func render<V: View>(view: V, scale: CGFloat) async -> UIImage {
+        await Task.yield()
+
         let renderer = ImageRenderer(content: view)
         renderer.scale = scale
         renderer.isOpaque = false

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -46,7 +46,7 @@ final class BubbleImageRenderer {
         next: Message,
         progress: Double,
         scale: CGFloat? = nil
-    ) -> UIImage {
+    ) async -> UIImage {
         let bubble = MessageBubble(
             message: current,
             layout: .fixedSize(rotatingBubbleWidth)

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -22,19 +22,17 @@ final class BubbleImageRenderer {
     /// 단일 메시지 버블 이미지를 렌더링합니다.
     /// - Parameters:
     ///   - message: 렌더링할 메시지
-    ///   - showsAccentLine: 좌측 상태 라인 표시 여부
     ///   - scale: 렌더링 스케일 (nil이면 화면 스케일 사용)
     func renderSingleBubble(
         message: Message,
-        showsAccentLine: Bool,
         scale: CGFloat? = nil
     ) -> UIImage {
         let bubble = MessageBubble(
-            placeName: message.placeTag?.name,
-            layout: showsAccentLine ? .flexible : .fixedSize(rotatingBubbleWidth)
-        ) {
-            BubbleText(text: message.content)
-        }
+            message: message,
+            layout: .flexible
+        )
+
+        print("renderSingleBubble: \(message.content)")
 
         return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
@@ -52,15 +50,17 @@ final class BubbleImageRenderer {
         scale: CGFloat? = nil
     ) -> UIImage {
         let bubble = MessageBubble(
-            placeName: current.placeTag?.name,
+            message: current,
             layout: .fixedSize(rotatingBubbleWidth)
-        ) {
+        ) { _ in
             RotatingTextStack(
                 currentText: current.content,
                 nextText: next.content,
                 progress: progress
             )
         }
+
+        print("renderRotatingBubble: \(current.content)")
 
         return render(view: bubble.padding(4), scale: scale ?? UIScreen.main.scale)
     }
@@ -75,7 +75,7 @@ final class BubbleImageRenderer {
     ) -> UIImage {
         // TODO: MessageStackBubble 구현 후 교체
         guard let first = messages.first else { return UIImage() }
-        return renderSingleBubble(message: first, showsAccentLine: true, scale: scale)
+        return renderSingleBubble(message: first, scale: scale)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/BubbleImageRenderer.swift
@@ -32,7 +32,7 @@ final class BubbleImageRenderer {
         let bubble = MessageBubble(
             placeName: message.placeTag?.name,
             statusIndicator: showsAccentLine ? (message.isRecent() ? .recent : .normal) : .none,
-            layout: showsAccentLine ? .flexible : .fixedWidth(rotatingBubbleWidth)
+            layout: showsAccentLine ? .flexible : .fixedSize(rotatingBubbleWidth)
         ) {
             BubbleText(text: message.content)
         }
@@ -55,7 +55,7 @@ final class BubbleImageRenderer {
         let bubble = MessageBubble(
             placeName: current.placeTag?.name,
             statusIndicator: .none,
-            layout: .fixedWidth(rotatingBubbleWidth)
+            layout: .fixedSize(rotatingBubbleWidth)
         ) {
             RotatingTextStack(
                 currentText: current.content,

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -294,7 +294,9 @@ extension MessageMarkerManager {
             if animationStates[key] == nil {
                 let messagesProvider: () -> [Message] = { [weak self] in
                     guard let self else { return [] }
-                    let source = isPlace ? self.placeMessagesByCoord[coordinate] : self.noPlaceMessagesByCoord[coordinate]
+                    let source = isPlace
+                        ? self.placeMessagesByCoord[coordinate]
+                        : self.noPlaceMessagesByCoord[coordinate]
                     return Array((source ?? []).suffix(self.displayLimit))
                 }
 
@@ -523,15 +525,13 @@ extension MessageMarkerManager {
         let signature = makeRenderSignature(markerType: markerType, messages: messages)
 
         // 3-2. 기존 마커가 있고, 시그니처가 동일하면 아이콘 렌더 스킵
-        if let marker = markers[key], lastRenderedSignature[key] == signature { return }
+        if let _ = markers[key], lastRenderedSignature[key] == signature { return }
 
         // 시그니처 갱신
         lastRenderedSignature[key] = signature
 
         // 4. 초기 이미지 렌더 (key 기준 검증 + Task 누적 방지)
         scheduleInitialRender(for: key, marker: marker, markerType: markerType)
-
-
     }
 
     /// 마커를 지도에서 제거하고 저장소에서 삭제합니다.
@@ -620,15 +620,18 @@ extension MessageMarkerManager {
             // 메시지가 2개 미만이면 애니메이션 불필요
             guard state.messages.count > 1 else { continue }
             // 해당 마커가 없으면 스킵
-            guard let marker = markers[groupKey] else { continue }
+            guard markers[groupKey] != nil else { continue }
 
             if state.isAnimating {
                 // 애니메이션 진행 중: 진행률 업데이트
                 rotationAnimator.updateAnimation(for: &state, currentTime: currentTime)
 
+                let current = state.currentMessage
+                let next = state.nextMessage
+                let progress = state.animationProgress
+
                 // 현재/다음 메시지로 회전 이미지 렌더링
-                if let current = state.currentMessage,
-                    let next = state.nextMessage {
+                if let current, let next {
 
                     // 기존 렌더 취소 (프레임 누적 방지)
                     renderTasks[groupKey]?.cancel()
@@ -640,7 +643,7 @@ extension MessageMarkerManager {
                         let image = await bubbleImageRenderer.renderRotatingBubble(
                             current: current,
                             next: next,
-                            progress: state.animationProgress
+                            progress: progress
                         )
 
                         guard !Task.isCancelled else { return }

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -366,7 +366,7 @@ extension MessageMarkerManager {
         switch markerType {
         case .singleBubble(let message):
             // 메시지 1개: 최신 표시 accent line + 단일 버블
-            image = bubbleImageRenderer.renderSingleBubble(message: message, showsAccentLine: true)
+            image = bubbleImageRenderer.renderSingleBubble(message: message)
 
         case .rotatingBubble(let messages), .stackBubble(let messages):
             // 메시지 2개 이상: 첫 번째 메시지로 초기 이미지
@@ -377,7 +377,7 @@ extension MessageMarkerManager {
                 break
             }
 
-            image = bubbleImageRenderer.renderSingleBubble(message: firstMessage, showsAccentLine: false)
+            image = bubbleImageRenderer.renderSingleBubble(message: firstMessage)
         }
 
         marker.iconImage = NMFOverlayImage(image: image)

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -9,6 +9,20 @@ import UIKit
 
 import NMapsMap
 
+enum MarkerPlaceholder {
+    static let transparent1px: UIImage = {
+        let size = CGSize(width: 1, height: 1)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        defer { UIGraphicsEndImageContext() }
+
+        return UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
+    }()
+
+    static let overlayImage: NMFOverlayImage = {
+        NMFOverlayImage(image: transparent1px)
+    }()
+}
+
 // MARK: - MessageMarkerManager
 
 /// 지도 위 메시지 마커의 생성, 업데이트, 애니메이션을 관리하는 객체입니다.
@@ -19,13 +33,16 @@ import NMapsMap
 /// noPlaceMessagesByCoord: [좌표: [장소 태그가 없는 메시지들]]
 /// markers: [마커키: 네이버맵 마커]
 /// animationStates: [마커키: 애니메이션 상태]
+/// renderTasks: [마커키: 렌더링 Task] (누적 방지, 최신만 반영)
+/// fadeTasks:   [마커키: 페이드 Task] (페이드 애니메이션 중복 방지)
+/// hasFadedIn:  Set<마커키> (마커별 최초 1회 페이드 적용 여부)
 /// ```
 ///
 /// ## 사용 흐름
 /// ```
 /// 1. loadMessages() -> 초기 메시지 로딩 (전체 마커 생성)
-/// 2. handleEvent() -> 실시간 이벤트 처리 (해당 좌표만 업데이트)
-/// 3. updateAnimations() -> 매 프레임 애니메이션 업데이트 (60fps)
+/// 2. handleEvent() -> 실시간 이벤트 처리 (해당 좌표의 마커/상태 갱신 + 필요 시 아이콘 재렌더)
+/// 3. updateAnimations() -> 애니메이션 대상 마커는 매 프레임 iconImage 갱신 (60fps)
 /// ```
 @MainActor
 final class MessageMarkerManager {
@@ -44,6 +61,15 @@ final class MessageMarkerManager {
 
     /// 한 마커에 표시할 최대 메시지 수 (기본값: 10)
     private let displayLimit: Int
+
+    /// 마커별 렌더링 Task (누적 방지, 최신만 반영)
+    private var renderTasks: [MarkerGroupKey: Task<Void, Never>] = [:]
+
+    /// 페이드 관리용 Task
+    private var fadeTasks: [MarkerGroupKey: Task<Void, Never>] = [:]
+
+    /// 마커 페이드인 여부 상태 플래그
+    private var hasFadedIn: Set<MarkerGroupKey> = []
 
     // MARK: - Dependencies
 
@@ -65,11 +91,17 @@ final class MessageMarkerManager {
 
 extension MessageMarkerManager {
     /// 네이버맵 마커 객체를 생성합니다.
+    ///  - 기본 핀 깜빡임 방지를 위해 투명 placeholder icon을 먼저 세팅하고,
+    ///  - 최초 1회는 렌더링 완료 후 페이드 인, 이후 갱신은 alpha = 1 유지한 채 iconImage만 교체
     private func makeMarker(at position: NMGLatLng, mapView: NMFMapView) -> NMFMarker {
         let marker = NMFMarker(position: position)
         marker.anchor = CGPoint(x: 0.5, y: 1.0)   // 마커 하단 중앙이 좌표 위치
         marker.zIndex = 1000                      // 다른 오버레이보다 위에 표시
         marker.isFlat = false                     // 3D 틸트 시에도 수직 유지
+
+        marker.iconImage = MarkerPlaceholder.overlayImage
+        marker.alpha = 0.0
+
         marker.mapView = mapView                  // 지도에 마커 표시
         return marker
     }
@@ -110,6 +142,8 @@ extension MessageMarkerManager {
         // 5. 저장된 메시지 기반으로 모든 마커 생성
         rebuildAllMarkers(mapView: mapView, onTapPlace: onTapPlace, onTapNoPlace: onTapNoPlace)
     }
+
+    // TODO: - handleEvent 정리 (실시간 이벤트 없으므로)
 
     /// 실시간 이벤트 처리 (메시지 추가/삭제 시 호출)
     /// - Parameters:
@@ -213,6 +247,9 @@ extension MessageMarkerManager {
     /// - 마커 딕셔너리 초기화
     /// - 애니메이션 상태 초기화
     /// - 메시지 저장소 초기화
+    /// - 진행 중인 렌더링 Task 취소 (누적 방지)
+    /// - fadeTasks 취소
+    /// - hasFadedIn 초기화
     private func clearAll() {
         // 지도에서 마커 제거
         for (_, marker) in markers {
@@ -222,6 +259,13 @@ extension MessageMarkerManager {
         animationStates.removeAll()
         placeMessagesByCoord.removeAll()
         noPlaceMessagesByCoord.removeAll()
+
+        for (_, task) in renderTasks { task.cancel() }
+        renderTasks.removeAll()
+
+        for (_, task) in fadeTasks { task.cancel() }
+        fadeTasks.removeAll()
+        hasFadedIn.removeAll()
     }
 }
 
@@ -291,7 +335,9 @@ extension MessageMarkerManager {
         )
     }
 
-    /// 단일 마커를 생성하거나 업데이트합니다.
+    /// 단일 마커가 없으면 생성하거나 있으면 재사용하고,
+    /// 메시지 상태에 따라 아이콘을 비동기로 렌더링하여 갱신합니다.
+    /// (메시지가 없으면 markerType이 nil이므로 아이콘 갱신 없이 종료됩니다.)
     private func updateMarker(
         coord: Coordinate,
         isPlace: Bool,
@@ -301,20 +347,28 @@ extension MessageMarkerManager {
         // 마커 식별 키 생성
         let key = MarkerGroupKey(coordinate: coord, isPlace: isPlace)
 
-        // 1. 기존 마커 제거 (있다면)
-        removeMarker(for: key)
+        AppLog.debug("updateMarker key=\(key) count(place)=\(placeMessagesByCoord[coord]?.count ?? 0) count(noPlace)=\(noPlaceMessagesByCoord[coord]?.count ?? 0)", category: .location)
+
+        // 1. 기존 마커가 있다면 그대로 쓰고, 없으면 새로 만들기
+        let marker: NMFMarker
+        if let existing = markers[key] {
+            marker = existing
+        } else {
+            marker = createMarker(at: coord, mapView: mapView)
+            markers[key] = marker
+        }
 
         // 2. 메시지 조회 (최신 displayLimit개만)
         let messagesInCoord = isPlace ? placeMessagesByCoord[coord] : noPlaceMessagesByCoord[coord]
         let messages = Array((messagesInCoord ?? []).suffix(displayLimit))
 
         // 3. MarkerType 결정 (메시지가 없으면 nil -> 마커 생성 안 함)
-        guard let markerType = MarkerType.from(messages: messages, isPlace: isPlace) else { return }
+        guard let markerType = MarkerType.from(messages: messages, isPlace: isPlace) else {
+            removeMarker(for: key)
+            return
+        }
 
-        // 4. 마커 생성 (타입에 맞는 이미지로)
-        let marker = createMarker(for: markerType, at: coord, mapView: mapView)
-
-        // 5. 탭 핸들러 등록
+        // 4. 탭 핸들러 등록 (위에서 만든 마커 재사용)
         // - 탭 시점의 최신 메시지를 조회하여 콜백에 전달
         marker.touchHandler = { [weak self] _ in
             guard let self else { return true }
@@ -323,10 +377,10 @@ extension MessageMarkerManager {
             return true
         }
 
-        // 6. 마커 저장
-        markers[key] = marker
+        // 5. 초기 이미지 렌더 (key 기준 검증 + Task 누적 방지)
+        scheduleInitialRender(for: key, marker: marker, markerType: markerType)
 
-        // 7. 회전 애니메이션 상태 등록 (rotatingBubble 또는 stackBubble인 경우)
+        // 6. 회전 애니메이션 상태 등록 (rotatingBubble 또는 stackBubble인 경우)
         switch markerType {
         case .rotatingBubble, .stackBubble:
             let messagesProvider: () -> [Message] = { [weak self] in
@@ -349,39 +403,59 @@ extension MessageMarkerManager {
         markers[key]?.mapView = nil           // 지도에서 제거
         markers.removeValue(forKey: key)      // 마커 딕셔너리에서 삭제
         animationStates.removeValue(forKey: key)  // 애니메이션 상태 삭제
+
+        renderTasks[key]?.cancel()
+        renderTasks.removeValue(forKey: key)
+
+        fadeTasks[key]?.cancel()
+        fadeTasks.removeValue(forKey: key)
+
+        hasFadedIn.remove(key)
     }
 
     /// MarkerType에 맞는 마커를 생성하고 이미지를 설정합니다.
     private func createMarker(
-        for markerType: MarkerType,
         at coord: Coordinate,
         mapView: NMFMapView
     ) -> NMFMarker {
         let position = NMGLatLng(lat: coord.latitude, lng: coord.longitude)
-        let marker = makeMarker(at: position, mapView: mapView)
+        return makeMarker(at: position, mapView: mapView)
+    }
 
-        // MarkerType에 따라 다른 이미지 렌더링
-        let image: UIImage
+    private func scheduleInitialRender(
+        for key: MarkerGroupKey,
+        marker: NMFMarker,
+        markerType: MarkerType
+    ) {
+        // 기존 렌더 작업 취소 (최신만 반영)
+        renderTasks[key]?.cancel()
 
-        switch markerType {
-        case .singleBubble(let message):
-            // 메시지 1개: 최신 표시 accent line + 단일 버블
-            image = bubbleImageRenderer.renderSingleBubble(message: message)
+        renderTasks[key] = Task { @MainActor in
+            let image: UIImage
 
-        case .rotatingBubble(let messages), .stackBubble(let messages):
-            // 메시지 2개 이상: 첫 번째 메시지로 초기 이미지
-            // 악센트 라인 없음 (회전 중에는 표시 안 함)
-            // stackBubble도 임시로 rotatingBubble과 동일하게 처리 (추후 별도 UI 구현 예정)
-            guard let firstMessage = messages.first else {
-                image = UIImage()
-                break
+            switch markerType {
+            case .singleBubble(let message):
+                image = await bubbleImageRenderer.renderSingleBubble(message: message)
+
+            case .rotatingBubble(let messages), .stackBubble(let messages):
+                guard let first = messages.first else { return }
+                image = await bubbleImageRenderer.renderSingleBubble(message: first)
             }
 
-            image = bubbleImageRenderer.renderSingleBubble(message: firstMessage)
-        }
+            // 취소되었으면 적용 X
+            guard !Task.isCancelled else { return }
 
-        marker.iconImage = NMFOverlayImage(image: image)
-        return marker
+            // 아직 이 key의 현재 마커가 이 marker인지 확인
+            guard markers[key] === marker else { return }
+
+            if hasFadedIn.contains(key) {
+                marker.iconImage = NMFOverlayImage(image: image)
+                marker.alpha = 1.0
+            } else {
+                hasFadedIn.insert(key)
+                applyIconWithFade(image, to: marker, key: key)
+            }
+        }
     }
 }
 
@@ -391,8 +465,8 @@ extension MessageMarkerManager {
 
     /// 회전 애니메이션 상태를 업데이트합니다.
     ///
-    /// MapViewController의 타이머에서 매 프레임(60fps) 호출됩니다.
-    /// rotatingBubble 타입의 마커들에 대해 애니메이션을 처리합니다.
+    /// MapViewController의 타이머/디스플레이 링크에서 주기적으로(예: 60fps 주기) 호출됩니다.
+    /// rotatingBubble / stackBubble 타입(다중 메시지)의 마커들에 대해 애니메이션을 처리합니다.
     ///
     /// ## 애니메이션 흐름
     /// 1. 대기 중 -> rotationInterval(3초) 후 애니메이션 시작
@@ -417,12 +491,25 @@ extension MessageMarkerManager {
                 // 현재/다음 메시지로 회전 이미지 렌더링
                 if let current = state.currentMessage,
                     let next = state.nextMessage {
-                    let image = bubbleImageRenderer.renderRotatingBubble(
-                        current: current,
-                        next: next,
-                        progress: state.animationProgress
-                    )
-                    marker.iconImage = NMFOverlayImage(image: image)
+
+                    // 기존 렌더 취소 (프레임 누적 방지)
+                    renderTasks[groupKey]?.cancel()
+
+                    renderTasks[groupKey] = Task { @MainActor in
+                        // marker는 Task 안에서 다시 가져오도록 하기 (교체될 수 있으므로)
+                        guard let marker = self.markers[groupKey] else { return }
+
+                        let image = await bubbleImageRenderer.renderRotatingBubble(
+                            current: current,
+                            next: next,
+                            progress: state.animationProgress
+                        )
+
+                        guard !Task.isCancelled else { return }
+                        guard self.markers[groupKey] === marker else { return }
+
+                        marker.iconImage = NMFOverlayImage(image: image)
+                    }
                 }
             } else {
                 // 대기 중: 시작 시간 확인 후 애니메이션 시작
@@ -432,6 +519,35 @@ extension MessageMarkerManager {
             }
 
             animationStates[groupKey] = state
+        }
+    }
+
+    private func applyIconWithFade(
+        _ image: UIImage,
+        to marker: NMFMarker,
+        key: MarkerGroupKey,
+        duration: TimeInterval = 0.5,
+        fps: Double = 60
+    ) {
+        // 기존 페이드 작업 취소
+        fadeTasks[key]?.cancel()
+
+        // 아이콘은 먼저 교체
+        marker.iconImage = NMFOverlayImage(image: image)
+
+        // 시작은 투명
+        marker.alpha = 0.0
+
+        let totalFrames = max(1, Int(duration * fps))
+        let frameNanos = UInt64(1_000_000_000 / fps)
+
+        fadeTasks[key] = Task { @MainActor in
+            for i in 0...totalFrames {
+                if Task.isCancelled { return }
+                marker.alpha = CGFloat(Double(i) / Double(totalFrames))
+                try? await Task.sleep(nanoseconds: frameNanos)
+            }
+            marker.alpha = 1.0
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -23,6 +23,15 @@ enum MarkerPlaceholder {
     }()
 }
 
+private struct MarkerRenderSignature: Hashable {
+    enum Kind: Int, Hashable { case single, rotating, stack }
+
+    let kind: Kind
+    let firstMessageId: MessageID?      // 초기 아이콘에 쓰는 메시지(=single이면 그거, rotating/stack이면 first)
+    let count: Int                  // 표시 대상(messages: suffix(displayLimit)) 개수
+    let idsHash: Int                // 메시지 묶음 내용 변화 감지용
+}
+
 // MARK: - MessageMarkerManager
 
 /// 지도 위 메시지 마커의 생성, 업데이트, 애니메이션을 관리하는 객체입니다.
@@ -40,7 +49,7 @@ enum MarkerPlaceholder {
 ///
 /// ## 사용 흐름
 /// ```
-/// 1. loadMessages() -> 초기 메시지 로딩 (전체 마커 생성)
+/// 1. loadMessages() -> applySnapshot()으로 스토어 재구성 + diff 기반 마커 갱신
 /// 2. handleEvent() -> 실시간 이벤트 처리 (해당 좌표의 마커/상태 갱신 + 필요 시 아이콘 재렌더)
 /// 3. updateAnimations() -> 애니메이션 대상 마커는 매 프레임 iconImage 갱신 (60fps)
 /// ```
@@ -70,6 +79,8 @@ final class MessageMarkerManager {
 
     /// 마커 페이드인 여부 상태 플래그
     private var hasFadedIn: Set<MarkerGroupKey> = []
+
+    private var lastRenderedSignature: [MarkerGroupKey: MarkerRenderSignature] = [:]
 
     // MARK: - Dependencies
 
@@ -111,7 +122,7 @@ extension MessageMarkerManager {
 
     /// 초기 메시지 로딩 (앱 시작 또는 화면 진입 시 호출)
     ///
-    /// 기존 데이터를 모두 초기화하고 전달받은 메시지들로 마커를 새로 생성합니다.
+    /// 기존 상태(place/noPlace/markers) 대비 diff를 계산해 필요한 마커만 갱신합니다.
     /// Place 메시지를 먼저 저장한 후 NoPlace 메시지를 저장하여 좌표 겹침 시 오프셋을 적용합니다.
     ///
     /// - Parameters:
@@ -123,24 +134,12 @@ extension MessageMarkerManager {
         onTapPlace: ((Place) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
-        // 1. 기존 데이터 모두 제거
-        clearAll()
-
-        // 2. 메시지를 오래된 순으로 정렬 (suffix로 최신 N개를 가져오기 위함)
-        let sortedMessages = messages.sorted { $0.createdAt < $1.createdAt }
-
-        // 3. Place 메시지 먼저 저장 (좌표 확정)
-        for message in sortedMessages where message.placeTag != nil {
-            insertMessage(message)
-        }
-
-        // 4. NoPlace 메시지 저장 (Place 좌표와 겹치면 오프셋 적용)
-        for message in sortedMessages where message.placeTag == nil {
-            insertMessage(message)
-        }
-
-        // 5. 저장된 메시지 기반으로 모든 마커 생성
-        rebuildAllMarkers(mapView: mapView, onTapPlace: onTapPlace, onTapNoPlace: onTapNoPlace)
+        applySnapshot(
+            messages,
+            mapView: mapView,
+            onTapPlace: onTapPlace,
+            onTapNoPlace: onTapNoPlace
+        )
     }
 
     // TODO: - handleEvent 정리 (실시간 이벤트 없으므로)
@@ -169,6 +168,144 @@ extension MessageMarkerManager {
 
         // 2. 해당 좌표의 마커 업데이트
         updateMarkersForCoordinate(coord, mapView: mapView, onTapPlace: onTapPlace, onTapNoPlace: onTapNoPlace)
+    }
+}
+
+// MARK: - Diff
+extension MessageMarkerManager {
+    private func applySnapshot(
+        _ messages: [Message],
+        mapView: NMFMapView,
+        onTapPlace: ((Place) -> Void)?,
+        onTapNoPlace: (([Message]) -> Void)?
+    ) {
+        // 0) 이전 상태 기반 좌표 집합(Place + NoPlace)
+        let oldTotalCoordinates = Set(placeMessagesByCoord.keys).union(Set(noPlaceMessagesByCoord.keys))
+
+        // 1) 새 스토어를 로컬에서 구성
+        // - Place 먼저 저장 -> NoPlace 저장(Place 겹치면 offset 적용)
+        var newPlace: [Coordinate: [Message]] = [:]
+        var newNoPlace: [Coordinate: [Message]] = [:]
+
+        let sorted = messages.sorted { $0.createdAt < $1.createdAt }
+
+        // 1-1) Place
+        for message in sorted where message.placeTag != nil {
+            let coordinate = message.coordinate
+            newPlace[coordinate, default: []].append(message)
+        }
+
+        // 1-2) NoPlace (Place가 있는 좌표와 동일하면 offset 적용)
+        for message in sorted where message.placeTag == nil {
+            let originalCoordinate = message.coordinate
+            let displayCoordinate: Coordinate
+
+            if newPlace[originalCoordinate] != nil {
+                displayCoordinate = originalCoordinate.offset(for: message.id)
+            } else {
+                displayCoordinate = originalCoordinate
+            }
+            newNoPlace[displayCoordinate, default: []].append(message)
+        }
+
+        let newTotalCoordinates = Set(newPlace.keys).union(Set(newNoPlace.keys))
+
+        // 2) diff 계산
+        let removed = oldTotalCoordinates.subtracting(newTotalCoordinates)
+        let added = newTotalCoordinates.subtracting(oldTotalCoordinates)
+        let common = oldTotalCoordinates.intersection(newTotalCoordinates)
+
+        // 3) common 중 메시지 id 집합이 바뀐 coordinate만 추출
+        // (바뀐 coordinate만 updateMarkersForCoordinate 호출)
+        var changed: [Coordinate] = []
+        changed.reserveCapacity(common.count)
+
+        for coordinate in common {
+            let oldIDs = Set((placeMessagesByCoord[coordinate] ?? []).map { $0.id })
+                .union(Set((noPlaceMessagesByCoord[coordinate] ?? []).map { $0.id }))
+
+            let newIDs = Set((newPlace[coordinate] ?? []).map { $0.id })
+                .union(Set((newNoPlace[coordinate] ?? []).map { $0.id }))
+
+            if oldIDs != newIDs {
+                changed.append(coordinate)
+            }
+        }
+
+        // 4) 데이터 저장소 최신화 (updateMarkersForCoordinate가 새 데이터를 보도록)
+        placeMessagesByCoord = newPlace
+        noPlaceMessagesByCoord = newNoPlace
+
+        // 5) 지도에서 사라질 좌표의 마커 제거
+        for coordinate in removed {
+            removeMarker(for: MarkerGroupKey(coordinate: coordinate, isPlace: true))
+            removeMarker(for: MarkerGroupKey(coordinate: coordinate, isPlace: false))
+        }
+
+        // 6) added + changed 업데이트
+        for coordinate in added.union(Set(changed)) {
+            updateMarkersForCoordinate(
+                coordinate,
+                mapView: mapView,
+                onTapPlace: onTapPlace,
+                onTapNoPlace: onTapNoPlace
+            )
+        }
+    }
+
+    private func makeRenderSignature(
+        markerType: MarkerType,
+        messages: [Message]
+    ) -> MarkerRenderSignature {
+        let kind: MarkerRenderSignature.Kind
+        let firstId: MessageID?
+
+        switch markerType {
+        case .singleBubble(let message):
+            kind = .single
+            firstId = message.id
+        case .rotatingBubble(let messages):
+            kind = .rotating
+            firstId = messages.first?.id
+        case .stackBubble(let messages):
+            kind = .stack
+            firstId = messages.first?.id
+        }
+
+        let idsHash = idsHash(messages)
+
+        return MarkerRenderSignature(
+            kind: kind,
+            firstMessageId: firstId,
+            count: messages.count,
+            idsHash: idsHash
+        )
+    }
+
+    private func syncAnimationStateIfNeeded(
+        key: MarkerGroupKey,
+        markerType: MarkerType,
+        coordinate: Coordinate,
+        isPlace: Bool
+    ) {
+        // 회전 애니메이션 상태 정합성 확인 후 업데이트
+        switch markerType {
+        case .rotatingBubble, .stackBubble:
+            if animationStates[key] == nil {
+                let messagesProvider: () -> [Message] = { [weak self] in
+                    guard let self else { return [] }
+                    let source = isPlace ? self.placeMessagesByCoord[coordinate] : self.noPlaceMessagesByCoord[coordinate]
+                    return Array((source ?? []).suffix(self.displayLimit))
+                }
+
+                animationStates[key] = BubbleAnimationState(
+                    messagesProvider: messagesProvider,
+                    lastRotationTime: Date().timeIntervalSince1970
+                )
+            }
+        case .singleBubble:
+            animationStates.removeValue(forKey: key)
+        }
     }
 }
 
@@ -266,6 +403,8 @@ extension MessageMarkerManager {
         for (_, task) in fadeTasks { task.cancel() }
         fadeTasks.removeAll()
         hasFadedIn.removeAll()
+
+        lastRenderedSignature.removeAll()
     }
 }
 
@@ -301,43 +440,37 @@ extension MessageMarkerManager {
         onTapPlace: ((Place) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
-        // Place 마커 생성/업데이트
-        updateMarker(
-            coord: coord,
-            isPlace: true,
-            mapView: mapView,
-            onTap: { messages in
-                // 탭 시 실행될 로직
+        // Place가 없고, 기존 place 마커도 없다면 스킵
+        if (placeMessagesByCoord[coord]?.isEmpty ?? true)
+            && markers[.init(coordinate: coord, isPlace: true)] == nil {
+            // 아무 동작 X
+        } else {
+            updateMarker(coord: coord, isPlace: true, mapView: mapView) { messages in
                 guard let place = messages.first?.placeTag else { return }
-                let uniquePlaces = Set(messages.compactMap { $0.placeTag })
 
+                let uniquePlaces = Set(messages.compactMap(\.placeTag))
                 if uniquePlaces.count == 1 {
-                    // 장소가 1개 -> Space 화면으로 이동
                     onTapPlace?(place)
-                } else {
-                    // TODO: 장소가 여러 개 -> 선택 모달 표시
-                    print("장소 여러 개: \(uniquePlaces.count)")
                 }
             }
-        )
+        }
 
-        // NoPlace 마커 생성/업데이트
-        updateMarker(
-            coord: coord,
-            isPlace: false,
-            mapView: mapView,
-            onTap: { messages in
-                // 메시지가 2개 이상일 때만 콜백 실행 (스택 펼치기)
+        // NoPlace가 없고, 기존 noPlace 마커도 없다면 스킵
+        if (noPlaceMessagesByCoord[coord]?.isEmpty ?? true)
+            && markers[.init(coordinate: coord, isPlace: false)] == nil {
+            // 아무 동작 X
+        } else {
+            updateMarker(coord: coord, isPlace: false, mapView: mapView) { messages in
                 if messages.count >= 2 {
                     onTapNoPlace?(messages)
                 }
             }
-        )
+        }
     }
 
     /// 단일 마커가 없으면 생성하거나 있으면 재사용하고,
     /// 메시지 상태에 따라 아이콘을 비동기로 렌더링하여 갱신합니다.
-    /// (메시지가 없으면 markerType이 nil이므로 아이콘 갱신 없이 종료됩니다.)
+    /// MarkerType이 nil이면(메시지 없음) 해당 key의 마커를 제거하고 종료합니다.
     private func updateMarker(
         coord: Coordinate,
         isPlace: Bool,
@@ -365,10 +498,19 @@ extension MessageMarkerManager {
         // 3. MarkerType 결정 (메시지가 없으면 nil -> 마커 생성 안 함)
         guard let markerType = MarkerType.from(messages: messages, isPlace: isPlace) else {
             removeMarker(for: key)
+            lastRenderedSignature.removeValue(forKey: key)
             return
         }
 
-        // 4. 탭 핸들러 등록 (위에서 만든 마커 재사용)
+        // 애니메이션 상태 정합성 체크
+        syncAnimationStateIfNeeded(
+            key: key,
+            markerType: markerType,
+            coordinate: coord,
+            isPlace: isPlace
+        )
+
+        // 탭 핸들러 등록 (위에서 만든 마커 재사용)
         // - 탭 시점의 최신 메시지를 조회하여 콜백에 전달
         marker.touchHandler = { [weak self] _ in
             guard let self else { return true }
@@ -377,25 +519,19 @@ extension MessageMarkerManager {
             return true
         }
 
-        // 5. 초기 이미지 렌더 (key 기준 검증 + Task 누적 방지)
+        // 3-1. 현재 렌더 시그니처 계산
+        let signature = makeRenderSignature(markerType: markerType, messages: messages)
+
+        // 3-2. 기존 마커가 있고, 시그니처가 동일하면 아이콘 렌더 스킵
+        if let marker = markers[key], lastRenderedSignature[key] == signature { return }
+
+        // 시그니처 갱신
+        lastRenderedSignature[key] = signature
+
+        // 4. 초기 이미지 렌더 (key 기준 검증 + Task 누적 방지)
         scheduleInitialRender(for: key, marker: marker, markerType: markerType)
 
-        // 6. 회전 애니메이션 상태 등록 (rotatingBubble 또는 stackBubble인 경우)
-        switch markerType {
-        case .rotatingBubble, .stackBubble:
-            let messagesProvider: () -> [Message] = { [weak self] in
-                guard let self else { return [] }
-                let source = isPlace ? self.placeMessagesByCoord[coord] : self.noPlaceMessagesByCoord[coord]
-                return Array((source ?? []).suffix(self.displayLimit))
-            }
 
-            animationStates[key] = BubbleAnimationState(
-                messagesProvider: messagesProvider,
-                lastRotationTime: Date().timeIntervalSince1970
-            )
-        case .singleBubble:
-            break
-        }
     }
 
     /// 마커를 지도에서 제거하고 저장소에서 삭제합니다.
@@ -411,6 +547,8 @@ extension MessageMarkerManager {
         fadeTasks.removeValue(forKey: key)
 
         hasFadedIn.remove(key)
+
+        lastRenderedSignature.removeValue(forKey: key)
     }
 
     /// MarkerType에 맞는 마커를 생성하고 이미지를 설정합니다.
@@ -549,5 +687,35 @@ extension MessageMarkerManager {
             }
             marker.alpha = 1.0
         }
+    }
+}
+
+// MARK: - Helpers
+
+private extension MessageMarkerManager {
+    func idsHash(_ messages: [Message]?) -> Int {
+        guard let messages, !messages.isEmpty else { return 0 }
+
+        var hasher = Hasher()
+        for message in messages {
+            hasher.combine(message.id)
+            hasher.combine(message.createdAt.timeIntervalSince1970)
+        }
+
+        return hasher.finalize()
+    }
+
+    func contentHash(_ messages: [Message]?) -> Int {
+        guard let messages, !messages.isEmpty else { return 0 }
+
+        var hasher = Hasher()
+        for message in messages {
+            hasher.combine(message.id)
+            hasher.combine(message.createdAt.timeIntervalSince1970)
+            hasher.combine(message.coordinate.latitude)
+            hasher.combine(message.coordinate.longitude)
+        }
+
+        return hasher.finalize()
     }
 }


### PR DESCRIPTION
## 배경
- closed #271

## 작업 요약
- 마커 렌더링 이슈 해결

## 작업 내용
### 1. 마커 렌더링 최종 이슈 분석
초기 상황: 지도 드래그/줌 제스처마다 전체 버블 깜빡임 발생

#### 1) 문제
- 앞 단계(비동기 렌더 + placeholder + fade + Representable 스냅샷 가드)를 적용한 뒤에도 **지도 드래그 / 줌 인아웃 제스처**를 할 때마다 화면에 보이는 버블들이 **전부 다시 깜빡이는 현상**이 남아있었음.

#### 2) 원인
- 기존 loadMessages() 흐름이 **매번 전체 마커를 삭제 후에 재생성하는 구조(clearAll -> rebuild)**로 되어있었음.
- 지도 상태 변화(줌/드래그 등)로 인해 update가 들어올 때도 **전체 리렌더링 + 전체 페이드**가 반복되었음.
  - 마커가 다시 생성되거나, 아이콘이 다시 렌더링되거나, 페이드가 다시 적용되는 모습을 보임.

### 2. 해결: 메시지 스냅샷 diff 기반 업데이트 + 렌더 시그니처로 재렌더 차단

#### a) 목표
- 바뀐 좌표만 업데이트
- 아이콘 상태가 같으면 렌더 스킵

#### b) AS-IS
기존 MessageMarkerManager는 메시지 갱신 시 좌표 단위가 아닌 전체 업데이트가 발생하여 **불필요한 마커 갱신/아이콘 재렌더링**이 반복됨.

- 동일 좌표 내 메시지 변경이 없음에도 updateMarker가 호출됨.
- 동일한 아이콘 상태임에도 이미지 재렌더가 발생
- 성능(렌더 비용) + 상태 정합성(깜빡임) 측면에서 개선 필요

#### c) 변경 사항
1. **applySnapshot()에 diff 로직 도입 (좌표 단위 최소 업데이트)**
   - 기존 place / noPlace 좌표 집합과 신규 스냅샷을 비교
   - `added / removed / changed` 좌표만을 선별
     - added: 새로 생긴 좌표
     - removed: 사라진 좌표
     - changed: 기존 좌표 중 **메시지 id 집합이 바뀐 좌표**
   - changed 판단 기준은 **메시지 id 집합 변경 여부**
     ```swift
     oldIDs != newIDs -> changed coordinate
     ```
     - offset 좌표가 유지되면 -> Coordinate 자체도 동일
     - 메시지 id 구성도 동일하면 -> changed로 잡히지 않음.
     - -> updateMarker를 필요한 상황에만 부르게 됨.
   - -> 이를 통해 실제로 변경된 좌표에 대해서만 updateMarkersForCoordinate를 호출하도록 개선.
2. **MarkerRenderSignature 기반 아이콘 재렌더 스킵**
   - MarkerRenderSignature 구성
     - marker kind (single / rotating / stack)
     * 첫 메시지 id
     * 표시 메시지 개수
     * 메시지 id hash
       ```swift
       if lastRenderedSignature[key] == signature {
       return // 아이콘 재렌더 스킵
       }
       ```
   - -> 메시지 구성은 같고 좌표 diff만 발생한 경우의 렌더링 비용 제거.
   - placeholder + face와 결합되어 발생하던 불필요한 깜빡임 감소.
3. **렌더/페이드 Task 누적 방지 + 애니메이션 상태 정합성 유지**
   - renderTasks[key], fadeTasks[key]를 key 단위로 관리
   - 새 렌더 시작 전 기존 Task 취소 -> **최신 상태만 반영**
   - syncAnimationStateIfNeeded()로 rotating/stack 타입의 상태가 없으면 생성, single이면 제거
   - -> 결과적으로 빠르게 연속 호출되어도 이전 렌더가 뒤늦게 덮어쓰는 현상을 방지하고, 애니메이션 상태와 렌더 상태가 엇갈리는 문제가 줄어듬.

---
## MessageMarkerManager 동작 방식
### 요약
> 1. 메시지 배열을 좌표별로 그룹화
> 2. diff로 바뀐 좌표를 골라서 필요한 마커만 생성/업데이트
> 3. 아이콘은 상태가 바뀐 경우에만 비동기로 렌더
> 4. 회전/스택 버블은 프레임마다 교체

### 1. 입력(messages)이 들어오면 loadMessages()
- loadMessages()는 내부에서 applySnapshot()을 호출
* 여기서 메시지를 두 개의 저장소로 분리하여 구성

#### 저장소 구조
* **placeTag 있는 메시지들: 원본 좌표 그대로**
  * `placeMessagesByCoord[Coordinate] = [Message]`
* **placeTag 없는 메시지들: place 좌표와 겹치면 offset 좌표로 분산**
  * `noPlaceMessagesByCoord[Coordinate] = [Message]`

### 2. applySnapshot() 동작
1. 기존 좌표 집합(oldTotalCoordinates)과 새 좌표 집합(newTotalCoordinates) 비교
2. removed / added / changed 좌표를 계산
3. removed 좌표는 마커 제거
4. added/changed 좌표만 updateMarkersForCoordinate() 호출

-> 전체를 재생성하지 않고 바뀐 좌표에 대해서만 작용하도록 함.

### 3. 좌표 하나 업데이트: updateMarkersForCoordinate(coord)
좌표 하나에 대해 마커가 최대 2개 생길 수 있음:
* Place 마커 (isPlace: true)
* NoPlace 마커 (isPlace: false)

각 케이스에 대해
* 해당 좌표에 메시지가 있거나(또는 기존 마커가 남아있으면) updateMarker() 실행
* 메시지도 없고 마커도 없으면 스킵

### 4. 실제 마커 업데이트: updateMarker(coord, isPlace)
1. **key 생성**: `MarkerGroupKey(coordinate:isPlace:)`
2. **마커가 있으면 재사용, 없으면 생성** (makeMarker()로 placeholder + alpha 0)
3. 해당 좌표 메시지 중 최신 displayLimit개만 추림
4. `MarkerType.from(messages:)`로 타입 결정
   * single / rotating / stack
   * 메시지 없으면 마커 제거 후 종료
5. **애니메이션 상태(sync) 맞춤** (rotating/stack이면 상태 생성)
6. 터치 핸들러 등록(탭 시점의 최신 메시지를 다시 읽어서 전달)
7. **MarkerRenderSignature 생성**
   * 이전 시그니처와 같으면 **렌더 스킵**
8. **렌더 필요 시 scheduleInitialRender() 실행**
   * key 단위로 기존 render task cancel
   * 비동기 렌더 완료 후 **현재 마커가 여전히 같은 객체인지 검증** 후 적용
   * 첫 적용만 fade-in, 이후는 alpha 유지 + icon만 교체

### 5. 회전/스택 애니메이션: updateAnimations()
* 타이머(60fps)에서 매 프레임 호출됨
* animationStates의 key들을 순회
  * rotation interval이 지났으면 애니메이션 시작
  * 진행 중이면 progress 업데이트
  * 매 프레임 이미지를 다시 렌더하여 marker.iconImage 교체
* 이때도 render task는 cancel 후 최신만 반영

### 동작 흐름
```mermaid
flowchart TD
  A[MapViewWrapper] --> B[MapViewController 생성]
  A --> C{messagesSnapshot 변경됨?}
  C -->|아니오| X[return]
  C -->|예| D[loadMessages 호출]

  B --> D
  D --> E[MessageMarkerManager.loadMessages]
  E --> F[applySnapshot 실행]

  %% snapshot build
  F --> G[새 메시지 스토어 구성]
  G --> H[이전 좌표 집합 계산]
  G --> I[신규 좌표 집합 계산]

  %% diff
  H --> J[diff 계산]
  I --> J
  J --> K[changed 좌표 선별]

  %% store swap
  K --> L[스토어 교체]

  %% removed
  L --> M[removed 좌표 마커 제거]

  %% added + changed
  L --> N[added + changed 좌표만 업데이트]
  N --> O[updateMarkersForCoordinate]

  %% per coordinate
  O --> P{Place 메시지 있음 또는 기존 마커 있음}
  P -->|예| R1[updateMarker place]
  P -->|아니오| Q1[skip]

  O --> S{NoPlace 메시지 있음 또는 기존 마커 있음}
  S -->|예| R2[updateMarker noPlace]
  S -->|아니오| Q2[skip]

  %% updateMarker internals
  subgraph UM[updateMarker]
    U1[MarkerGroupKey 생성]
    U2{마커 존재?}
    U3[기존 마커 재사용]
    U4[마커 생성 placeholder]
    U5[표시 메시지 계산]
    U6{MarkerType 결정}
    U7[마커 제거]
    U8[애니메이션 상태 동기화]
    U9[touchHandler 등록]
    U10[RenderSignature 생성]
    U11{Signature 동일?}
    U12[렌더 스킵]
    U13[렌더 예약]

    U1 --> U2
    U2 -->|예| U3
    U2 -->|아니오| U4
    U3 --> U5
    U4 --> U5
    U5 --> U6
    U6 -->|없음| U7
    U6 -->|있음| U8
    U8 --> U9
    U9 --> U10
    U10 --> U11
    U11 -->|예| U12
    U11 -->|아니오| U13
  end

  R1 --> UM
  R2 --> UM

  %% render
  subgraph IR[초기 렌더링]
    I1[기존 렌더 Task 취소]
    I2[비동기 이미지 렌더]
    I3{취소 또는 마커 변경됨?}
    I4[아이콘 교체]
    I5[페이드 인 적용]

    I1 --> I2
    I2 --> I3
    I3 -->|문제 없음| I4
    I4 --> I5
  end

  U13 --> IR

  %% animation loop
  T[60fps 타이머] --> U[updateAnimations]
  U --> V[animationStates 순회]
  V --> W{애니메이션 대상?}
  W -->|아니오| V
  W -->|예| Y{애니메이션 중?}
  Y -->|아니오| Z[시작 여부 판단]
  Y -->|예| AA[progress 계산]
  AA --> AB[회전 버블 렌더]

```

## 스크린샷
![diff 적용 후 동작모습](https://github.com/user-attachments/assets/ff0e40f6-1b82-456a-8609-6bc3d98a87a6)

## 리뷰 요구사항
코드 상의 기존 주석은 변경한 흐름에 맞춰 수정해두었으나, **전체적인 코드 상세 정리(변수명 통일, 주석 넘버링 방식 통일 등)는 진행하지 못했습니다.**
MeesageMarkerManager 리팩터링 목적이 아닌, 5, 6주차 데모 시연 시의 과도한 깜빡임 방지를 위하여 적용한 내용이니 양해 부탁드립니다.
그럼에도 지금 수정할 부분이 있다면 남겨주세요!

### 현재 남은 이슈
- 지도 드래그 시 회전 버블 rotate 동작이 처음부터 다시 시작
- 회전 버블 초기 렌더링 시 단일 버블로 들어가는 것 같음.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Messages now display address and formatted date information
  * Enhanced message bubble layout to show location names

* **Performance & Optimization**
  * Optimized marker rendering with improved state management and change detection
  * Added intelligent caching to reduce unnecessary re-rendering

* **Style**
  * Refined rotating text animation positioning on the map view

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->