### PR TITLE
장소 검색 페이지네이션 구현

### DIFF
--- a/Meomun/Meomun/Data/Repository/NaverPlaceSearchRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/NaverPlaceSearchRepositoryImpl.swift
@@ -22,9 +22,10 @@ final class NaverPlaceSearchRepositoryImpl: PlaceRepository {
         self.clientSecret = clientSecret
     }
 
-    func searchPlace(query: String) async throws -> [NaverLocalItemDTO] {
+    func searchPlace(query: String, start: Int) async throws -> [NaverLocalItemDTO] {
         let endpoint = NaverLocalSearchEndpoint(
             query: query,
+            start: start,
             clientId: clientId,
             clientSecret: clientSecret
         )

--- a/Meomun/Meomun/Domain/Repository/PlaceRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/PlaceRepository.swift
@@ -6,5 +6,5 @@
 //
 
 protocol PlaceRepository: Sendable {
-    func searchPlace(query: String) async throws -> [NaverLocalItemDTO]
+    func searchPlace(query: String, start: Int) async throws -> [NaverLocalItemDTO]
 }

--- a/Meomun/Meomun/Domain/UseCase/SearchNearbyPlaceUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/SearchNearbyPlaceUseCase.swift
@@ -9,6 +9,7 @@ protocol SearchNearbyPlaceUseCase {
     func execute(
         query: String,
         userLocation: Coordinate,
+        start: Int
     ) async throws -> [Place]
 }
 
@@ -24,9 +25,10 @@ final class SearchNearbyPlaceUseCaseImpl: SearchNearbyPlaceUseCase {
     func execute(
         query: String,
         userLocation: Coordinate,
+        start: Int
     ) async throws -> [Place] {
 
-        let candidates = try await placeRepository.searchPlace(query: query)
+        let candidates = try await placeRepository.searchPlace(query: query, start: start)
 
         let places: [Place] = candidates.compactMap { item -> Place? in
             // mapx = longitude, mapy = latitude

--- a/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/LoadingOverlayView.swift
@@ -26,6 +26,8 @@ struct LoadingOverlayView: View {
     let status: LoadingStatus
     let message: String?
 
+    @State private var isPresented = false
+
     init(status: LoadingStatus = .loading, message: String? = nil) {
         self.status = status
         self.message = message
@@ -39,7 +41,15 @@ struct LoadingOverlayView: View {
             content
                 .frame(width: cardSize.width, height: cardSize.height)
                 .background(cardBackground)
+                .scaleEffect(isPresented ? 1.0 : 0.98)
+                .opacity(isPresented ? 1.0 : 0.0)
         }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isPresented = true
+            }
+        }
+        .onDisappear { isPresented = false }
         .animation(.spring(duration: 0.3), value: status)
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/PlaceSearchContainerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/PlaceSearchContainerView.swift
@@ -25,6 +25,7 @@ struct PlaceSearchContainerView<Content: View>: View {
                 .frame(width: 20, height: 20)
                 .clipped()
                 .foregroundStyle(Color(hex: "#53808C"))
+                .allowsHitTesting(false)
 
             content()
         }

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -43,18 +43,6 @@ struct MessageComposerView: View {
         ZStack {
             content
                 .disabled(isInteractionDisabled)
-
-            if store.state.isPlaceSearchPresented {
-                placeSearchOverlay
-                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
-                    .zIndex(999)
-            }
-
-            if store.state.confirmStatus != .idle {
-                loadingOverlay
-                    .transition(.opacity.animation(.easeInOut(duration: 0.2)))
-                    .zIndex(1000)
-            }
         }
         .enableSwipeBack(
             shouldBegin: {
@@ -95,6 +83,22 @@ struct MessageComposerView: View {
             guard store.state.alert != newValue else { return }
             send(.setAlert(newValue))
         }
+        .fullScreenCover(isPresented: Binding(
+            get: { store.state.isPlaceSearchPresented && store.state.confirmStatus == .idle },
+            set: { isPresented in if !isPresented { send(.dismissPlaceSearch) } }
+        )) {
+            placeSearchOverlay
+                .presentationBackground(.clear)
+        }
+        .fullScreenCover(isPresented: Binding(
+            get: { store.state.confirmStatus != .idle },
+            set: { _ in } // 사용자가 내리지 못하게 dismiss는 상태로만 제어
+        )) {
+            loadingOverlay
+                .presentationBackground(.clear)
+                .interactiveDismissDisabled(true)
+        }
+        .transaction { $0.disablesAnimations = true }
     }
 }
 
@@ -185,7 +189,8 @@ private extension MessageComposerView {
     var loadingOverlay: some View {
         LoadingOverlayView(
             status: store.state.confirmStatus,
-            message: loadingOverlayMessage)
+            message: loadingOverlayMessage
+        )
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -141,12 +141,12 @@ private extension MessageComposerView {
 
     var placeSection: some View {
         HStack(spacing: 8) {
-            PlaceSearchContainerView {
-                Button(action: onTapPlaceField) {
+            Button(action: onTapPlaceField) {
+                PlaceSearchContainerView {
                     Text(placeFieldText)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(placeFieldColor)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(placeFieldColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchOverlayView.swift
@@ -18,6 +18,8 @@ struct PlaceSearchOverlayView: View {
     @FocusState private var isFocused: Bool
     @StateObject private var store: PlaceSearchStore
 
+    @State private var isPresented = false
+
     init(store: PlaceSearchStore) {
         _store = StateObject(wrappedValue: store)
     }
@@ -28,24 +30,30 @@ struct PlaceSearchOverlayView: View {
                 .ignoresSafeArea()
                 .onTapGesture { Task { await store.send(intent: .dismiss) } }
 
-            VStack {
-                header
-                searchBar
-                searchResultList
-            }
-            .padding(28)
-            .frame(width: 320, height: 400)
-            .background(Color.white)
-            .cornerRadius(25)
-            .shadow(radius: 8)
-
-            .onTapGesture {
-                isFocused = false
-            }
-            .onAppear {
-                isFocused = true
+            if isPresented {
+                VStack {
+                    header
+                    searchBar
+                    searchResultList
+                }
+                .padding(28)
+                .frame(width: 320, height: 400)
+                .background(Color.white)
+                .cornerRadius(25)
+                .shadow(radius: 8)
+                .transition(.opacity.combined(with: .scale(scale: 0.98)))
+                .onTapGesture {
+                    isFocused = false
+                }
             }
         }
+        .onAppear {
+            isFocused = true
+            withAnimation(.easeInOut(duration: 0.3)) {
+                isPresented = true
+            }
+        }
+        .onDisappear { isPresented = false }
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchOverlayView.swift
@@ -28,7 +28,13 @@ struct PlaceSearchOverlayView: View {
         ZStack {
             Color.black.opacity(0.35)
                 .ignoresSafeArea()
-                .onTapGesture { Task { await store.send(intent: .dismiss) } }
+                .onTapGesture {
+                    if isFocused {
+                        isFocused = false
+                    } else {
+                        Task { await store.send(intent: .dismiss) }
+                    }
+                }
 
             if isPresented {
                 VStack {
@@ -59,12 +65,24 @@ struct PlaceSearchOverlayView: View {
 
 extension PlaceSearchOverlayView {
     var header: some View {
-        HStack {
-            Spacer()
+        ZStack {
             Text(Constants.title)
                 .font(.headline.weight(.semibold))
                 .foregroundStyle(Color.meomunPrimaryColor)
-            Spacer()
+
+            HStack {
+                Spacer()
+
+                Button {
+                    Task { await store.send(intent: .dismiss) }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.meomunSecondaryColor)
+                        .padding(10)
+                        .contentShape(Rectangle())
+                }
+            }
         }
     }
 

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchOverlayView.swift
@@ -131,6 +131,11 @@ extension PlaceSearchOverlayView {
                                     }
                                     Spacer()
                                 }
+                                .onAppear {
+                                    if place == results.last {
+                                        Task { await store.send(intent: .scrollReachedBottom) }
+                                    }
+                                }
                                 .foregroundStyle(Color.meomunPrimaryColor)
                                 .padding(.vertical, 5)
                                 .padding(.horizontal, 12)

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/SearchPlace/PlaceSearchStore.swift
@@ -30,6 +30,7 @@ final class PlaceSearchStore: Store {
     enum Intent {
         case queryChanged(String)
         case submit
+        case scrollReachedBottom
         case tapResult(Place)
         case dismiss
     }
@@ -38,18 +39,29 @@ final class PlaceSearchStore: Store {
         case setQuery(String)
         case setPhase(Phase)
         case clear
+
+        case appendResults([Place])
+        case setPagination(nextStart: Int, hasMore: Bool)
+        case setLoadingMore(Bool)
     }
 
     struct State {
         var query: String = ""
         var phase: Phase = .idle
         var userLocation: Coordinate?
+
+        // 페이지네이션
+        var display: Int = 5
+        var nextStart: Int = 1
+        var hasMore: Bool = true
+        var isLoadingMore: Bool = false
     }
 
     @Published var state: State
 
     // 검색 작업이 결과를 반환
     private var searchTask: Task<[Place], Never>?
+    private var loadMoreTask: Task<[Place], Never>?
 
     private let searchNearbyPlaces: SearchNearbyPlaceUseCase
 
@@ -78,11 +90,17 @@ final class PlaceSearchStore: Store {
             case .submit:
                 search(for: state.query, immediate: true)
 
+            case .scrollReachedBottom:
+                Task { @MainActor in
+                    loadMore()
+                }
+
             case .tapResult(let place):
                 onSelect(place)
 
             case .dismiss:
                 cancelSearch()
+                cancelLoadMore()
                 onDismiss()
             }
 
@@ -103,6 +121,21 @@ final class PlaceSearchStore: Store {
         case .clear:
             newState.query = ""
             newState.phase = .idle
+            newState.nextStart = 1
+            newState.hasMore = true
+            newState.isLoadingMore = false
+
+        case .appendResults(let places):
+            let current = newState.phase.results
+            let merged = current + places
+            newState.phase = .loaded(merged)
+
+        case .setPagination(nextStart: let nextStart, hasMore: let hasMore):
+            newState.nextStart = nextStart
+            newState.hasMore = hasMore
+
+        case .setLoadingMore(let flag):
+            newState.isLoadingMore = flag
         }
 
         return newState
@@ -112,11 +145,17 @@ final class PlaceSearchStore: Store {
     private func apply(_ action: Action) {
         state = reduce(state: state, action: action)
     }
+}
 
-    private func search(for query: String, immediate: Bool = false) {
+private extension PlaceSearchStore {
+
+    // MARK: - 검색
+
+    func search(for query: String, immediate: Bool = false) {
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         cancelSearch()
+        cancelLoadMore()
 
         guard !trimmedQuery.isEmpty else {
             Task { @MainActor in
@@ -128,6 +167,13 @@ final class PlaceSearchStore: Store {
         let stabilizedQuery = trimmedQuery
         let userLocation = self.state.userLocation
         let useCase = self.searchNearbyPlaces
+
+        // 페이지네이션 초기화
+        Task { @MainActor in
+            apply(.setPagination(nextStart: 1, hasMore: true))
+            apply(.setLoadingMore(false))
+            apply(.setPhase(.loading))
+        }
 
         searchTask = Task { [weak self] in
             guard let self, let userLocation else { return [] }
@@ -141,7 +187,8 @@ final class PlaceSearchStore: Store {
             do {
                 let results = try await useCase.execute(
                     query: stabilizedQuery,
-                    userLocation: userLocation
+                    userLocation: userLocation,
+                    start: 1
                 )
                 return results
             } catch {
@@ -151,29 +198,22 @@ final class PlaceSearchStore: Store {
         }
 
         Task { @MainActor [weak self] in
-            guard let self else { return }
-            self.apply(.setPhase(.loading))
-        }
-
-        Task { @MainActor [weak self] in
             guard let self, let task = self.searchTask else { return }
             let results = await task.value
             if Task.isCancelled { return }
 
-            await MainActor.run {
-                switch self.state.phase {
-                case .failed:
-                    return
-                default:
-                    let nextPhase: Phase = results.isEmpty ? .empty : .loaded(results)
-                    self.apply(.setPhase(nextPhase))
-                }
-            }
+            // 첫 페이지 결과 반영 + 페이지네이션 상태 업데이트
+            let hasMore = results.count == self.state.display
+            let nextStart = 1 + results.count
+
+            let nextPhase: Phase = results.isEmpty ? .empty : .loaded(results)
+            apply(.setPhase(nextPhase))
+            apply(.setPagination(nextStart: nextStart, hasMore: hasMore))
         }
     }
 
     @MainActor
-    private func handleSearchError(_ error: Error) {
+    func handleSearchError(_ error: Error) {
         if let urlError = error as? URLError, urlError.code == .cancelled {
             AppLog.debug("Search cancelled", category: .store)
             return
@@ -206,8 +246,71 @@ final class PlaceSearchStore: Store {
         }
     }
 
-    private func cancelSearch() {
+    func cancelSearch() {
         searchTask?.cancel()
         searchTask = nil
+    }
+
+    // MARK: - 페이지네이션
+
+    @MainActor
+    func loadMore() {
+        // loaded 상태에서만 더 불러오도록 함.
+        guard case .loaded = state.phase else { return }
+        guard state.hasMore else { return }
+        guard !state.isLoadingMore else { return }
+
+        let query = state.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return }
+
+        guard let userLocation = state.userLocation else { return }
+
+        let useCase = searchNearbyPlaces
+        let start = state.nextStart
+        let display = state.display
+
+        cancelLoadMore()
+        apply(.setLoadingMore(true))
+
+        loadMoreTask = Task {
+            if Task.isCancelled { return [] }
+
+            do {
+                let results = try await useCase.execute(
+                    query: query,
+                    userLocation: userLocation,
+                    start: start
+                )
+                return results
+            } catch {
+                AppLog.error("Load more failed", category: .network, error: error)
+                return []
+            }
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self, let task = self.loadMoreTask else { return }
+
+            defer {
+                apply(.setLoadingMore(false))
+            }
+
+            let results = await task.value
+            if Task.isCancelled { return }
+
+            if !results.isEmpty {
+                apply(.appendResults(results))
+            }
+
+            let hasMore = results.count == display
+            let nextStart = start + results.count
+
+            apply(.setPagination(nextStart: nextStart, hasMore: hasMore))
+        }
+    }
+
+    func cancelLoadMore() {
+        loadMoreTask?.cancel()
+        loadMoreTask = nil
     }
 }


### PR DESCRIPTION
## 배경
- closed #257

## 작업 요약
- 네이버 장소 검색 페이지네이션 구현
- 부분 단어 검색 확인

### 추가 수정 사항
- 장소 검색 오버레이 모달에 명시적 닫기 버튼 추가
- 장소 검색 오버레이(dim) 탭 동작 개선

## 작업 내용
### 1. 네이버 장소 검색 페이지네이션 구현
#### 1) Repository/UseCase 계층: start 기반 재호출 구조
* `NaverPlaceSearchRepositoryImpl.searchPlace(query:start:)`는 start를 받아 네이버 장소 검색을 재호출
* `SearchNearbyPlaceUseCase.execute(query:userLocation:start:)`는 DTO → Place 변환 후 사용자 위치 기준 정렬 수행

> **Store**: **‘start를 얼마로 요청할지’** 관리,
> **정렬/가공 로직**은 **UseCase**에서 일관되게 처리

#### 2) Store: 페이지네이션 상태 및 액션 추가
- **Intent 추가**
  * `.scrollReachedBottom`
    * 뷰에서 마지막 셀이 나타날 때 트리거되어 loadMore() 호출
- **Action 추가**
  * `.appendResults([Place])`: 기존 결과 뒤에 이어붙이기
  * `.setPagination(nextStart:hasMore:)`: 다음 요청 start 갱신 + 추가 로드 가능 여부 갱신
  * `.setLoadingMore(Bool)`: 중복 호출 방지 플래그
- **State 추가**
  * display: Int = 5 : 페이지당 수(기본값 및 최댓값 = 5)
  * nextStart: Int = 1 : 다음 start
  * hasMore: Bool = true : 더 불러올 수 있는지
  * isLoadingMore: Bool = false : 로딩 중 중복 호출 방지

#### 3) 검색 로직: 새 검색 시 페이지 상태 초기화
* `search(for:)` 실행 시:
  * 기존 searchTask, loadMoreTask 취소
  * `nextStart = 1`, `hasMore = true`, `isLoadingMore = false`로 초기화
  * 첫 페이지 요청은 start: 1로 수행
* 첫 페이지 결과 반영 후:
  * `hasMore = (results.count == display)`
  * `nextStart = 1 + results.count`

#### 4) loadMore 로직: 상태 기반 방어 + defer로 로딩 플래그 정리
* loadMore()는 아래 조건에서만 동작:
  * 현재 phase == .loaded
  * hasMore == true
  * isLoadingMore == false
  * query 비어있지 않음
  * userLocation 존재
* 실행 흐름:
  1. cancelLoadMore()
  2. setLoadingMore(true)
  3. start = state.nextStart로 요청
  4. 결과가 있으면 .appendResults
  5. nextStart / hasMore 갱신
  6. defer로 setLoadingMore(false) 보장

#### 5) View: 마지막 셀 노출 시 바닥 도달 트리거
* `.loaded(let results)`에서 ForEach 항목 중 **마지막 place가 onAppear 될 때** `store.send(.scrollReachedBottom)` 호출
* Store는 isLoadingMore로 중복 호출을 방어

### 2. 부분 단어 검색 확인
- 현재 쿼리가 바뀔 때마다 API 요청을 보내는 구조로 구현되어 있음.
  - queryChanged에서 `search(for:)` 바로 호출
- 그러나 **네이버 Local Search API 자체가 부분검색 지원을 잘 해주지 않음.**
  - 네이버 지역검색은 일반적인 like 검색이 아닌, **연관 검색(형태소/토큰 기반)**으로 동작함.
    - “판” -> 결과가 잘 나오지 않음.
    - “판교” -> 결과가 잘 나옴.

### 3. 장소 검색 오버레이(dim) 동작 개선
#### 배경
장소 검색 오버레이(PlaceSearchOverlayView)에서 dim 영역을 탭하면 모달 dismiss

이때 모달 진입 시 자동 포커싱으로 **키보드가 올라온 상태에서 dim을 탭하면**, 사용자는 **키보드를 내리려는 의도**였으나 모달이 바로 dismiss되는 문제가 발생함.

#### 개선 목표
dim 영역 탭에 대해 사용자 의도에 맞게 우선순위 재정의
* **키보드가 올라와 있으면(dim 탭) → 키보드 먼저 내리기**
* **키보드가 내려가 있으면(dim 탭) → 모달 dismiss**

#### 적용 내용
* dim 영역 onTapGesture에서 isFocused 상태를 기준으로 동작 분기
* 카드 컨테이너 내부 탭은 기존처럼 키보드만 내리도록 유지

#### 결과
![Simulator Screen Recording - iPhone 17 Pro - 2026-01-27 at 13 41 49](https://github.com/user-attachments/assets/a9c0a186-f989-4d23-b36c-4d5b4e497fd7)

## 스크린샷

https://github.com/user-attachments/assets/0a056dda-9042-4ed5-816c-0720bbe6b456


## 리뷰 요구사항
### 페이지네이션 로직 관련 참고 사항
응답에서 내려주는 total을 기준으로 페이지네이션을 구현하려 하였으나, **네이버 검색 API 응답에서 주는 total**의 의미는 ‘전체 응답 개수’가 아닌, **‘현재 내려주는 응답 개수’**인 것으로 보여졌습니다. (계속 5로만 떨어짐) 

-> 이에 따라 **’이번 페이지에서 받아온 결과 개수(results.count)가 display(=5)와 같으면 다음 페이지도 있을 것**’이라는 기준 아래 hasMore를 정하는 로직으로 구현한 점 참고 부탁드립니다!

### 추가 참고 사항
- #257 이슈에 포함된 내용 관련..
  - 장소 검색 후 엔터를 치면 모달 & 중앙의 '검색 결과가 없어요' 레이블이 각각 따로 내려감. -> 진입/퇴장 버그 수정 후 확인해보니 이제 해당 버그가 발견되지 않아 그냥 유지했습니다.
  - 장소 검색 결과 리스트에서 가끔 1번째와 동일한 요소가 리스트 3번째에 나오면서 스크롤에 따라 깜빡이는 형태로 보여짐. (재현 검색어: 가산 모비우스) -> 정말 저 재현 검색어 하나의 경우에서만 발견되는 문제여서 원인을 찾지 못했고, 이후 다른 오류 케이스가 더 나온다면 그때 다시 확인해보면 될 것 같습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 장소 검색에 명시적 페이징 지원 추가 — 스크롤 시 추가 결과를 불러옵니다.
  * 검색 결과 더보기(로드 더) 흐름과 취소 로직이 개선되었습니다.

* **Style**
  * 검색 오버레이를 전체 화면으로 전환하고 전환 애니메이션을 최적화했습니다.
  * 로딩 오버레이에 스케일 및 투명도 기반의 부드러운 애니메이션을 적용했습니다.
  * 지도 핀 아이콘의 터치 처리를 비활성화하여 기본 지도 인터랙션이 우선되도록 조정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->