### PR TITLE
메시지 삭제 흐름 구현

### DIFF
--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -63,8 +63,8 @@ final class MessageRepositoryImpl: MessageRepository {
             )
     }
 
-    func deleteMessages(messageIDs: [MessageID]) async throws {
-        return
+    func deleteMessages(messageIDs: Set<MessageID>) async throws {
+        try await storage.delete(messageIDs: messageIDs)
     }
 
     func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message] {

--- a/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
+++ b/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
@@ -71,4 +71,10 @@ actor MessageInMemoryStorage: MessageStorage {
             place: message.place
         )
     }
+
+    func delete(messageIDs: Set<MessageID>) async throws {
+        storage.removeAll { message in
+            messageIDs.contains(MessageID(value: message.id))
+        }
+    }
 }

--- a/Meomun/Meomun/Data/Storage/Interface/MessageStorage.swift
+++ b/Meomun/Meomun/Data/Storage/Interface/MessageStorage.swift
@@ -28,4 +28,6 @@ protocol MessageStorage: Sendable {
     func create(for message: CreateMessageRequestDTO) async throws
 
     func update(for message: UpdateMessageRequestDTO) async throws
+
+    func delete(messageIDs: Set<MessageID>) async throws
 }

--- a/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
+++ b/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
@@ -85,20 +85,29 @@ actor MessageSwiftDataStorage: MessageStorage {
         try context.save()
     }
 
-    func delete(messageID: MessageID) async throws {
+    func delete(messageIDs: Set<MessageID>) async throws {
         let context = makeContext()
 
-        let messageIdValue: UUID = messageID.value
-        var descriptor = FetchDescriptor<MessageModel>(
-            predicate: #Predicate { $0.id == messageIdValue }
-        )
-        descriptor.fetchLimit = 1
+        // Message.id: MessageID, MessageModel.id: UUID 이므로 타입을 맞추기 위해 map으로 변환
+        let messageIdValues: Set<UUID> = Set(messageIDs.map { $0.value })
 
-        if let target = try context.fetch(descriptor).first {
+        let descriptor = FetchDescriptor<MessageModel>(
+            predicate: #Predicate { message in
+                messageIdValues.contains(message.id)
+            }
+        )
+
+        let targets = try context.fetch(descriptor)
+
+        for target in targets {
             context.delete(target)
+        }
+
+        if !targets.isEmpty {
             try context.save()
+
         } else {
-            AppLog.warn("삭제할 대상 데이터가 없어요. MessageID : \(messageID)", category: .storage)
+            AppLog.warn("삭제할 대상 데이터가 없어요. MessageID : \(messageIDs)", category: .storage)
         }
     }
 

--- a/Meomun/Meomun/Domain/Repository/MessageRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/MessageRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol MessageRepository: Sendable {
     func createMessage(_ request: CreateMessageRequest) async throws
     func updateMessage(_ request: Message) async throws
-    func deleteMessages(messageIDs: [MessageID]) async throws
+    func deleteMessages(messageIDs: Set<MessageID>) async throws
 
     func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message]
     func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message]

--- a/Meomun/Meomun/Domain/UseCase/DeleteMessageUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/DeleteMessageUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  DeleteMessagesUseCase.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/27/26.
+//
+
+protocol DeleteMessagesUseCase {
+    func execute(for messageIDs: Set<MessageID>) async throws
+}
+
+final class DeleteMessagesUseCaseImpl: DeleteMessagesUseCase {
+    private let messageRepository: MessageRepository
+
+    init(messageRepository: MessageRepository) {
+        self.messageRepository = messageRepository
+    }
+
+    func execute(for messageIDs: Set<MessageID>) async throws {
+        try await messageRepository.deleteMessages(messageIDs: messageIDs)
+    }
+}


### PR DESCRIPTION
## 배경
- #282 
- #72 

## 작업 요약
- `MessageStorage`의 `delete` 메서드를 다중 삭제로 수정 (파라미터: `MessageID` -> `Set<MessageID>`)
- `MessageRepository`, `DeleteMessageUseCaseImpl` 구현

## 작업 내용
작업 요약과 동일해요~

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메시지 일괄 삭제 기능 추가

* **개선 사항**
  * 메시지 삭제 작업의 효율성 개선
  * 메시지 삭제 시 고유 ID 검증 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->