### PR TITLE
SpaceView 네비게이션 진입 시 드래그 회전 미동작 문제 해결

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -13,6 +13,7 @@ struct SpaceView: View {
     @EnvironmentObject private var locationProvider: LocationProvider
     @StateObject private var store: SpaceStore
     @State private var domeEnvironment: DomeEnvironment
+    @State private var rotationCamera: RotationCamera
 
     @State private var spaceRootEntity: Entity?
     @State private var messageBubbleTemplateEntity: Entity?
@@ -24,11 +25,6 @@ struct SpaceView: View {
     private let place: Place
     private let onNavigate: (Coordinate, Place) -> Void
 
-    private let rotationCamera = RotationCamera(
-        position: .init(x: 0, y: 0.7, z: 0),    // 카메라 시작 위치 (돔 중심에서 약간 위)
-        rotateSensitivity: 0.003                // 회전 민감도 (값이 클수록 더 빠르게 회전)
-    )
-
     init(
         store: SpaceStore,
         domeEnvironment: DomeEnvironment,
@@ -36,7 +32,13 @@ struct SpaceView: View {
         onNavigate: @escaping (Coordinate, Place) -> Void
     ) {
         _store = StateObject(wrappedValue: store)
-        self.domeEnvironment = domeEnvironment
+        _rotationCamera = State(
+            initialValue: RotationCamera(
+                position: .init(x: 0, y: 0.7, z: 0),    // 카메라 시작 위치 (돔 중심에서 약간 위)
+                rotateSensitivity: 0.003                // 회전 민감도 (값이 클수록 더 빠르게 회전)
+            )
+        )
+        _domeEnvironment = State(initialValue: domeEnvironment)
         self.place = place
         self.onNavigate = onNavigate
     }

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -53,6 +53,10 @@ struct SpaceView: View {
             .gesture(
                 DragGesture()
                     .onChanged { value in
+                        AppLog.debug(
+                            "Drag changed: start=\(value.startLocation) loc=\(value.location) translation=\(value.translation)",
+                            category: .space
+                        )
                         rotationCamera.handleDrag(
                             translationX: Float(value.translation.width),
                             translationY: Float(value.translation.height)
@@ -124,7 +128,9 @@ extension SpaceView {
                 }
 
                 // 카메라 추가
+                AppLog.debug("RotationCamera: will add to scene", category: .space)
                 rotationCamera.addToScene(content)
+                AppLog.debug("RotationCamera: did add to scene", category: .space)
             } catch {
                 AppLog.error(
                     "Failed to load dome entity",


### PR DESCRIPTION
## 배경
- closed #283 

## 작업 요약

- [x] rotationCamera 생명주기 수정

## 작업 내용

### 1. 배경 / 문제 상황

SpaceView는 지도 화면에서 특정 메시지 버블(마커)을 선택했을 때 진입하는 **몰입형 공간 화면**입니다.

SpaceView에서는 `DragGesture`를 통해 사용자가 화면을 드래그하면 **가상 카메라(RotationCamera)가 회전**하여 돔 내부를 둘러볼 수 있도록 구현되어 있습니다.

하지만 **지도 → 네비게이션(push)으로 SpaceView로 진입하는 경우**, 드래그 제스처 입력은 발생하는 것처럼 보이는데도 **카메라 회전이 화면에 반영되지 않는 문제**가 발생했습니다.

- 제스처 콜백(onChanged/onEnded) 로그는 정상 출력됨
- 화면 회전(카메라 시점 변화)은 발생하지 않음
- 네비게이션 없이 SpaceView를 단독으로 띄우면 회전이 정상 동작

즉, 입력 자체가 막힌 문제가 아니라 **네비게이션 흐름에서만 회전 결과가 반영되지 않는 상태**였습니다.

### 2. 원인 분석 과정

2-1) “제스처 충돌” 가설 검증

처음에는 NavigationStack의 기본 back-swipe(Interactive Pop)와 DragGesture가 충돌하여 입력이 소비되는 문제를 의심했습니다.

하지만 아래 로그로 확인한 결과:

- `DragGesture`의 `onChanged`, `onEnded`가 **항상 호출됨**
- HighPriorityGesture 없이도 **동일하게 로그가 찍힘**

결론적으로,

> 제스처는 정상적으로 인식되고 있었고, 네비게이션 제스처 충돌이 핵심 원인은 아니었습니다.
> 

2-2) “씬 구성/카메라 attach 문제” 가설 검증

다음으로 `RotationCamera.addToScene(content)` 호출 타이밍을 로그로 확인했습니다.

- `RotationCamera: will add to scene`
- `RotationCamera: did add to scene`

즉, 카메라를 씬에 붙이는 코드는 정상적으로 실행되고 있었습니다.

2-3) 핵심 원인: View 재생성으로 인한 RotationCamera 인스턴스 불일치

제스처 입력도 정상이고, addToScene도 정상이라면 남는 가능성은:

> 화면에 붙어있는 RotationCamera 인스턴스와, 드래그에서 호출하는 RotationCamera 인스턴스가 서로 다른 객체일 수 있다.
> 

SwiftUI `NavigationStack`의 `navigationDestination` 환경에서는 뷰가 push되는 과정에서 **View가 여러 번 생성(re-init)되거나, body가 재평가되며 내부 stored property들이 새 인스턴스로 교체될 수 있습니다.**

기존 구현이 다음과 같은 형태였다면:

```swift
private let rotationCamera = RotationCamera(...)
```

`SpaceView`가 재생성될 때마다 `rotationCamera`도 **새 인스턴스**로 만들어질 수 있고, 그 결과로:

- configure 단계에서 씬에 attach 된 RotationCamera(A)
- 드래그에서 handleDrag를 호출하는 RotationCamera(B)

가 서로 달라져서,

> 입력은 들어오지만 실제 카메라 변환은 화면에 반영되지 않는 상태가 됩니다.
> 

이 현상은 **네비게이션 없이 단독으로 SpaceView를 띄울 때는 재생성이 덜 발생해서 우연히 정상 동작**하는 것처럼 보일 수 있습니다.

### 3. 해결 방법

RotationCamera가 SpaceView 생명주기 동안 **항상 동일 인스턴스**를 유지하도록 변경했습니다.

```swift
@State private var rotationCamera: RotationCamera
```

그리고 `@State`는 init에서 값을 대입하는 것이 아니라, SwiftUI 상태 저장소를 초기화하는 방식으로 넣어야 하므로 init에서 다음 방식으로 초기화했습니다.

```swift
_rotationCamera = State(
    initialValue: RotationCamera(
        position: .init(x: 0, y: 0.7, z: 0),
        rotateSensitivity: 0.003
    )
)
```

이렇게 함으로써:

- `addToScene`으로 씬에 붙는 RotationCamera
- `handleDrag`로 회전시키는 RotationCamera

가 **항상 동일 객체**가 되어, 네비게이션 환경에서도 회전이 정상 반영됩니다.

### 4. 결과 / 검증

- 지도 화면에서 메시지 버블 선택 → SpaceView 진입(네비게이션 push) 시
    - DragGesture 입력이 정상적으로 **카메라 회전으로 반영됨**
- SpaceView 단독 진입에서도 기존 기능 유지
- addToScene 로그가 정상 출력되며 카메라 attach 흐름 유지

이번 이슈는 “제스처 인식 문제”가 아니라,

> SwiftUI NavigationStack 환경에서 View 재생성으로 인해 `private let rotationCamera`가 새로운 인스턴스로 교체되면서 “씬에 붙은 카메라”와 “드래그로 조작하는 카메라”가 분리된 문제였습니다.
> 

이를 해결하기 위해 RotationCamera를 `@State`로 소유하고 init에서 `_rotationCamera = State(initialValue:)`로 초기화하여 **SpaceView 생명주기 동안 동일 인스턴스를 유지하도록 변경**했습니다.

## 스크린샷

https://github.com/user-attachments/assets/4ee7bf8c-b9e3-4984-bdf3-18d065f7a9ff

## 리뷰 요구사항

머지 후 미동작에 대한 상황을 파악하기 위해 디버깅 코드를 추가하였습니다. 공간 화면에서 제스처가 동작하지 않는 경우 로그에서 이동 값이 변경되는지 확인하면 됩니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 수정 사항

* **리팩터링**
  * 공간 뷰의 내부 상태 관리 개선으로 반응형 업데이트 지원 강화
  * 카메라 회전 기능의 상태 관리 최적화
  * 사용자 드래그 상호작용 및 카메라 설정 과정에 대한 디버깅 로깅 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->