### PR TITLE
네트워크 연결이 끊어진 경우 얼럿 대응

### DIFF
--- a/Meomun/Meomun/App/NetworkMonitor.swift
+++ b/Meomun/Meomun/App/NetworkMonitor.swift
@@ -5,25 +5,14 @@
 //  Created by MinwooJe on 1/26/26.
 //
 
-import Combine
 import Network
 
 final class NetworkMonitor {
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "NetworkMonitor")
 
-    private var isConnected = true
-
     init() {
-        monitor.pathUpdateHandler = { [weak self] path in
-            DispatchQueue.main.async {
-                self?.isConnected = path.status == .satisfied
-            }
-        }
         monitor.start(queue: queue)
-
-        // 초기 상태 설정
-        isConnected = monitor.currentPath.status == .satisfied
     }
 
     deinit {

--- a/Meomun/Meomun/App/NetworkMonitor.swift
+++ b/Meomun/Meomun/App/NetworkMonitor.swift
@@ -1,0 +1,37 @@
+//
+//  NetworkMonitor.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/26/26.
+//
+
+import Combine
+import Network
+
+final class NetworkMonitor {
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "NetworkMonitor")
+
+    private var isConnected = true
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                self?.isConnected = path.status == .satisfied
+            }
+        }
+        monitor.start(queue: queue)
+
+        // 초기 상태 설정
+        isConnected = monitor.currentPath.status == .satisfied
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    /// 즉시 네트워크 연결 상태를 체크합니다 (동기)
+    func checkConnection() -> Bool {
+        return monitor.currentPath.status == .satisfied
+    }
+}

--- a/Meomun/Meomun/App/NetworkMonitor.swift
+++ b/Meomun/Meomun/App/NetworkMonitor.swift
@@ -5,13 +5,21 @@
 //  Created by MinwooJe on 1/26/26.
 //
 
+import Foundation
 import Network
 
 final class NetworkMonitor {
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "NetworkMonitor")
+    private var isConnected: Bool = false
+    private let lock = NSLock()
 
     init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.lock.lock()
+            defer { self?.lock.unlock() }
+            self?.isConnected = path.status == .satisfied
+        }
         monitor.start(queue: queue)
     }
 
@@ -21,6 +29,8 @@ final class NetworkMonitor {
 
     /// 즉시 네트워크 연결 상태를 체크합니다 (동기)
     func checkConnection() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
         return monitor.currentPath.status == .satisfied
     }
 }

--- a/Meomun/Meomun/Infra/Network/NetworkClientImpl.swift
+++ b/Meomun/Meomun/Infra/Network/NetworkClientImpl.swift
@@ -50,6 +50,13 @@ final class NetworkClientImpl: NetworkClient, @unchecked Sendable {
                 throw NetworkError.decodingError(error)
             }
 
+        } catch let urlError as URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .timedOut:
+                throw NetworkError.noConnection
+            default:
+                throw NetworkError.transportError(urlError)
+            }
         } catch let networkError as NetworkError {
             throw networkError
         } catch {

--- a/Meomun/Meomun/Infra/Network/NetworkError.swift
+++ b/Meomun/Meomun/Infra/Network/NetworkError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum NetworkError: Error {
+    case noConnection
     case invalidURL
     case transportError(Error)
     case serverError(statusCode: Int, data: Data?)

--- a/Meomun/Meomun/Presentation/Common/Component/AlertView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/AlertView.swift
@@ -48,8 +48,6 @@ enum AlertType {
 }
 
 struct AlertView: View {
-    @Environment(\.openURL) private var openURL
-
     private let titleImage: Image
     private let title: String
     private let description: String

--- a/Meomun/Meomun/Presentation/Common/Component/AlertView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/AlertView.swift
@@ -1,0 +1,131 @@
+//
+//  AlertView.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/26/26.
+//
+
+import SwiftUI
+
+fileprivate enum Constants {
+    static let dimOpacity: Double = 0.4
+    static let popupCornerRadius: CGFloat = 16
+    static let popupInset: CGFloat = 24
+    static let popupHorizontalPadding: CGFloat = 32
+    static let popupContentSpacing: CGFloat = 20
+    static let descriptionSpacing: CGFloat = 6
+}
+
+enum AlertType {
+    struct AlertConfiguration {
+        let image: Image
+        let title: String
+        let description: String
+        let buttonTitle: String
+    }
+
+    case location
+    case network
+
+    var config: AlertConfiguration {
+        switch self {
+        case .location:
+                .init(
+                    image: Image(systemName: "location.slash.fill"),
+                    title: "위치 권한이 필요해요",
+                    description: "위치 접근을 허용하고 지도 위에 기록을 남겨봐요!",
+                    buttonTitle: "위치 권한 설정하기"
+                )
+        case .network:
+                .init(
+                    image: Image(systemName: "network.slash"),
+                    title: "인터넷 연결에 문제가 있어요",
+                    description: "인터넷 연결 상태를 확인하고 다시 시도해주세요!",
+                    buttonTitle: "새로고침"
+                )
+        }
+    }
+}
+
+struct AlertView: View {
+    @Environment(\.openURL) private var openURL
+
+    private let titleImage: Image
+    private let title: String
+    private let description: String
+    private let buttonTitle: String
+
+    private let onTapButton: () -> Void
+
+    init(type: AlertType, onTapButton: @escaping () -> Void) {
+        self.titleImage = type.config.image
+        self.title = type.config.title
+        self.description = type.config.description
+        self.buttonTitle = type.config.buttonTitle
+        self.onTapButton = onTapButton
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(Constants.dimOpacity)
+                .ignoresSafeArea()
+
+            VStack(spacing: Constants.popupContentSpacing) {
+                titleImageView
+
+                VStack(spacing: Constants.descriptionSpacing) {
+                    titleText
+                    descriptionText
+                }
+
+                ctaButton
+            }
+            .padding(Constants.popupInset)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: Constants.popupCornerRadius))
+            .padding(.horizontal, Constants.popupHorizontalPadding)
+        }
+    }
+}
+
+extension AlertView {
+    private var titleImageView: some View {
+        titleImage
+            .font(.largeTitle)
+            .imageScale(.large)
+            .foregroundStyle(.secondary)
+    }
+
+    private var titleText: some View {
+        Text(title)
+            .font(.title3)
+            .fontWeight(.semibold)
+    }
+
+    private var descriptionText: some View {
+        Text(description)
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+    }
+
+    private var ctaButton: some View {
+        Button {
+            onTapButton()
+        } label: {
+            Text(buttonTitle)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+    }
+}
+
+#Preview {
+    AlertView(type: .location) {
+        print("로케이션 버튼 탭")
+    }
+
+    AlertView(type: .network) {
+        print("네트워크 버튼 탭")
+    }
+}

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -11,14 +11,6 @@ import CoreLocation
 fileprivate enum Constants {
     // Title
     static let loadingMessage = "현재 위치 불러오는 중..."
-
-    // UI
-    static let dimOpacity: Double = 0.4
-    static let popupCornerRadius: CGFloat = 16
-    static let popupInset: CGFloat = 24
-    static let popupHorizontalPadding: CGFloat = 32
-    static let popupContentSpacing: CGFloat = 20
-    static let descriptionSpacing: CGFloat = 6
 }
 
 struct LocationGateView: View {

--- a/Meomun/Meomun/Presentation/Root/LocationGateView.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationGateView.swift
@@ -11,12 +11,6 @@ import CoreLocation
 fileprivate enum Constants {
     // Title
     static let loadingMessage = "현재 위치 불러오는 중..."
-    static let permissionTitle = "위치 권한이 필요해요"
-    static let permissionMessage = "위치 접근을 허용하고 지도 위에 기록을 남겨봐요!"
-    static let settingsButtonTitle = "위치 권한 설정하기"
-
-    // Image
-    static let locationImage = "location.slash.fill"
 
     // UI
     static let dimOpacity: Double = 0.4
@@ -51,12 +45,10 @@ struct LocationGateView: View {
                 // TODO: - 타임아웃 처리 -> "현재 위치를 불러올 수 없어요. 잠시 후 다시 시도해주세요."
 
             case .denied, .restricted:
-                ZStack {
-                    Color.black.opacity(Constants.dimOpacity)
-                        .ignoresSafeArea()
-
-                    permissionRequestView
-
+                AlertView(type: .location) {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(url)
+                    }
                 }
 
             default:
@@ -68,41 +60,5 @@ struct LocationGateView: View {
                 locationProvider.requestAuthorizationIfNeeded()
             }
         }
-    }
-}
-
-extension LocationGateView {
-    private var permissionRequestView: some View {
-        VStack(spacing: Constants.popupContentSpacing) {
-            Image(systemName: Constants.locationImage)
-                .font(.largeTitle)
-                .imageScale(.large)
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: Constants.descriptionSpacing) {
-                Text(Constants.permissionTitle)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-
-                Text(Constants.permissionMessage)
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-
-            Button {
-                if let url = URL(string: UIApplication.openSettingsURLString) {
-                    openURL(url)
-                }
-            } label: {
-                Text(Constants.settingsButtonTitle)
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-        }
-        .padding(Constants.popupInset)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: Constants.popupCornerRadius))
-        .padding(.horizontal, Constants.popupHorizontalPadding)
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -18,6 +18,7 @@ final class MapStore: Store {
         case updateMessages([Message])
         case tapNoPlaceMarker([Message])
         case dismissTimelineView
+        case tapNetworkRefresh
         case setToast(String?)
     }
 
@@ -27,6 +28,7 @@ final class MapStore: Store {
         case setMessages([Message])
         case setSelectedNoPlace([Message])
         case setLoading(Bool)
+        case setNetworkConnected(Bool)
         case setError(String)
         case setToastMessage(String?)
     }
@@ -37,6 +39,7 @@ final class MapStore: Store {
         var isShowingAddMessage: Bool = false
         var selectedNoPlaceMessages: [Message] = []
         var isLoading: Bool = false
+        var isNetworkConnected = true
         var errorMessage: String = ""
         var toastMessage: String?
     }
@@ -47,12 +50,15 @@ final class MapStore: Store {
 
     private var getNearbyMessageTask: Task<Void, Never>?
     private let getNearbyMessagesUseCase: GetNearbyMessagesUseCase
+    private let networkMonitor: NetworkMonitor
 
     init(
-        getNearbyMessagesUseCase: GetNearbyMessagesUseCase
+        getNearbyMessagesUseCase: GetNearbyMessagesUseCase,
+        networkMonitor: NetworkMonitor
     ) {
         self.state = State()
         self.getNearbyMessagesUseCase = getNearbyMessagesUseCase
+        self.networkMonitor = networkMonitor
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {
@@ -60,6 +66,10 @@ final class MapStore: Store {
             switch intent {
             case .onAppear(let coordinate):
                 continuation.yield(.setCameraCoordinate(coordinate))
+
+                let isConnected = networkMonitor.checkConnection()
+                continuation.yield(.setNetworkConnected(isConnected))
+
                 self.getNearbyMessages(at: coordinate, continuation: continuation)
 
             case .onDisappear:
@@ -92,6 +102,11 @@ final class MapStore: Store {
                 continuation.yield(.setSelectedNoPlace([]))
                 continuation.finish()
 
+            case .tapNetworkRefresh:
+                let isConnected = networkMonitor.checkConnection()
+                continuation.yield(.setNetworkConnected(isConnected))
+                continuation.finish()
+
             case .setToast(let message):
                 continuation.yield(.setToastMessage(message))
                 continuation.finish()
@@ -117,6 +132,9 @@ final class MapStore: Store {
 
         case .setLoading(let isLoading):
             newState.isLoading = isLoading
+
+        case .setNetworkConnected(let isConnected):
+            newState.isNetworkConnected = isConnected
 
         case .setError(let message):
             newState.errorMessage = message

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -156,6 +156,7 @@ struct MapView: View {
                                     client: NetworkClientImpl()
                                 )
                             ),
+                            networkMonitor: NetworkMonitor(),
                             onClose: { _ in
                                 navigationPath.removeLast()
                             }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -156,7 +156,6 @@ struct MapView: View {
                                     client: NetworkClientImpl()
                                 )
                             ),
-                            networkMonitor: NetworkMonitor(),
                             onClose: { _ in
                                 navigationPath.removeLast()
                             }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -25,7 +25,8 @@ struct MapView: View {
         _store = StateObject(wrappedValue: MapStore(
             getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(
                 messageRepository: MessageRepositoryImpl()
-            )
+            ),
+            networkMonitor: NetworkMonitor()
         ))
         self.messageMarkerManager = messageMarkerManager
         self.initialUserLocation = userLocation
@@ -88,6 +89,14 @@ struct MapView: View {
                 }
                 .padding(.top, 12)
                 .padding(.bottom, 96)
+
+                if !store.state.isNetworkConnected {
+                    AlertView(type: .network) {
+                        Task {
+                            await store.send(intent: .tapNetworkRefresh)
+                        }
+                    }
+                }
             }
             .sheet(
                 isPresented: Binding(

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -99,16 +99,10 @@ final class MessageComposerStore: Store {
         AsyncStream<Action>(bufferingPolicy: .unbounded) { continuation in
             switch intent {
             case .onAppear:
-                let coordinate = state.startLocation
-                Task { [weak self] in
-                    guard let self, let coordinate else {
-                        continuation.finish()
-                        return
-                    }
-
+                executeWithCoordinate(continuation: continuation) { [weak self] coordinate, continuation in
+                    guard let self else { return }
                     let address = await self.fetchAddress(for: coordinate)
                     continuation.yield(.setStartAddress(address))
-                    continuation.finish()
                 }
                 return
 
@@ -166,16 +160,10 @@ final class MessageComposerStore: Store {
 
             case .retryReverseGeocoding:
                 continuation.yield(.setShowEmptyLocationAlert(false))
-                let coordinate = state.startLocation
-                Task { [weak self] in
-                    guard let self, let coordinate else {
-                        continuation.finish()
-                        return
-                    }
-
+                executeWithCoordinate(continuation: continuation) { [weak self] coordinate, continuation in
+                    guard let self else { return }
                     let address = await self.fetchAddress(for: coordinate)
                     continuation.yield(.setStartAddress(address))
-                    continuation.finish()
                 }
                 return
             }
@@ -236,6 +224,21 @@ extension MessageComposerStore {
         } catch {
             AppLog.error("Failed to get address from coordinates", category: .store, error: error)
             return "위치 없음"
+        }
+    }
+
+    private func executeWithCoordinate(
+        continuation: AsyncStream<Action>.Continuation,
+        work: @escaping @Sendable (Coordinate, AsyncStream<Action>.Continuation) async -> Void
+    ) {
+        let coordinate = state.startLocation
+        Task {
+            guard let coordinate else {
+                continuation.finish()
+                return
+            }
+            await work(coordinate, continuation)
+            continuation.finish()
         }
     }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -27,6 +27,8 @@ final class MessageComposerStore: Store {
         var alert: AlertModel?
         var toastMessage: String?
 
+        var isNetworkConnected: Bool = true
+
         var confirmStatus: LoadingStatus = .idle
 
         var isConfirmEnabled: Bool {
@@ -48,6 +50,7 @@ final class MessageComposerStore: Store {
         case clearPlace
 
         case tapConfirm
+        case tapNetworkRefresh
 
         case setAlert(AlertModel?)
         case setToast(String?)
@@ -61,6 +64,7 @@ final class MessageComposerStore: Store {
         case updatePlace(Place)
         case clearPlace
 
+        case setNetworkConnected(Bool)
         case setConfirmStatus(LoadingStatus)
         case presentAlert(AlertModel?)
         case presentToast(String?)
@@ -71,6 +75,7 @@ final class MessageComposerStore: Store {
 
     private let createMessageUseCase: CreateMessageUseCase
     private let reverseGeocodingUseCase: ReverseGeocodeUseCase
+    private let networkMonitor: NetworkMonitor
 
     private let onClose: (Bool) -> Void
 
@@ -79,6 +84,7 @@ final class MessageComposerStore: Store {
         currentPlace: Place?,
         createMessage: CreateMessageUseCase,
         reverseGeocoding: ReverseGeocodeUseCase,
+        networkMonitor: NetworkMonitor,
         onClose: @escaping (Bool) -> Void
     ) {
         self.state = State(
@@ -87,6 +93,7 @@ final class MessageComposerStore: Store {
         )
         self.createMessageUseCase = createMessage
         self.reverseGeocodingUseCase = reverseGeocoding
+        self.networkMonitor = networkMonitor
         self.onClose = onClose
     }
 
@@ -138,8 +145,18 @@ final class MessageComposerStore: Store {
                     continuation.yield(.updateMessage(finalMessage))
                 }
 
+                let isConnected = networkMonitor.checkConnection()
+                continuation.yield(.setNetworkConnected(isConnected))
+                if !isConnected {
+                    break
+                }
+
                 createMessage(continuation: continuation)
                 return
+
+            case .tapNetworkRefresh:
+                let isConnected = networkMonitor.checkConnection()
+                continuation.yield(.setNetworkConnected(isConnected))
 
             case .setAlert(let alert):
                 continuation.yield(.presentAlert(alert))
@@ -170,6 +187,9 @@ final class MessageComposerStore: Store {
 
         case .clearPlace:
             newState.selectedPlace = nil
+
+        case .setNetworkConnected(let isConnected):
+            newState.isNetworkConnected = isConnected
 
         case .setConfirmStatus(let status):
             newState.confirmStatus = status

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -27,7 +27,6 @@ final class MessageComposerStore: Store {
         var alert: AlertModel?
         var toastMessage: String?
 
-        var isNetworkConnected: Bool = true
 
         var confirmStatus: LoadingStatus = .idle
 
@@ -50,7 +49,6 @@ final class MessageComposerStore: Store {
         case clearPlace
 
         case tapConfirm
-        case tapNetworkRefresh
 
         case setAlert(AlertModel?)
         case setToast(String?)
@@ -64,7 +62,6 @@ final class MessageComposerStore: Store {
         case updatePlace(Place)
         case clearPlace
 
-        case setNetworkConnected(Bool)
         case setConfirmStatus(LoadingStatus)
         case presentAlert(AlertModel?)
         case presentToast(String?)
@@ -75,7 +72,6 @@ final class MessageComposerStore: Store {
 
     private let createMessageUseCase: CreateMessageUseCase
     private let reverseGeocodingUseCase: ReverseGeocodeUseCase
-    private let networkMonitor: NetworkMonitor
 
     private let onClose: (Bool) -> Void
 
@@ -84,7 +80,6 @@ final class MessageComposerStore: Store {
         currentPlace: Place?,
         createMessage: CreateMessageUseCase,
         reverseGeocoding: ReverseGeocodeUseCase,
-        networkMonitor: NetworkMonitor,
         onClose: @escaping (Bool) -> Void
     ) {
         self.state = State(
@@ -93,7 +88,6 @@ final class MessageComposerStore: Store {
         )
         self.createMessageUseCase = createMessage
         self.reverseGeocodingUseCase = reverseGeocoding
-        self.networkMonitor = networkMonitor
         self.onClose = onClose
     }
 
@@ -145,11 +139,6 @@ final class MessageComposerStore: Store {
                     continuation.yield(.updateMessage(finalMessage))
                 }
 
-                let isConnected = networkMonitor.checkConnection()
-                continuation.yield(.setNetworkConnected(isConnected))
-                if !isConnected {
-                    break
-                }
 
                 createMessage(continuation: continuation)
                 return
@@ -188,8 +177,8 @@ final class MessageComposerStore: Store {
         case .clearPlace:
             newState.selectedPlace = nil
 
-        case .setNetworkConnected(let isConnected):
-            newState.isNetworkConnected = isConnected
+        case .setShowEmptyLocationAlert(let show):
+            newState.showEmptyLocationAlert = show
 
         case .setConfirmStatus(let status):
             newState.confirmStatus = status

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerStore.swift
@@ -17,7 +17,7 @@ enum EditorPolicy {
 final class MessageComposerStore: Store {
     struct State: Equatable {
         var startLocation: Coordinate?
-        var startAddress: String = "위치 정보 없음"
+        var startAddress: String = "위치 없음"
 
         var message: String = ""
         var address: String = ""
@@ -27,6 +27,7 @@ final class MessageComposerStore: Store {
         var alert: AlertModel?
         var toastMessage: String?
 
+        var showEmptyLocationAlert: Bool = false
 
         var confirmStatus: LoadingStatus = .idle
 
@@ -49,9 +50,11 @@ final class MessageComposerStore: Store {
         case clearPlace
 
         case tapConfirm
+        case confirmWithEmptyLocation
 
         case setAlert(AlertModel?)
         case setToast(String?)
+        case retryReverseGeocoding
     }
 
     enum Action {
@@ -62,6 +65,7 @@ final class MessageComposerStore: Store {
         case updatePlace(Place)
         case clearPlace
 
+        case setShowEmptyLocationAlert(Bool)
         case setConfirmStatus(LoadingStatus)
         case presentAlert(AlertModel?)
         case presentToast(String?)
@@ -139,19 +143,41 @@ final class MessageComposerStore: Store {
                     continuation.yield(.updateMessage(finalMessage))
                 }
 
+                // 케이스 1: startAddress가 "위치 없음"이면 얼럿 표시
+                if state.startAddress == "위치 없음" {
+                    continuation.yield(.setShowEmptyLocationAlert(true))
+                    break
+                }
 
-                createMessage(continuation: continuation)
+                // 케이스 2: startAddress가 정상이면 네트워크 체크 없이 진행
+                createMessage(continuation: continuation, allowEmptyLocation: false)
                 return
-
-            case .tapNetworkRefresh:
-                let isConnected = networkMonitor.checkConnection()
-                continuation.yield(.setNetworkConnected(isConnected))
 
             case .setAlert(let alert):
                 continuation.yield(.presentAlert(alert))
 
             case .setToast(let message):
                 continuation.yield(.presentToast(message))
+
+            case .confirmWithEmptyLocation:
+                continuation.yield(.setShowEmptyLocationAlert(false))
+                createMessage(continuation: continuation, allowEmptyLocation: true)
+                return
+
+            case .retryReverseGeocoding:
+                continuation.yield(.setShowEmptyLocationAlert(false))
+                let coordinate = state.startLocation
+                Task { [weak self] in
+                    guard let self, let coordinate else {
+                        continuation.finish()
+                        return
+                    }
+
+                    let address = await self.fetchAddress(for: coordinate)
+                    continuation.yield(.setStartAddress(address))
+                    continuation.finish()
+                }
+                return
             }
 
             continuation.finish()
@@ -213,7 +239,10 @@ extension MessageComposerStore {
         }
     }
 
-    private func createMessage(continuation: AsyncStream<Action>.Continuation) {
+    private func createMessage(
+        continuation: AsyncStream<Action>.Continuation,
+        allowEmptyLocation: Bool = false
+    ) {
         Task {
             continuation.yield(.setConfirmStatus(.loading))
             defer {
@@ -221,8 +250,10 @@ extension MessageComposerStore {
             }
 
             do {
-                guard let createMessageRequest = await makeCreateMessageRequest() else {
-                    await finish(isSuccess: false, continuation)
+                guard let createMessageRequest = await makeCreateMessageRequest(
+                    allowEmptyLocation: allowEmptyLocation
+                ) else {
+                    continuation.yield(.setConfirmStatus(.idle))
                     return
                 }
 
@@ -249,9 +280,15 @@ extension MessageComposerStore {
         continuation.yield(.close(isSuccess: isSuccess))
     }
 
-    private func makeCreateMessageRequest() async -> CreateMessageRequest? {
-        guard let startLocation = state.startLocation,
-              state.startAddress != "위치 없음" else { return nil }
+    private func makeCreateMessageRequest(
+        allowEmptyLocation: Bool = false
+    ) async -> CreateMessageRequest? {
+        guard let startLocation = state.startLocation else { return nil }
+
+        // allowEmptyLocation이 false이고 startAddress가 "위치 없음"이면 nil 반환
+        if !allowEmptyLocation && state.startAddress == "위치 없음" {
+            return nil
+        }
 
         return CreateMessageRequest(
             content: state.message,

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -95,6 +95,11 @@ struct MessageComposerView: View {
             guard store.state.alert != newValue else { return }
             send(.setAlert(newValue))
         }
+        .onChange(of: store.state.showEmptyLocationAlert) { _, show in
+            if show {
+                presentedAlert = emptyLocationAlert
+            }
+        }
     }
 }
 
@@ -300,6 +305,17 @@ private extension MessageComposerView {
                 )
             ]
         )
+    }
+
+    var emptyLocationAlert: AlertModel {
+        AlertModel(title: "위치 정보를 가져올 수 없어요.", message: "네트워크 연결을 확인해주세요.", buttons: [
+            .init(title: "그대로 작성", role: .normal, action: {
+                send(.confirmWithEmptyLocation)
+            }),
+            .init(title: "새로 고침", role: .cancel, action: {
+                send(.retryReverseGeocoding)
+            })
+        ])
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -55,6 +55,14 @@ struct MessageComposerView: View {
                     .transition(.opacity.animation(.easeInOut(duration: 0.2)))
                     .zIndex(1000)
             }
+
+            if !store.state.isNetworkConnected {
+                AlertView(type: .network) {
+                    Task {
+                        await store.send(intent: .tapNetworkRefresh)
+                    }
+                }
+            }
         }
         .enableSwipeBack(
             shouldBegin: {
@@ -324,6 +332,7 @@ private extension MessageComposerView {
                         client: NetworkClientImpl()
                     )
                 ),
+                networkMonitor: NetworkMonitor(),
                 onClose: { _ in
                     print("close")
                 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -55,14 +55,6 @@ struct MessageComposerView: View {
                     .transition(.opacity.animation(.easeInOut(duration: 0.2)))
                     .zIndex(1000)
             }
-
-            if !store.state.isNetworkConnected {
-                AlertView(type: .network) {
-                    Task {
-                        await store.send(intent: .tapNetworkRefresh)
-                    }
-                }
-            }
         }
         .enableSwipeBack(
             shouldBegin: {
@@ -332,7 +324,6 @@ private extension MessageComposerView {
                         client: NetworkClientImpl()
                     )
                 ),
-                networkMonitor: NetworkMonitor(),
                 onClose: { _ in
                     print("close")
                 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
@@ -195,6 +195,8 @@ final class PlaceSearchStore: Store {
             }
 
             apply(.setPhase(.failed("검색 중 오류가 발생했습니다. (\(statusCode))")))
+        } else if case NetworkError.noConnection = error {
+            apply(.setPhase(.failed("네트워크 연결을 확인해주세요.")))
         } else {
             AppLog.error(
                 "LocalSearch unknown error",


### PR DESCRIPTION
## 배경
- closed #154
- closed #156

## 작업 요약
- 위치 권한 / 네트워크 연결 얼럿 공통 컴포넌트화
- 네트워크 연결이 없는 채 지도 화면 진입 시 네트워크 연결 얼럿 표시
- 작성화면에서 네트워크 연결이 없을 경우 얼럿 대응

## 작업 내용
### (1) 위치 권한 / 네트워크 연결 얼럿 공통 컴포넌트화  

<img width="916" height="609" alt="스크린샷 2026-01-26 오후 11 45 03" src="https://github.com/user-attachments/assets/9c5a2564-7011-47b0-bdb5-1f34581ff344" />

기존의 `LocationView` 내부 프로퍼티로 구현된 얼럿 UI를 `AlertView`로 컴포넌트화 하였습니다.

### (2) 네트워크 연결 상태 감지
API 요청 시 `URLError`를 확인해 연결이 끊어졌는지 감지하는 방법도 고려하였으나, 아래와 같은 이유로 선택하지 않았습니다.  
- 지도화면 진입 시 API 호출이 없음. (NaverMap SDK에서 자체적으로 불러옴)
- 작성 화면은 상황에 따라 네트워크 없이도 메시지 작성이 가능 (아래 참고)

따라서 `NWPathMonitor`를 래핑하는 `NetworkMonitor` 객체를 구현하여 네트워크 연결을 감지합니다.  

### (3) 네트워크 연결 해제 시나리오
1. 네트워크 연결이 없는 채로 앱 실행
   - AlertView(.network) 표시
2. 지도 화면에서 네트워크 Off -> 작성 화면 진입
   - `reverse geocoding` 실패 -> 메시지 작성 시 위치 정보가 ㅇ벗음.
   - 이 경우 사용자는 **그대로 작성** or 네트워크 연결 활성화 후 **위치 정보를 재설정** 할 수 있어야 함.
   - 따라서 `AlertView`가 아닌 새로운 얼럿을 띄움.
3. 메시지 작성 도중 네트워크 off
   - `reverse geocoding`은 되어있는 상태. 장소 검색이 안될 뿐.
   - 메시지 작성 버튼 탭 시 네트워크 off는 문제가 되지 않으므로 정상 흐름 유지

|1. 앱 실행|2.1 지도 off -> 작성 화면 (새로 고침) |2.2 지도 off -> 작성 화면 (그대로 작성)| 4. 작성화면에서 off |  
|---|---|---|---|  
| <video src="https://github.com/user-attachments/assets/bc2374ae-0597-4204-a725-d54d99569872">   | <video src="https://github.com/user-attachments/assets/8563b259-6cd2-4a7d-b6d1-44a80052cc0b"> | <video src="https://github.com/user-attachments/assets/a6def749-7b56-45da-bb3a-84bdd089573b">| <video src="https://github.com/user-attachments/assets/d2fc1b78-4df7-4420-b311-cf3042a240bd">  |  

## 리뷰 요구사항
- 얼럿 문구 괜찮나요?
- `네트워크 연결이 없어도 앱 사용 가능`을 우선으로 두어 작성화면 얼럿을 수정했습니다!  
  - 다른 의견 있으시면 언제든지 알려주세요~

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱 내부 네트워크 연결 모니터링 추가 및 연결 상태에 따른 인앱 알림과 수동 재시도 제공
  * 범용 Alert 컴포넌트 추가로 위치·네트워크 등 모달 메시지 통합 제공
  * 메시지 작성 시 위치가 비어있을 때 '그대로 작성' / '새로 고침' 선택지 제공

* **개선사항**
  * 위치 권한 UI를 경량화하고 공통 Alert로 통합
  * 장소 검색 실패 시 네트워크 미연결에 대한 명확한 안내 문구 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->