### PR TITLE
타임라인 뷰 편집모드 구현 및 삭제 기능 구현

### DIFF
--- a/Meomun/Meomun/Domain/UseCase/DeleteMessageUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/DeleteMessageUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  DeleteMessageUseCase.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/27/26.
+//
+
+protocol DeleteMessageUseCase {
+    func execute(for messageIDs: Set<MessageID>) async throws
+}
+
+final class DeleteMessageUseCaseImpl: DeleteMessageUseCase {
+    private let messageRepository: MessageRepository
+
+    init(messageRepository: MessageRepository) {
+        self.messageRepository = messageRepository
+    }
+
+    func execute(for messageIDs: Set<MessageID>) async throws {
+        try await messageRepository.deleteMessages(messageIDs: messageIDs)
+    }
+}

--- a/Meomun/Meomun/Presentation/Common/AlertFactory.swift
+++ b/Meomun/Meomun/Presentation/Common/AlertFactory.swift
@@ -1,0 +1,26 @@
+//
+//  AlertFactory.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/27/26.
+//
+
+import Foundation
+
+enum AlertFactory {
+    static func deleteMessage(
+        count: Int,
+        onConfirm: @escaping () -> Void
+    ) -> AlertModel {
+        AlertModel(
+            title: "메시지 삭제",
+            message: count == 1
+                ? "이 메시지를 삭제하시겠습니까?"
+                : "\(count)개의 메시지를 삭제하시겠습니까?",
+            buttons: [
+                AlertButtonConfig(title: "취소", role: .cancel, action: nil),
+                AlertButtonConfig(title: "삭제", role: .destructive, action: onConfirm)
+            ]
+        )
+    }
+}

--- a/Meomun/Meomun/Presentation/Common/Component/FloatingTabBar.swift
+++ b/Meomun/Meomun/Presentation/Common/Component/FloatingTabBar.swift
@@ -34,24 +34,7 @@ struct FloatingTabBar: View {
 //                onSelect(.myPage)
 //            }
         }
-        .padding(.horizontal, 22)
-        .padding(.vertical, 22)
-        .background(
-            CornerRadiusShape(
-                topLeft: 24,
-                topRight: 24,
-                bottomLeft: 10,
-                bottomRight: 10
-            )
-            .fill(.white.opacity(0.76))
-            .shadow(
-                color: .black.opacity(0.12),
-                radius: 18,
-                x: 0,
-                y: 6
-            )
-        )
-        .padding(.horizontal, 30)
+        .floatingContainer()
         .animation(
             .spring(
                 response: 0.25,
@@ -59,7 +42,6 @@ struct FloatingTabBar: View {
             ),
             value: selectedTab
         )
-        .padding(.bottom, 5)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Common/Modifier/FloatingContainerModifier.swift
+++ b/Meomun/Meomun/Presentation/Common/Modifier/FloatingContainerModifier.swift
@@ -1,0 +1,40 @@
+//
+//  FloatingContainerModifier.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/27/26.
+//
+
+import SwiftUI
+
+struct FloatingContainerModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(minHeight: 25)  // FloatingTabItem 내용물 기준 최소 높이
+            .padding(.horizontal, 22)
+            .padding(.vertical, 22)
+            .background(
+                CornerRadiusShape(
+                    topLeft: 24,
+                    topRight: 24,
+                    bottomLeft: 10,
+                    bottomRight: 10
+                )
+                .fill(.white.opacity(0.76))
+                .shadow(
+                    color: .black.opacity(0.12),
+                    radius: 18,
+                    x: 0,
+                    y: 6
+                )
+            )
+            .padding(.horizontal, 30)
+            .padding(.bottom, 5)
+    }
+}
+
+extension View {
+    func floatingContainer() -> some View {
+        modifier(FloatingContainerModifier())
+    }
+}

--- a/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
+++ b/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
@@ -55,7 +55,7 @@ struct MainTabShellView: View {
                     fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                         repository: MessageRepositoryImpl()
                     ),
-                    deleteMesagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
+                    deleteMessagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
                 )
             )
 

--- a/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
+++ b/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
@@ -52,7 +52,10 @@ struct MainTabShellView: View {
         case .record:
             TimelineListView(
                 store: TimelineListStore(
-                    fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(repository: MessageRepositoryImpl())
+                    fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
+                        repository: MessageRepositoryImpl()
+                    ),
+                    deleteMesagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
                 )
             )
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -113,7 +113,7 @@ struct MapView: View {
                         fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                             repository: MessageRepositoryImpl()
                         ),
-                        deleteMesagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
+                        deleteMessagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
                     ),
                     configuration: .bottomSheet
                 )

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -112,7 +112,8 @@ struct MapView: View {
                     store: TimelineListStore(
                         fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                             repository: MessageRepositoryImpl()
-                        )
+                        ),
+                        deleteMesagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
                     ),
                     configuration: .bottomSheet
                 )

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineIndicatorView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineIndicatorView.swift
@@ -7,6 +7,18 @@
 
 import SwiftUI
 
+/// 타임라인 행의 선택 상태를 의미합니다.
+enum TimelineSelectionState {
+    /// 편집 모드 비활성화 -> 기본 노드
+    case inactive
+
+    /// 편집 모드, 미선택 -> 회색 원
+    case unselected
+
+    /// 편집 모드, 선택됨 -> 체크 마크
+    case selected
+}
+
 struct TimelineIndicatorView: View {
     enum Layout {
         static let lineWidth: CGFloat = 1

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineIndicatorView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineIndicatorView.swift
@@ -29,6 +29,14 @@ struct TimelineIndicatorView: View {
     let height: CGFloat
     let showTopLine: Bool
     let showBottomLine: Bool
+    private let selectionState: TimelineSelectionState
+
+    init(height: CGFloat, showTopLine: Bool, showBottomLine: Bool, selectionState: TimelineSelectionState = .inactive) {
+        self.height = height
+        self.showTopLine = showTopLine
+        self.showBottomLine = showBottomLine
+        self.selectionState = selectionState
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -37,11 +45,7 @@ struct TimelineIndicatorView: View {
                 .frame(width: Layout.lineWidth)
                 .frame(maxHeight: .infinity)
 
-            Circle()
-                .strokeBorder(Color.meomunPointColor.opacity(0.7), lineWidth: 2)
-                .background(Circle().fill(Color.clear))
-                .frame(width: Layout.nodeSize, height: Layout.nodeSize)
-                .padding(.vertical, 6)
+            indicator
 
             Rectangle()
                 .fill(Color.meomunSecondaryColor.opacity(showBottomLine ? 0.35 : 0))
@@ -52,14 +56,40 @@ struct TimelineIndicatorView: View {
     }
 }
 
+extension TimelineIndicatorView {
+    private var indicator: some View {
+        Group {
+            switch selectionState {
+            case .inactive:
+                Circle()
+                    .strokeBorder(Color.meomunPointColor.opacity(0.7), lineWidth: 2)
+                    .background(Circle().fill(Color.clear))
+                    .frame(width: Layout.nodeSize, height: Layout.nodeSize)
+                    .padding(.vertical, 6)
+
+            case .unselected:
+                Circle()
+                    .strokeBorder(Color.meomunSecondaryColor, lineWidth: 1.5)
+                    .frame(width: Layout.nodeSize * 2.5, height: Layout.nodeSize * 2.5)
+
+            case .selected:
+                Image(systemName: "checkmark.circle")
+                    .resizable()
+                    .foregroundStyle(Color.meomunPointColor.opacity(0.7))
+                    .frame(width: Layout.nodeSize * 2.5, height: Layout.nodeSize * 2.5)
+            }
+        }
+    }
+}
+
 #Preview {
     let height: CGFloat = 120
     VStack(spacing: 0) {
-        TimelineIndicatorView(height: height, showTopLine: false, showBottomLine: true)
-        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: true)
-        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: true)
-        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: true)
-        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: false)
+        TimelineIndicatorView(height: height, showTopLine: false, showBottomLine: true, selectionState: .inactive)
+        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: true, selectionState: .unselected)
+        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: true, selectionState: .selected)
+        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: true, selectionState: .unselected)
+        TimelineIndicatorView(height: height, showTopLine: true, showBottomLine: false, selectionState: .unselected)
 
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineRowView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineRowView.swift
@@ -11,6 +11,19 @@ struct TimelineRowView: View {
     let message: Message
     let showTopLine: Bool
     let showBottomLine: Bool
+    private let selectionState: TimelineSelectionState
+
+    init(
+        message: Message,
+        showTopLine: Bool,
+        showBottomLine: Bool,
+        selectionState: TimelineSelectionState
+    ) {
+        self.message = message
+        self.showTopLine = showTopLine
+        self.showBottomLine = showBottomLine
+        self.selectionState = selectionState
+    }
 
     @State private var messageBoxHeight: CGFloat = 0
 
@@ -23,7 +36,8 @@ struct TimelineRowView: View {
             TimelineIndicatorView(
                 height: indicatorHeight,
                 showTopLine: showTopLine,
-                showBottomLine: showBottomLine
+                showBottomLine: showBottomLine,
+                selectionState: selectionState
             )
 
             MessageBoxView(message: message)
@@ -38,6 +52,7 @@ struct TimelineRowView: View {
 }
 
 #Preview {
+    var selectionStates: [TimelineSelectionState]  = [.inactive, .unselected, .selected]
     let messages: [Message] =  [
         Message(
             id: MessageID(value: UUID()),
@@ -70,7 +85,8 @@ struct TimelineRowView: View {
             TimelineRowView(
                 message: message,
                 showTopLine: index != 0,
-                showBottomLine: index != messages.count - 1
+                showBottomLine: index != messages.count - 1,
+                selectionState: selectionStates[index % messages.count]
             )
         }
     }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -15,6 +15,7 @@ final class TimelineListStore: Store {
         var isEditing: Bool = false
 
         var selectedMessageIDs: Set<MessageID> = []     // 편집 모드 시 선택 된 메시지
+        var deleteAlert: AlertModel?
 
         var sections: [(key: YearMonth, value: [Message])] {
             MessageTimelineGrouper.groupByYearMonth(messages)
@@ -24,7 +25,9 @@ final class TimelineListStore: Store {
     enum Intent: Equatable {
         case onAppear
         case setMessages([Message])
-        case deleteSelectedMessages
+        case requestDeleteSelectedMessages          // 편집 모드 -> 삭제
+        case confirmDeleteSelectedMessages          // 얼럿 - 삭제
+        case dismissAlert                           // 얼럿 - 취소
 
         case tapMessage(MessageID)
         case tapSection(YearMonth)
@@ -39,6 +42,8 @@ final class TimelineListStore: Store {
         case setSelectedSection(YearMonth?)
         case setEditing(Bool)
         case deleteMessages(Set<MessageID>)
+        case showDeleteAlert(AlertModel)
+        case hideAlert
     }
 
     @Published var state: State
@@ -83,17 +88,35 @@ final class TimelineListStore: Store {
                 guard state.isEditing else { break }
                 continuation.yield(.toggleMessageSelection(messageID))
 
-            case .deleteSelectedMessages:
+            case .requestDeleteSelectedMessages:
+                let alert = AlertFactory.deleteMessage(
+                    count: state.selectedMessageIDs.count,
+                    onConfirm: { [weak self] in
+                        guard let self else { return }
+                        Task {
+                            await self.send(intent: .confirmDeleteSelectedMessages)
+                        }
+                    }
+                )
+                continuation.yield(.showDeleteAlert(alert))
+
+            case .confirmDeleteSelectedMessages:
                 Task {
                     do {
                         try await deleteMesagesUseCase.execute(for: state.selectedMessageIDs)
                         continuation.yield(.deleteMessages(state.selectedMessageIDs))
                         continuation.yield(.setEditing(false))
                         continuation.yield(.clearSelectedMessageIDs)
+                        continuation.yield(.hideAlert)
                     } catch {
-                        print("메시지 삭제 실패")
+                        AppLog.error("메시지 삭제 실패", category: .store, error: error)
                     }
+                    continuation.finish()
                 }
+                return
+
+            case .dismissAlert:
+                continuation.yield(.hideAlert)
 
             case .setMessages(let messages):
                 continuation.yield(.setMessages(messages))
@@ -136,6 +159,12 @@ final class TimelineListStore: Store {
             newState.messages.removeAll { messageIDs.contains($0.id) }
             newState.selectedMessageIDs.subtract(messageIDs)
             cleanupSectionIfNeeded(&newState)
+
+        case .showDeleteAlert(let alert):
+            newState.deleteAlert = alert
+
+        case .hideAlert:
+            newState.deleteAlert = nil
         }
 
         return newState

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -24,7 +24,7 @@ final class TimelineListStore: Store {
     enum Intent: Equatable {
         case onAppear
         case setMessages([Message])
-        case deleteMessages([Message.ID])
+        case deleteSelectedMessages
 
         case tapMessage(MessageID)
         case tapSection(YearMonth)
@@ -38,16 +38,22 @@ final class TimelineListStore: Store {
         case clearSelectedMessageIDs
         case setSelectedSection(YearMonth?)
         case setEditing(Bool)
-        case deleteMessages([Message.ID])
+        case deleteMessages(Set<MessageID>)
     }
 
     @Published var state: State
 
     private let fetchRecentMessagesUseCase: FetchRecentMessagesUseCase
+    private let deleteMesagesUseCase: DeleteMessageUseCase
 
-    init(initialMessages: [Message] = [], fetchRecentMessagesUseCase: FetchRecentMessagesUseCase) {
+    init(
+        initialMessages: [Message] = [],
+        fetchRecentMessagesUseCase: FetchRecentMessagesUseCase,
+        deleteMesagesUseCase: DeleteMessageUseCase
+    ) {
         self.state = State(messages: initialMessages)
         self.fetchRecentMessagesUseCase = fetchRecentMessagesUseCase
+        self.deleteMesagesUseCase = deleteMesagesUseCase
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {
@@ -77,9 +83,17 @@ final class TimelineListStore: Store {
                 guard state.isEditing else { break }
                 continuation.yield(.toggleMessageSelection(messageID))
 
-            case .deleteMessages(let ids):
-                // TODO: 메시지 삭제 동작 구현
-                continuation.yield(.deleteMessages(ids))
+            case .deleteSelectedMessages:
+                Task {
+                    do {
+                        try await deleteMesagesUseCase.execute(for: state.selectedMessageIDs)
+                        continuation.yield(.deleteMessages(state.selectedMessageIDs))
+                        continuation.yield(.setEditing(false))
+                        continuation.yield(.clearSelectedMessageIDs)
+                    } catch {
+                        print("메시지 삭제 실패")
+                    }
+                }
 
             case .setMessages(let messages):
                 continuation.yield(.setMessages(messages))
@@ -118,9 +132,9 @@ final class TimelineListStore: Store {
         case .setEditing(let isEditing):
             newState.isEditing = isEditing
 
-        case .deleteMessages(let ids):
-            let idSet = Set(ids)
-            newState.messages.removeAll { idSet.contains($0.id) }
+        case .deleteMessages(let messageIDs):
+            newState.messages.removeAll { messageIDs.contains($0.id) }
+            newState.selectedMessageIDs.subtract(messageIDs)
             cleanupSectionIfNeeded(&newState)
         }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -56,11 +56,11 @@ final class TimelineListStore: Store {
     init(
         initialMessages: [Message] = [],
         fetchRecentMessagesUseCase: FetchRecentMessagesUseCase,
-        deleteMesagesUseCase: DeleteMessageUseCase
+        deleteMessagesUseCase: DeleteMessageUseCase
     ) {
         self.state = State(messages: initialMessages)
         self.fetchRecentMessagesUseCase = fetchRecentMessagesUseCase
-        self.deleteMesagesUseCase = deleteMesagesUseCase
+        self.deleteMesagesUseCase = deleteMessagesUseCase
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -14,6 +14,8 @@ final class TimelineListStore: Store {
         var selectedSection: YearMonth?
         var isEditing: Bool = false
 
+        var selectedMessageIDs: Set<MessageID> = []     // 편집 모드 시 선택 된 메시지
+
         var sections: [(key: YearMonth, value: [Message])] {
             MessageTimelineGrouper.groupByYearMonth(messages)
         }
@@ -24,6 +26,7 @@ final class TimelineListStore: Store {
         case setMessages([Message])
         case deleteMessages([Message.ID])
 
+        case tapMessage(MessageID)
         case tapSection(YearMonth)
         case tapEdit
     }
@@ -31,6 +34,8 @@ final class TimelineListStore: Store {
     enum Action {
         case setMessages([Message])
         case addMessages([Message])
+        case toggleMessageSelection(MessageID)
+        case clearSelectedMessageIDs
         case setSelectedSection(YearMonth?)
         case setEditing(Bool)
         case deleteMessages([Message.ID])
@@ -65,8 +70,12 @@ final class TimelineListStore: Store {
                 continuation.yield(.setSelectedSection(section))
 
             case .tapEdit:
-                // TODO: 편집 버튼 탭 동작 구현
                 continuation.yield(.setEditing(!state.isEditing))
+                continuation.yield(.clearSelectedMessageIDs)
+
+            case .tapMessage(let messageID):
+                guard state.isEditing else { break }
+                continuation.yield(.toggleMessageSelection(messageID))
 
             case .deleteMessages(let ids):
                 // TODO: 메시지 삭제 동작 구현
@@ -90,6 +99,18 @@ final class TimelineListStore: Store {
 
         case .addMessages(let messages):
             newState.messages += messages
+
+        case .toggleMessageSelection(let messageID):
+            if newState.selectedMessageIDs.contains(messageID) {
+                // 이미 선택되어 있으면 -> 선택 해제
+                newState.selectedMessageIDs.remove(messageID)
+            } else {
+                // 선택되어 있지 않으면 -> 선택
+                newState.selectedMessageIDs.insert(messageID)
+            }
+
+        case .clearSelectedMessageIDs:
+            newState.selectedMessageIDs.removeAll()
 
         case .setSelectedSection(let section):
             newState.selectedSection = section
@@ -124,5 +145,15 @@ private extension TimelineListStore {
         if hasSection == false {
             state.selectedSection = nil
         }
+    }
+}
+
+extension TimelineListStore {
+    func selectionState(for message: Message) -> TimelineSelectionState {
+        if !state.isEditing {
+            return .inactive
+        }
+
+        return state.selectedMessageIDs.contains(message.id) ? .selected : .unselected
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -16,6 +16,7 @@ final class TimelineListStore: Store {
 
         var selectedMessageIDs: Set<MessageID> = []     // 편집 모드 시 선택 된 메시지
         var deleteAlert: AlertModel?
+        var deleteStatus: LoadingStatus = .idle
 
         var sections: [(key: YearMonth, value: [Message])] {
             MessageTimelineGrouper.groupByYearMonth(messages)
@@ -44,6 +45,7 @@ final class TimelineListStore: Store {
         case deleteMessages(Set<MessageID>)
         case showDeleteAlert(AlertModel)
         case hideAlert
+        case setDeleteStatus(LoadingStatus)
     }
 
     @Published var state: State
@@ -101,16 +103,29 @@ final class TimelineListStore: Store {
                 continuation.yield(.showDeleteAlert(alert))
 
             case .confirmDeleteSelectedMessages:
+                continuation.yield(.setDeleteStatus(.loading))
+                continuation.yield(.hideAlert)
+
                 Task {
                     do {
                         try await deleteMesagesUseCase.execute(for: state.selectedMessageIDs)
                         continuation.yield(.deleteMessages(state.selectedMessageIDs))
                         continuation.yield(.setEditing(false))
                         continuation.yield(.clearSelectedMessageIDs)
-                        continuation.yield(.hideAlert)
+                        continuation.yield(.setDeleteStatus(.success))
+
+                        // 성공 메시지를 1초간 보여준 후 idle로 전환
+                        try? await Task.sleep(for: .seconds(1))
+                        continuation.yield(.setDeleteStatus(.idle))
                     } catch {
                         AppLog.error("메시지 삭제 실패", category: .store, error: error)
+                        continuation.yield(.setDeleteStatus(.fail))
+
+                        // 실패 메시지를 1초간 보여준 후 idle로 전환
+                        try? await Task.sleep(for: .seconds(1))
+                        continuation.yield(.setDeleteStatus(.idle))
                     }
+
                     continuation.finish()
                 }
                 return
@@ -165,6 +180,9 @@ final class TimelineListStore: Store {
 
         case .hideAlert:
             newState.deleteAlert = nil
+
+        case .setDeleteStatus(let status):
+            newState.deleteStatus = status
         }
 
         return newState

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -61,7 +61,7 @@ private extension TimelineListView {
                             await store.send(intent: .tapEdit)
                         }
                     } label: {
-                        Text("편집")
+                        Text(store.state.isEditing ? "삭제": "편집")
                             .font(.headline)
                             .foregroundStyle(Color.meomunPointColor)
                     }
@@ -83,8 +83,15 @@ private extension TimelineListView {
                             TimelineRowView(
                                 message: message,
                                 showTopLine: index != 0,
-                                showBottomLine: index != monthMessages.count - 1
+                                showBottomLine: index != monthMessages.count - 1,
+                                selectionState: store.selectionState(for: message)
                             )
+                            .animation(.spring(response: 0.3, dampingFraction: 0.6), value: store.state.isEditing)
+                            .onTapGesture {
+                                Task {
+                                    await store.send(intent: .tapMessage(message.id))
+                                }
+                            }
                         }
                     } header: {
                         TimelineSectionHeaderView(yearMonth: section.key)
@@ -97,7 +104,6 @@ private extension TimelineListView {
             if configuration.showsFooter && !store.state.messages.isEmpty {
                 footer
             }
-
         }
     }
 
@@ -130,12 +136,38 @@ extension TimelineListView {
 }
 
 #Preview {
-    let emptyMessages: [Message] = []
+    let messages: [Message] =  [
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-7 * 60),
+            content: "[Case4] NoPlace 스택 메시지 1",
+            coordinate: Coordinate.seoulCity,
+            address: "가람로 109",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-30 * 60),
+            content: "[Case4] NoPlace 스택 메시지 2",
+            coordinate: Coordinate.seoulCity,
+            address: "가람로 109",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-15000 * 60),
+            content: "[Case4] NoPlace 스택 메시지 3",
+            coordinate: Coordinate.seoulCity,
+            address: "가람로 109",
+            placeTag: nil
+        )
+    ]
+
     TimelineListView(
         store: TimelineListStore(
-            initialMessages: emptyMessages,
+            initialMessages: messages,
             fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
-                repository: MessageRepositoryImpl()
+                repository: MessageRepositoryImpl(storage: MessageInMemoryStorage.shared)
             )
         )
     )

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -270,7 +270,7 @@ extension TimelineListView {
             fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                 repository: MessageRepositoryImpl(storage: MessageInMemoryStorage.shared)
             ),
-            deleteMesagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
+            deleteMessagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
         )
     )
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -54,6 +54,23 @@ struct TimelineListView: View {
         }
         .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.isEditing)
         .background(Color.meomunBackgroundColor)
+        .customAlert(
+            deleteAlertBinding,
+            title: { $0.title },
+            message: { $0.message },
+            buttons: { $0.buttons }
+        )
+    }
+
+    private var deleteAlertBinding: Binding<AlertModel?> {
+        Binding(
+            get: { store.state.deleteAlert },
+            set: { _ in
+                Task {
+                    await store.send(intent: .dismissAlert)
+                }
+            }
+        )
     }
 }
 
@@ -150,7 +167,7 @@ private extension TimelineListView {
 
             Button {
                 Task {
-//                    await store.send(intent: .deleteSelectedMessages)
+                    await store.send(intent: .requestDeleteSelectedMessages)
                 }
             } label: {
                 Text("삭제")

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -12,6 +12,8 @@ fileprivate enum Constants {
 }
 
 struct TimelineListView: View {
+    @Environment(\.setTabBarHidden) private var setTabBarHidden
+
     @StateObject private var store: TimelineListStore
     private let configuration: Configuration
 
@@ -36,11 +38,21 @@ struct TimelineListView: View {
                 Spacer()
             }
         }
+        .overlay(alignment: .bottom) {
+            if store.state.isEditing {
+                selectionBar
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
         .onAppear {
             Task {
                 await store.send(intent: .onAppear)
             }
         }
+        .onChange(of: store.state.isEditing) { _, newValue in
+            setTabBarHidden(newValue)
+        }
+        .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.isEditing)
         .background(Color.meomunBackgroundColor)
     }
 }
@@ -61,7 +73,7 @@ private extension TimelineListView {
                             await store.send(intent: .tapEdit)
                         }
                     } label: {
-                        Text(store.state.isEditing ? "삭제": "편집")
+                        Text(store.state.isEditing ? "취소": "편집")
                             .font(.headline)
                             .foregroundStyle(Color.meomunPointColor)
                     }
@@ -120,6 +132,36 @@ private extension TimelineListView {
         }
         .frame(maxWidth: .infinity)
         .padding(.bottom, 100)
+    }
+
+    var selectionBar: some View {
+        HStack {
+            Text(
+                store.state.selectedMessageIDs.isEmpty 
+                ? "항목을 선택하세요"
+                : "\(store.state.selectedMessageIDs.count)개 항목 선택됨"
+            )
+            .font(.body.weight(.semibold))
+            .foregroundStyle(
+                store.state.selectedMessageIDs.isEmpty ? Color.meomunPrimaryColor : Color.meomunPrimaryColor
+            )
+
+            Spacer()
+
+            Button {
+                Task {
+//                    await store.send(intent: .deleteSelectedMessages)
+                    print("store.삭제")
+                }
+            } label: {
+                Text("삭제")
+                    .font(.headline)
+                    .foregroundStyle(store.state.selectedMessageIDs.isEmpty ? Color.tabInactive : Color.red)
+                    .padding(.horizontal, 24)
+            }
+            .disabled(store.state.selectedMessageIDs.isEmpty)
+        }
+        .floatingContainer()
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -163,7 +163,7 @@ private extension TimelineListView {
             )
             .font(.body.weight(.semibold))
             .foregroundStyle(
-                store.state.selectedMessageIDs.isEmpty ? Color.meomunPrimaryColor : Color.meomunPrimaryColor
+                store.state.selectedMessageIDs.isEmpty ? Color.tabInactive : Color.meomunPrimaryColor
             )
 
             Spacer()

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 fileprivate enum Constants {
     static let navigationTitle = "머물렀던 순간들"
+
+    static let deleteLoadingMessage = "메시지를 삭제하고 있어요."
+    static let deleteSuccessMessage = "메시지를 삭제했어요."
+    static let deleteFailMessage = "메시지 삭제 실패\n다시 시도해주세요."
 }
 
 struct TimelineListView: View {
@@ -49,8 +53,11 @@ struct TimelineListView: View {
                 await store.send(intent: .onAppear)
             }
         }
-        .onChange(of: store.state.isEditing) { _, newValue in
-            setTabBarHidden(newValue)
+        .onChange(of: store.state.isEditing) { _, _ in
+            setTabBarHidden(store.state.isEditing || store.state.deleteStatus != .idle)
+        }
+        .onChange(of: store.state.deleteStatus) { _, _ in
+            setTabBarHidden(store.state.isEditing || store.state.deleteStatus != .idle)
         }
         .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.isEditing)
         .background(Color.meomunBackgroundColor)
@@ -60,17 +67,12 @@ struct TimelineListView: View {
             message: { $0.message },
             buttons: { $0.buttons }
         )
-    }
-
-    private var deleteAlertBinding: Binding<AlertModel?> {
-        Binding(
-            get: { store.state.deleteAlert },
-            set: { _ in
-                Task {
-                    await store.send(intent: .dismissAlert)
-                }
+        .overlay {
+            if store.state.deleteStatus != .idle {
+                deleteLoadingOverlay
+                    .transition(.identity) // 애니메이션 없음
             }
-        )
+        }
     }
 }
 
@@ -181,6 +183,44 @@ private extension TimelineListView {
             .disabled(store.state.selectedMessageIDs.isEmpty)
         }
         .floatingContainer()
+    }
+}
+
+// MARK: - Alert & LoadingOverlay
+
+private extension TimelineListView {
+    var deleteAlertBinding: Binding<AlertModel?> {
+        Binding(
+            get: { store.state.deleteAlert },
+            set: { _ in
+                Task {
+                    await store.send(intent: .dismissAlert)
+                }
+            }
+        )
+    }
+
+    var isDeleteLoadingOverlayPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { store.state.deleteStatus != .idle },
+            set: { _ in }
+        )
+    }
+
+    var deleteLoadingOverlay: some View {
+        LoadingOverlayView(
+            status: store.state.deleteStatus,
+            message: deleteLoadingOverlayMessage
+        )
+    }
+
+    var deleteLoadingOverlayMessage: String {
+        switch store.state.deleteStatus {
+        case .loading: return Constants.deleteLoadingMessage
+        case .success: return Constants.deleteSuccessMessage
+        case .fail: return Constants.deleteFailMessage
+        case .idle: return ""
+        }
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -92,8 +92,11 @@ private extension TimelineListView {
                     } label: {
                         Text(store.state.isEditing ? "취소": "편집")
                             .font(.headline)
-                            .foregroundStyle(Color.meomunPointColor)
+                            .foregroundStyle(
+                                store.state.messages.isEmpty ? Color.tabInactive : Color.meomunPointColor
+                            )
                     }
+                    .disabled(store.state.messages.isEmpty)
                 }
             }
         }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -151,7 +151,6 @@ private extension TimelineListView {
             Button {
                 Task {
 //                    await store.send(intent: .deleteSelectedMessages)
-                    print("store.삭제")
                 }
             } label: {
                 Text("삭제")
@@ -210,7 +209,8 @@ extension TimelineListView {
             initialMessages: messages,
             fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                 repository: MessageRepositoryImpl(storage: MessageInMemoryStorage.shared)
-            )
+            ),
+            deleteMesagesUseCase: DeleteMessageUseCaseImpl(messageRepository: MessageRepositoryImpl())
         )
     )
 }


### PR DESCRIPTION
## 배경
- closed #71

## 작업 요약
- 타임 라인 뷰 편집 모드 구현
- 탭바 배경 UI 재사용을 위한 `FloatingContainerModifier` 구현
- 메시지 삭제 얼럿 재사용을 위한 팩토리 구현

## 작업 내용
### (1) 타임 라인 뷰 편집모드 구현
> 백문이 불여일견

|삭제 성공|실패 시 로딩 뷰|  
|---|---|  
|<video src="https://github.com/user-attachments/assets/93ef4937-9556-4bc4-94d1-e8dd2cfffa58">|<video src="https://github.com/user-attachments/assets/943822ec-a789-4203-b300-ce29f235bf14">|






|메시지 없을 때|편집 모드 활성화|  
|---|---|
|<img width=100% alt="메시지없을떄" src="https://github.com/user-attachments/assets/9fd10695-e0e6-476a-9cdd-9938da1e3120" />|<img width=100% alt="기본" src="https://github.com/user-attachments/assets/4aaa6262-b997-4db2-a79e-02f899a1d39a" />|  
|편집모드 후 선택 안함|편집 모드 후 선택|  
|<img width=100% alt="편집모드노선택" src="https://github.com/user-attachments/assets/b2011c63-a5bd-428b-bc6e-b9b2267cd0b0" />|<img width=100% alt="편집모드선택" src="https://github.com/user-attachments/assets/ac9903e5-71f5-4205-9579-171314678792" />|

- 편집 모드 활성화 시 `TimelineListView`의 왼쪽 노드가 변경되도록 수정했습니다. (애니메이션도 있어요)
  - 탭바가 내려가고 하단에 뷰(`TimelineListView.selectionBar`)가 올라옵니다.
  - 탭바와 동일한 UI를 맞추기 위해 `FloatingContainerModifier`를 구현했습니다.

### (2) `AlertFactory`
- 메시지 삭제 얼럿은 지도, 공간 화면에서도 필요해 팩토리로 구현했습니다.

## 스크린샷
위에 첨부해서 생략하겠습니다~

## 리뷰 요구사항
- 탭바도 애니메이션 적용하려했는데 실패했습니다...
  - 크기도 완전 동일하게 하려고 했는데 실패했습니다..

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 타임라인에서 메시지 다중 선택 및 선택 토글 UI 추가
  * 선택된 메시지 일괄 삭제 흐름 추가(삭제 확인 알림, 로딩/성공/실패 오버레이 포함)
  * 각 행에 선택 상태(비활성/미선택/선택) 표시 추가
  * 삭제 확인 알림 생성 유틸리티 추가

* **Style**
  * 플로팅 컨테이너 스타일 도입으로 탭 바 및 하단 UI 시각 통일 및 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->