### PR TITLE
작성 화면에서 스와이프 시 뒤로가기 구현

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -56,6 +56,7 @@ struct MessageComposerView: View {
                     .zIndex(1000)
             }
         }
+        .enableSwipeBack()
         .onAppear { send(.onAppear) }
         .onDisappear { send(.onDisappear) }
         .onChange(of: store.state.alert) { _, newValue in

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -56,7 +56,36 @@ struct MessageComposerView: View {
                     .zIndex(1000)
             }
         }
-        .enableSwipeBack()
+        .enableSwipeBack(
+            shouldBegin: {
+                // 로딩 중이면 swipe back 금지
+                if store.state.confirmStatus == .loading { return false }
+
+                // 장소 검색 overlay가 떠있으면 pop 금지
+                if store.state.isPlaceSearchPresented { return false }
+
+                // draft 존재하면 pop 금지 (경고 띄우는 형태로 유도)
+                if !isDraftEmpty { return false }
+
+                return true
+            },
+            onAttempt: {
+                // swipe 시도했는데 막혔을 때
+                if store.state.isPlaceSearchPresented {
+                    send(.dismissPlaceSearch)
+                    return
+                }
+
+                if store.state.confirmStatus == .loading {
+                     send(.setToast("머문 흔적을 남기는 중이에요."))
+                    return
+                }
+
+                if !isDraftEmpty {
+                    send(.setAlert(exitAlert))
+                }
+            }
+        )
         .onAppear { send(.onAppear) }
         .onDisappear { send(.onDisappear) }
         .onChange(of: store.state.alert) { _, newValue in

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SwipeBackEnabler.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SwipeBackEnabler.swift
@@ -1,0 +1,30 @@
+//
+//  SwipeBackEnabler.swift
+//  Meomun
+//
+//  Created by 지연 on 1/26/26.
+//
+
+import SwiftUI
+import UIKit
+
+struct SwipeBackEnabler: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = UIViewController()
+
+        DispatchQueue.main.async {
+            viewController.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+            viewController.navigationController?.interactivePopGestureRecognizer?.delegate = nil
+        }
+
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+extension View {
+    func enableSwipeBack() -> some View {
+        background(SwipeBackEnabler())
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SwipeBackEnabler.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SwipeBackEnabler.swift
@@ -9,22 +9,70 @@ import SwiftUI
 import UIKit
 
 struct SwipeBackEnabler: UIViewControllerRepresentable {
+    // swipe 가능 여부 판단 클로저
+    let shouldBegin: () -> Bool
+
+    // swipe 시도했지만 막혔을 때 실행할 콜백
+    let onAttempt: (() -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(shouldBegin: shouldBegin, onAttempt: onAttempt)
+    }
+
     func makeUIViewController(context: Context) -> UIViewController {
         let viewController = UIViewController()
-
-        DispatchQueue.main.async {
-            viewController.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-            viewController.navigationController?.interactivePopGestureRecognizer?.delegate = nil
-        }
-
+        viewController.view.backgroundColor = .clear
         return viewController
     }
 
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+    func updateUIViewController(_ viewController: UIViewController, context: Context) {
+        context.coordinator.shouldBegin = shouldBegin
+        context.coordinator.onAttempt = onAttempt
+
+        DispatchQueue.main.async {
+            guard let navigationController = viewController.navigationController,
+                  let gesture = navigationController.interactivePopGestureRecognizer
+            else { return }
+
+            gesture.isEnabled = true
+            gesture.delegate = context.coordinator
+        }
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var shouldBegin: () -> Bool
+        var onAttempt: (() -> Void)?
+
+        init(shouldBegin: @escaping () -> Bool, onAttempt: (() -> Void)?) {
+            self.shouldBegin = shouldBegin
+            self.onAttempt = onAttempt
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            let allowed = shouldBegin()
+
+            if !allowed {
+                // swipe pop 차단 + 시도했음을 상위에 알림
+                DispatchQueue.main.async { [weak self] in
+                    self?.onAttempt?()
+                }
+            }
+
+            return allowed
+        }
+    }
 }
 
 extension View {
-    func enableSwipeBack() -> some View {
-        background(SwipeBackEnabler())
+    func enableSwipeBack(
+        shouldBegin: @escaping () -> Bool,
+        onAttempt: (() -> Void)? = nil
+    ) -> some View {
+        background(
+            SwipeBackEnabler(
+                shouldBegin: shouldBegin,
+                onAttempt: onAttempt
+            )
+        )
     }
 }


### PR DESCRIPTION
## 배경
- closed #253

## 작업 요약
- 작성 화면에서 스와이프 뒤로 가기 활성화

## 작업 내용
### 1. 작성 화면: 스와이프로 뒤로가기 구현
#### 배경
SwiftUI NavigationStack 환경에서 화면을 push한 뒤
* .navigationBarBackButtonHidden()을 사용해 기본 back 버튼을 숨기고
* toolbar에 커스텀 back 버튼을 올려서 네비게이션을 구성하는 경우
iOS 기본 기능인 **스와이프 뒤로가기(좌측 edge swipe pop)**가 비활성화되는 문제 발생

#### 해결 방향
- SwiftUI만으로는 UINavigationController.interactivePopGestureRecognizer를 직접 제어하기 어려움.
- -> UIViewControllerRepresentable을 사용해 UIKit 레벨에서 interactivePopGestureRecognizer를 강제로 활성화하는 방식으로 해결

#### 구현
1) SwipeBackEnabler (UIKit 브릿지)
   ```swift
   import SwiftUI
   import UIKit
   
   struct SwipeBackEnabler: UIViewControllerRepresentable {
    func makeUIViewController(context: Context) -> UIViewController {
        let viewController = UIViewController()
   
        DispatchQueue.main.async {
   	viewController.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
            viewController.navigationController?.interactivePopGestureRecognizer?.delegate = nil
        }
   
        return viewController
    }
   
       func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
   }
   ```

2) View extension으로 모디파이어 제공
   ```swift
   extension View {
    func enableSwipeBack() -> some View {
        background(SwipeBackEnabler())
    }
   }
   ```

3) 스와이프 뒤로가기 적용

#### + DispatchQueue.main.async 사용 이유
makeUIViewController()가 호출되는 시점에는 viewController.navigationController가 아직 연결되지 않아 nil일 수 있다.
따라서 **다음 runloop로 미뤄 navigationController attach 이후**에 제스처 설정이 가능하도록 DispatchQueue.main.async로 실행 시점을 조정할 수 있도록 하였다.


### 2. 스와이프 뒤로가기 우회 문제 해결 (CodeRabbit 리뷰 반영)
#### 1) 문제 상황

- MessageComposerView에서 커스텀 BackButton(onTapBackButton)을 사용하면서 **스와이프 뒤로가기 제스처(pop gesture)**가 동작하지 않아 `.enableSwipeBack()`을 추가했음. (1번 내용)
- 하지만 기존 구현(interactivePopGestureRecognizer?.delegate = nil) 방식은 다음 로직들을 **완전히 우회**해버렸다.
  * 초안 작성 중 뒤로가기 경고(Alert) 표시
  * 로딩 중 뒤로가기 비활성화
  * 장소 검색 오버레이(isPlaceSearchPresented)가 떠 있을 때 뒤로가기 제어
* 즉, 사용자가 스와이프로 뒤로가기 하면 **초안 확인 없이 바로 pop**되어 초안 데이터 손실 위험이 발생했다.

#### 2) 원인 분석

스와이프 뒤로가기(pop gesture)는 UINavigationController 레벨에서 직접 pop을 수행한다.
따라서
* 커스텀 BackButton이 호출하는 onTapBackButton()의 보호 로직을 거치지 않는다.
* `interactivePopGestureRecognizer?.delegate = nil`로 설정하면, 제스처 시작 여부를 판단할 **delegate 제어권이 사라져** `gestureRecognizerShouldBegin(_:)` 같은 안전장치를 적용할 수 없다.

#### 3) 해결 전략

스와이프 pop 제스처가 커스텀 back 로직을 우회하지 않도록
* SwipeBackEnabler에서 UIGestureRecognizerDelegate 직접 구현
* `gestureRecognizerShouldBegin(_:)`에서 현재 상태 기반으로 **스와이프 시작 여부를 결정**
* pop이 차단되는 상황에서는 onAttempt 콜백을 통해 Alert 표시 / overlay dismiss 등 사용자 피드백을 제공하도록 개선

#### 4) 적용 정책 (MessageComposer 기준)

스와이프 뒤로가기 허용 조건:
* 로딩 중(`confirmStatus == .loading`) → 스와이프 pop 차단
* 장소 검색 overlay 표시 중(`isPlaceSearchPresented == true`) → 스와이프 pop 차단
* Draft 존재(`!isDraftEmpty`) → 스와이프 pop 차단 + Alert 유도

## 스크린샷

https://github.com/user-attachments/assets/6aca0dee-4236-4f60-a40c-09f62fc98296


## 리뷰 요구사항


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 메시지 작성 화면에 스와이프-백 제스처 추가
  * 로딩 중, 장소 검색 오버레이 노출 시, 또는 작성 중인 임시글이 있을 때 제스처 자동 차단
  * 제스처 시도 시 오버레이 닫기, 로딩 중 토스트 표시 또는 임시글 존재 시 종료 확인 알림 표시

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->