### PR TITLE
근처 메시지 조회 로직 구현 및 적용

### DIFF
--- a/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/MessageRepositoryImpl.swift
@@ -67,8 +67,8 @@ final class MessageRepositoryImpl: MessageRepository {
         return
     }
 
-    func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message] {
-        try await storage.fetchNearby(at: location, limit: limit)
+    func fetchNearbyMessages(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message] {
+        try await storage.fetchNearby(at: location, bounds: bounds, limit: limit)
             .map { $0.toDomain() }
     }
 

--- a/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
+++ b/Meomun/Meomun/Data/Storage/InMemory/MessageInMemoryStorage.swift
@@ -14,7 +14,7 @@ actor MessageInMemoryStorage: MessageStorage {
 
     private init() { }
 
-    func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO] {
+    func fetchNearby(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [MessageResponseDTO] {
         // 인메모리 임시 구현이므로 반경 필터링 생략
         storage
     }

--- a/Meomun/Meomun/Data/Storage/Interface/MessageStorage.swift
+++ b/Meomun/Meomun/Data/Storage/Interface/MessageStorage.swift
@@ -11,7 +11,7 @@ protocol MessageStorage: Sendable {
     /// - Parameters:
     ///   - coordinate: 검색 기준이 되는 중심 좌표
     ///   - limit: 반환할 최대 메시지 개수. nil이면 모든 메시지를 반환합니다.
-    func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO]
+    func fetchNearby(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [MessageResponseDTO]
 
     /// 특정 장소의 메시지를 최신순으로 반환합니다.
     /// - Parameters:

--- a/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
+++ b/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
@@ -44,8 +44,6 @@ actor MessageSwiftDataStorage: MessageStorage {
                 message.longitude <= maxLongitude
             }
         )
-        if let limit { descriptor.fetchLimit = limit }
-
         let filteredData = try context.fetch(descriptor)
 
         // 2차: 거리 계산 정렬
@@ -55,9 +53,10 @@ actor MessageSwiftDataStorage: MessageStorage {
                 return (item, location.distance(to: other))
             }
             .sorted { $0.1 < $1.1 }
+            .map { $0.0 }
 
-        let results = sortedData
-        return results.map { $0.0.toDTO() }
+        let results = limit.map { Array(sortedData.prefix($0)) } ?? sortedData
+        return results.map { $0.toDTO() }
     }
 
     func fetchByPlace(at placeID: PlaceID, limit: Int?) async throws -> [MessageResponseDTO] {

--- a/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
+++ b/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
@@ -27,17 +27,37 @@ actor MessageSwiftDataStorage: MessageStorage {
         return ModelContext(container)
     }
 
-    // TODO: Usecase에 근처 메시지 조회 로직 추가 후 fetchNearby 파라미터 변경 필요
-    func fetchNearby(at coordinate: Coordinate, limit: Int?) async throws -> [MessageResponseDTO] {
+    func fetchNearby(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [MessageResponseDTO] {
         let context = makeContext()
 
+        let minLatitude = bounds.minLatitude
+        let maxLatitude = bounds.maxLatitude
+        let minLongitude = bounds.minLongitude
+        let maxLongitude = bounds.maxLongitude
+
+        // 1차: BoundingBox 범위로 필터링
         var descriptor = FetchDescriptor<MessageModel>(
-            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+            predicate: #Predicate { message in
+                message.latitude >= minLatitude &&
+                message.latitude <= maxLatitude &&
+                message.longitude >= minLongitude &&
+                message.longitude <= maxLongitude
+            }
         )
         if let limit { descriptor.fetchLimit = limit }
 
-        let results = try context.fetch(descriptor)
-        return results.map { $0.toDTO() }
+        let filteredData = try context.fetch(descriptor)
+
+        // 2차: 거리 계산 정렬
+        let sortedData = filteredData
+            .map { item -> (MessageModel, Double) in
+                let other = Coordinate(latitude: item.latitude, longitude: item.longitude)
+                return (item, location.distance(to: other))
+            }
+            .sorted { $0.1 < $1.1 }
+
+        let results = sortedData
+        return results.map { $0.0.toDTO() }
     }
 
     func fetchByPlace(at placeID: PlaceID, limit: Int?) async throws -> [MessageResponseDTO] {

--- a/Meomun/Meomun/Domain/Entity/BoundingBox.swift
+++ b/Meomun/Meomun/Domain/Entity/BoundingBox.swift
@@ -1,0 +1,13 @@
+//
+//  BoundingBox.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/27/26.
+//
+
+struct BoundingBox: Equatable, Sendable {
+    let minLatitude: Double
+    let maxLatitude: Double
+    let minLongitude: Double
+    let maxLongitude: Double
+}

--- a/Meomun/Meomun/Domain/Entity/BoundingBox.swift
+++ b/Meomun/Meomun/Domain/Entity/BoundingBox.swift
@@ -11,3 +11,20 @@ struct BoundingBox: Equatable, Sendable {
     let minLongitude: Double
     let maxLongitude: Double
 }
+
+extension BoundingBox {
+    func expanded(by ratio: Double) -> BoundingBox {
+        let latitudeSpan = maxLatitude - minLatitude
+        let longitudeSpan = maxLongitude - minLongitude
+
+        let latitudePadding = latitudeSpan * ratio
+        let longitudePadding = longitudeSpan * ratio
+
+        return BoundingBox(
+            minLatitude: minLatitude - latitudePadding,
+            maxLatitude: maxLatitude + latitudePadding,
+            minLongitude: minLongitude - longitudePadding,
+            maxLongitude: maxLongitude + longitudePadding
+        )
+    }
+}

--- a/Meomun/Meomun/Domain/Repository/MessageRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/MessageRepository.swift
@@ -12,7 +12,7 @@ protocol MessageRepository: Sendable {
     func updateMessage(_ request: Message) async throws
     func deleteMessages(messageIDs: [MessageID]) async throws
 
-    func fetchNearbyMessages(location: Coordinate, limit: Int?) async throws -> [Message]
+    func fetchNearbyMessages(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message]
     func fetchPlaceMessages(placeID: PlaceID, limit: Int?) async throws -> [Message]
     func fetchRecentMessages(page: Int, pageSize: Int) async throws -> [Message]
 }

--- a/Meomun/Meomun/Domain/UseCase/GetNearbyMessagesUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/GetNearbyMessagesUseCase.swift
@@ -6,7 +6,7 @@
 //
 
 protocol GetNearbyMessagesUseCase {
-    func execute(location: Coordinate, limit: Int?) async throws -> [Message]
+    func execute(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message]
 }
 
 final class GetNearbyMessagesUseCaseImpl: GetNearbyMessagesUseCase {
@@ -16,7 +16,7 @@ final class GetNearbyMessagesUseCaseImpl: GetNearbyMessagesUseCase {
         self.messageRepository = messageRepository
     }
 
-    func execute(location: Coordinate, limit: Int?) async throws -> [Message] {
-        try await messageRepository.fetchNearbyMessages(location: location, limit: limit)
+    func execute(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message] {
+        try await messageRepository.fetchNearbyMessages(at: location, bounds: bounds, limit: limit)
     }
 }

--- a/Meomun/Meomun/Domain/UseCase/GetNearbyMessagesUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/GetNearbyMessagesUseCase.swift
@@ -5,6 +5,10 @@
 //  Created by 지연 on 1/15/26.
 //
 
+fileprivate enum Constants {
+    static let prefetchRatio: Double = 0.2
+}
+
 protocol GetNearbyMessagesUseCase {
     func execute(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message]
 }
@@ -17,6 +21,8 @@ final class GetNearbyMessagesUseCaseImpl: GetNearbyMessagesUseCase {
     }
 
     func execute(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message] {
-        try await messageRepository.fetchNearbyMessages(at: location, bounds: bounds, limit: limit)
+        let prefetchBounds = bounds.expanded(by: Constants.prefetchRatio)
+
+        return try await messageRepository.fetchNearbyMessages(at: location, bounds: prefetchBounds, limit: limit)
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -12,8 +12,8 @@ final class MapStore: Store {
     enum Intent {
         case onAppear(Coordinate)
         case onDisappear
-        case cameraDidIdle(Coordinate)
-        case cameraChangedByLocation(Coordinate)
+        case cameraDidIdle(Coordinate, BoundingBox)
+        case cameraChangedByLocation(Coordinate, BoundingBox)
         case dismissAddMessage
         case updateMessages([Message])
         case tapNoPlaceMarker([Message])
@@ -70,21 +70,19 @@ final class MapStore: Store {
                 let isConnected = networkMonitor.checkConnection()
                 continuation.yield(.setNetworkConnected(isConnected))
 
-                self.getNearbyMessages(at: coordinate, continuation: continuation)
-
             case .onDisappear:
                 self.getNearbyMessageTask?.cancel()
                 self.getNearbyMessageTask = nil
                 continuation.yield(.setLoading(false))
                 continuation.finish()
 
-            case .cameraDidIdle(let coordinate):
+            case .cameraDidIdle(let coordinate, let boundingBox):
                 continuation.yield(.setCameraCoordinate(coordinate))
-                self.getNearbyMessages(at: coordinate, continuation: continuation)
+                self.getNearbyMessages(at: coordinate, bounds: boundingBox, continuation: continuation)
 
-            case .cameraChangedByLocation(let coordinate):
+            case .cameraChangedByLocation(let coordinate, let boundingBox):
                 continuation.yield(.setCameraCoordinate(coordinate))
-                self.getNearbyMessages(at: coordinate, continuation: continuation)
+                self.getNearbyMessages(at: coordinate, bounds: boundingBox, continuation: continuation)
 
             case .dismissAddMessage:
                 continuation.yield(.setShowAddMessage(false))
@@ -148,6 +146,7 @@ final class MapStore: Store {
 
     private func getNearbyMessages(
         at coordinate: Coordinate,
+        bounds: BoundingBox,
         continuation: AsyncStream<Action>.Continuation
     ) {
         getNearbyMessageTask?.cancel()
@@ -174,10 +173,10 @@ final class MapStore: Store {
 
             do {
                 let messages = try await self.getNearbyMessagesUseCase.execute(
-                    location: coordinate,
+                    at: coordinate,
+                    bounds: bounds,
                     limit: nil
                 )
-//                let messages = self.getDummyMessages()
 
                 guard !Task.isCancelled else { return }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -49,12 +49,12 @@ struct MapView: View {
                     },
                     onCameraIdle: { coordinate, bounds in
                         Task {
-                            await store.send(intent: .cameraDidIdle(coordinate))
+                            await store.send(intent: .cameraDidIdle(coordinate, bounds))
                         }
                     },
                     onCameraChangedByLocation: { coordinate, bounds in
                         Task {
-                            await store.send(intent: .cameraChangedByLocation(coordinate))
+                            await store.send(intent: .cameraChangedByLocation(coordinate, bounds))
                         }
                     }
                 )

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -47,12 +47,12 @@ struct MapView: View {
                             await store.send(intent: .tapNoPlaceMarker(messages))
                         }
                     },
-                    onCameraIdle: { coordinate in
+                    onCameraIdle: { coordinate, bounds in
                         Task {
                             await store.send(intent: .cameraDidIdle(coordinate))
                         }
                     },
-                    onCameraChangedByLocation: { coordinate in
+                    onCameraChangedByLocation: { coordinate, bounds in
                         Task {
                             await store.send(intent: .cameraChangedByLocation(coordinate))
                         }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -249,14 +249,7 @@ extension MapViewController: NMFMapViewCameraDelegate {
     func mapViewCameraIdle(_ mapView: NMFMapView) {
         let center = mapView.cameraPosition.target
         let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
-
-        let nmfBounds = mapView.contentBounds
-        let domainBounds = BoundingBox(
-            minLatitude: nmfBounds.southWestLat,
-            maxLatitude: nmfBounds.northEastLat,
-            minLongitude: nmfBounds.southWestLng,
-            maxLongitude: nmfBounds.northEastLng
-        )
+        let domainBounds = makeBoundingBox(from: mapView)
 
         onCameraIdle?(coordinate, domainBounds)
     }
@@ -272,16 +265,19 @@ extension MapViewController: NMFMapViewCameraDelegate {
         // 카메라 중심 좌표 추출 및 콜백 호출
         let center = mapView.cameraPosition.target
         let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
+        let domainBounds = makeBoundingBox(from: mapView)
 
+        onCameraChangedByLocation?(coordinate, domainBounds)
+    }
+
+    private func makeBoundingBox(from mapView: NMFMapView) -> BoundingBox {
         let nmfBounds = mapView.contentBounds
-        let domainBounds = BoundingBox(
+        return BoundingBox(
             minLatitude: nmfBounds.southWestLat,
             maxLatitude: nmfBounds.northEastLat,
             minLongitude: nmfBounds.southWestLng,
             maxLongitude: nmfBounds.northEastLng
         )
-
-        onCameraChangedByLocation?(coordinate, domainBounds)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -27,8 +27,8 @@ final class MapViewController: UIViewController {
 
     private let onTapPlace: ((Place) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
-    private let onCameraIdle: ((Coordinate) -> Void)?
-    private let onCameraChangedByLocation: ((Coordinate) -> Void)?
+    private let onCameraIdle: ((Coordinate, BoundingBox) -> Void)?
+    private let onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)?
 
     // MARK: - Dependencies
 
@@ -41,8 +41,8 @@ final class MapViewController: UIViewController {
         messageMarkerManager: MessageMarkerManager,
         onTapPlace: ((Place) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
-        onCameraIdle: ((Coordinate) -> Void)? = nil,
-        onCameraChangedByLocation: ((Coordinate) -> Void)? = nil
+        onCameraIdle: ((Coordinate, BoundingBox) -> Void)? = nil,
+        onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)? = nil
     ) {
         self.messageMarkerManager = messageMarkerManager
         self.onTapPlace = onTapPlace
@@ -249,7 +249,16 @@ extension MapViewController: NMFMapViewCameraDelegate {
     func mapViewCameraIdle(_ mapView: NMFMapView) {
         let center = mapView.cameraPosition.target
         let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
-        onCameraIdle?(coordinate)
+
+        let nmfBounds = mapView.contentBounds
+        let domainBounds = BoundingBox(
+            minLatitude: nmfBounds.southWestLat,
+            maxLatitude: nmfBounds.northEastLat,
+            minLongitude: nmfBounds.southWestLng,
+            maxLongitude: nmfBounds.northEastLng
+        )
+
+        onCameraIdle?(coordinate, domainBounds)
     }
 
     func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
@@ -263,7 +272,16 @@ extension MapViewController: NMFMapViewCameraDelegate {
         // 카메라 중심 좌표 추출 및 콜백 호출
         let center = mapView.cameraPosition.target
         let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
-        onCameraChangedByLocation?(coordinate)
+
+        let nmfBounds = mapView.contentBounds
+        let domainBounds = BoundingBox(
+            minLatitude: nmfBounds.southWestLat,
+            maxLatitude: nmfBounds.northEastLat,
+            minLongitude: nmfBounds.southWestLng,
+            maxLongitude: nmfBounds.northEastLng
+        )
+
+        onCameraChangedByLocation?(coordinate, domainBounds)
     }
 }
 
@@ -274,8 +292,8 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     private let userLocation: Coordinate?
     private let onTapPlace: ((Place) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
-    private let onCameraIdle: ((Coordinate) -> Void)?
-    private let onCameraChangedByLocation: ((Coordinate) -> Void)?
+    private let onCameraIdle: ((Coordinate, BoundingBox) -> Void)?
+    private let onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)?
 
     private let messageMarkerManager: MessageMarkerManager
 
@@ -285,8 +303,8 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         messages: [Message],
         onTapPlace: ((Place) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
-        onCameraIdle: ((Coordinate) -> Void)? = nil,
-        onCameraChangedByLocation: ((Coordinate) -> Void)? = nil
+        onCameraIdle: ((Coordinate, BoundingBox) -> Void)? = nil,
+        onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)? = nil
     ) {
         self.userLocation = userLocation
         self.messageMarkerManager = markerManager


### PR DESCRIPTION
## 배경
- closed #291 

## 작업 요약
- [x] Naver Dynamic Map SDK 기반 카메라 뷰포트(BoundingBox) 계산
- [x] Nearby 메시지 조회 흐름 설계
- [x] 카메라 Idle / 위치 추적 변경 시점을 기준으로 한 Nearby 조회 트리거 정리

## 작업 내용
### Naver Map 카메라 뷰포트(BoundingBox) 계산
#### 배경
- UseCase에 BoundingBox 로직을 작성하다가, MapSDK에서 기능을 제공할 것 같다는 생각이 들었음
- 확인 결과 SDK에서 뷰포트 영역을 제공하고 있었기 때문에 해당 값을 활용하는 것으로 방향을 변경 [SDK문서 참고](https://navermaps.github.io/ios-map-sdk/guide-ko/2-2.html)

#### 구현
- NMFMapView 는 현재 화면에 보이는 영역을 `NMGLatLngBounds` (MBR) 형태로 제공
- 이 값을 그대로 Domain 레벨의 BoundingBox 로 변환하면 “현재 사용자에게 실제로 보이는 지도 범위” 기준의 Nearby 조회 가능

```swift
let nmfBounds = mapView.contentBounds
let domainBounds = BoundingBox(
    minLatitude: nmfBounds.southWestLat,
    maxLatitude: nmfBounds.northEastLat,
    minLongitude: nmfBounds.southWestLng,
    maxLongitude: nmfBounds.northEastLng
)
```

### 카메라 이동 이벤트 기준 Nearby 조회 트리거 정리
#### 사용한 카메라 이벤트
- mapViewCameraIdle
  - 사용자가 드래그/줌을 끝낸 시점
  - Nearby 메시지 조회의 메인 트리거
- cameraDidChangeByReason == NMFMapChangedByLocation
  - 위치 추적 모드(direction / compass)에서의 자동 이동
  - Idle 이벤트가 발생하지 않는 경우를 보완

#### 적용 코드
```swift
func mapViewCameraIdle(_ mapView: NMFMapView) {
    onCameraIdle?(coordinate, **domainBounds**)
}

func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
    guard reason == NMFMapChangedByLocation else { return }
    guard positionMode == .direction || positionMode == .compass else { return }

    onCameraChangedByLocation?(coordinate, **domainBounds**)
}
```

→ “카메라 상태 변화 → viewport 계산 → Store 전달” 이 일관되게 유지됨

### SwiftUI onAppear 의존 제거 & viewport 단일 소스화

#### 기존 문제
- `MapView.onAppear` 시점에는 UIKit 기반 NMFMapView 레이아웃이 아직 완료되지 않았을 수 있음
- 따라서 BoundingBox를 신뢰할 수 없음 (!!)

#### 해결
- 초기 Nearby 조회도 MapViewController에서만 발생
- SwiftUI onAppear 에서는 `카메라 좌표 설정`, `네트워크 상태 체크만 수행`
- 실제 데이터 조회는 항상 `cameraIdle` / `cameraChangedByLocation` 이벤트 기반

→ “초기 진입 / 이후 이동” 모두 동일한 흐름으로 처리

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **개선사항**
  * 지도 경계(바운딩박스)를 활용해 주변 메시지를 조회하도록 개선되어 결과가 더 정확해졌습니다.
  * 카메라 이동 및 유휴 이벤트에서 지도 경계 정보를 전달해 자동으로 메시지 검색이 트리거됩니다.
  * 검색 결과가 거리 기준으로 우선 정렬되어 사용자가 가까운 메시지를 먼저 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->