### PR TITLE
공간 화면 진입을 위한 캐러셀 UI 구현

### DIFF
--- a/Meomun/Meomun/Data/DTO/PlaceDTO.swift
+++ b/Meomun/Meomun/Data/DTO/PlaceDTO.swift
@@ -29,7 +29,7 @@ extension PlaceDTO {
             id: PlaceID(value: placeId),
             name: name,
             coordinate: Coordinate(latitude: latitude, longitude: longitude),
-            address: ""
+            address: address
         )
     }
 

--- a/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
+++ b/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
@@ -46,6 +46,12 @@ struct MainTabShellView: View {
                 messageMarkerManager: MessageMarkerManager(
                     rotationAnimator: .init(),
                     bubbleImageRenderer: .init()
+                ),
+                store: .init(
+                    getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(
+                        messageRepository: MessageRepositoryImpl()
+                    ),
+                    networkMonitor: .init()
                 )
             )
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
@@ -1,0 +1,110 @@
+//
+//  PlaceCarousel.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/28/26.
+//
+
+import SwiftUI
+
+private enum Constants {
+    static let pageIndicatorSize: CGFloat = 6
+    static let pageIndicatorSpacing: CGFloat = 6
+    static let pageIndicatorBottomPadding: CGFloat = 20
+
+    static let verticalSpacing: CGFloat = 8
+
+    static let carouselHeight: CGFloat = 120
+}
+
+struct PlaceCarousel: View {
+    private let items: [PlaceCarouselDisplayModel]
+    private let onTapped: (Place) -> Void
+
+    init(items: [PlaceCarouselDisplayModel], onTapped: @escaping (Place) -> Void) {
+        self.items = items
+        self.onTapped = onTapped
+    }
+
+    @State private var currentIndex: Int = 0
+
+    var body: some View {
+        VStack(spacing: Constants.verticalSpacing) {
+            if items.count > 1 {
+                pageIndicator
+            }
+
+            carouselContent
+        }
+    }
+}
+
+// MARK: - Components
+
+private extension PlaceCarousel {
+    var pageIndicator: some View {
+        HStack(spacing: Constants.pageIndicatorSpacing) {
+            ForEach(0..<items.count, id: \.self) { index in
+                Circle()
+                    .fill(
+                        index == currentIndex
+                            ? Color.meomunPointColor
+                            : Color.meomunPrimaryColor.opacity(0.2)
+                    )
+                    .frame(width: Constants.pageIndicatorSize, height: Constants.pageIndicatorSize)
+            }
+        }
+    }
+
+    var carouselContent: some View {
+        TabView(selection: $currentIndex) {
+            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                PlaceCarouselCard(item: item)
+                    .onTapGesture {
+                        onTapped(item.place)
+                    }
+                    .tag(index)
+                    .padding()
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .frame(height: Constants.carouselHeight)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.gray.opacity(0.3)
+            .ignoresSafeArea()
+
+        VStack {
+            Spacer()
+
+            PlaceCarousel(
+                items: [
+                    PlaceCarouselDisplayModel(
+                        place: Place(
+                            id: PlaceID(value: "1"),
+                            name: "스타벅스 양재점",
+                            coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+                            address: "서울시 서초구 양재대로 123"
+                        ),
+                        messageCount: 12
+                    ),
+                    PlaceCarouselDisplayModel(
+                        place: Place(
+                            id: PlaceID(value: "2"),
+                            name: "투썸플레이스 양재점",
+                            coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+                            address: "서울시 서초구 양재대로 125"
+                        ),
+                        messageCount: 5
+                    )
+                ],
+                onTapped: { place in
+                    print("Selected: \(place.name)")
+                }
+            )
+        }
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
@@ -64,7 +64,7 @@ private extension PlaceCarousel {
                         onTapped(item.place)
                     }
                     .tag(index)
-                    .padding()
+                    .padding(.horizontal, 30)
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
@@ -35,11 +35,11 @@ struct PlaceCarousel: View {
 
     var body: some View {
         VStack(spacing: Constants.verticalSpacing) {
+            carouselContent
+
             if items.count > 1 {
                 pageIndicator
             }
-
-            carouselContent
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarousel.swift
@@ -8,10 +8,15 @@
 import SwiftUI
 
 private enum Constants {
+    // Page Indicator
     static let pageIndicatorSize: CGFloat = 6
     static let pageIndicatorSpacing: CGFloat = 6
-    static let pageIndicatorBottomPadding: CGFloat = 20
+    static let pageIndicatorVerticalPadding: CGFloat = 6
+    static let pageIndicatorHorizontalPadding: CGFloat = 12
 
+    static let pageIndicatorBackOpacity: CGFloat = 0.15
+
+    // Carousel
     static let verticalSpacing: CGFloat = 8
 
     static let carouselHeight: CGFloat = 120
@@ -54,6 +59,12 @@ private extension PlaceCarousel {
                     .frame(width: Constants.pageIndicatorSize, height: Constants.pageIndicatorSize)
             }
         }
+        .padding(.horizontal, Constants.pageIndicatorHorizontalPadding)
+        .padding(.vertical, Constants.pageIndicatorVerticalPadding)
+        .background(
+            Capsule()
+                .fill(Color.gray.opacity(Constants.pageIndicatorBackOpacity))
+        )
     }
 
     var carouselContent: some View {

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarouselCard.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarouselCard.swift
@@ -36,6 +36,20 @@ struct PlaceCarouselCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
         .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.cornerRadius, style: .continuous)
+                .stroke(
+                    LinearGradient(
+                        colors: [
+                            Color.gray.opacity(0.65),
+                            Color.gray.opacity(0.22)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
+        }
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarouselCard.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarouselCard.swift
@@ -1,0 +1,82 @@
+//
+//  PlaceCarouselCard.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/28/26.
+//
+
+import SwiftUI
+
+private enum Constants {
+    static let padding: CGFloat = 20
+    static let verticalSpacing: CGFloat = 8
+
+    static let cornerRadius: CGFloat = 10
+
+    static let addressTextOpacity: Double = 0.6
+    static let messageCountTextOpacity: Double = 0.5
+}
+
+struct PlaceCarouselCard: View {
+    private let item: PlaceCarouselDisplayModel
+
+    init(item: PlaceCarouselDisplayModel) {
+        self.item = item
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+            nameText
+
+            addressText
+
+            messageCountText
+        }
+        .padding(Constants.padding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+    }
+}
+
+// MARK: - Components
+
+private extension PlaceCarouselCard {
+    var nameText: some View {
+        Text(item.place.name)
+            .font(.title3.weight(.semibold))
+            .foregroundStyle(Color.meomunPrimaryColor)
+    }
+
+    var addressText: some View {
+        Text(item.place.address)
+            .font(.subheadline)
+            .foregroundStyle(Color.meomunPrimaryColor.opacity(Constants.addressTextOpacity))
+    }
+
+    var messageCountText: some View {
+        Label {
+            Text("\(item.messageCount)개의 메시지")
+        } icon: {
+            Image(systemName: "message")
+        }
+        .font(.footnote)
+        .foregroundStyle(Color.meomunPrimaryColor.opacity(Constants.messageCountTextOpacity))
+    }
+}
+
+#Preview {
+    PlaceCarouselCard(
+        item: PlaceCarouselDisplayModel(
+            place: Place(
+                id: PlaceID(value: "1"),
+                name: "스타벅스 양재점",
+                coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+                address: "서울시 서초구 양재대로 123"
+            ),
+            messageCount: 12
+        )
+    )
+    .padding()
+    .background(Color.gray.opacity(0.2))
+}

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarouselCard.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/PlaceCarouselCard.swift
@@ -25,12 +25,16 @@ struct PlaceCarouselCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
-            nameText
+        HStack {
+            VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                nameText
+                addressText
+                messageCountText
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            addressText
-
-            messageCountText
+            Image(systemName: "chevron.right")
+                .foregroundStyle(Color.meomunPrimaryColor.opacity(0.4))
         }
         .padding(Constants.padding)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -80,17 +84,30 @@ private extension PlaceCarouselCard {
 }
 
 #Preview {
-    PlaceCarouselCard(
-        item: PlaceCarouselDisplayModel(
-            place: Place(
-                id: PlaceID(value: "1"),
-                name: "스타벅스 양재점",
-                coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
-                address: "서울시 서초구 양재대로 123"
-            ),
-            messageCount: 12
+    VStack {
+        PlaceCarouselCard(
+            item: PlaceCarouselDisplayModel(
+                place: Place(
+                    id: PlaceID(value: "1"),
+                    name: "스타벅스 양재점",
+                    coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+                    address: "서울시 서초구 양재대로 123"
+                ),
+                messageCount: 12
+            )
         )
-    )
+        PlaceCarouselCard(
+            item: PlaceCarouselDisplayModel(
+                place: Place(
+                    id: PlaceID(value: "1"),
+                    name: "이름이 길어요 두 줄 정도 된다면? 어떻게 나올까요 스타벅스 양재점",
+                    coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+                    address: "주소는 짧게 보여주지만 혹시나 두 줄이 된다면? 서울시 서초구 양재대로 123"
+                ),
+                messageCount: 12
+            )
+        )
+    }
     .padding()
     .background(Color.gray.opacity(0.2))
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -26,6 +26,8 @@ final class MapStore: Store {
         case updateMessages([Message])
 
         case tapNoPlaceMarker([Message])
+        case tapPlaceMarker([Message])
+        case dismissPlaceCarousel
 
         case dismissTimelineView
         case tapNetworkRefresh
@@ -42,6 +44,7 @@ final class MapStore: Store {
         case setMessages([Message])
 
         case setSelectedNoPlace([Message])
+        case setCarouselItems([PlaceCarouselDisplayModel])
 
         case setLoading(Bool)
         case setNetworkConnected(Bool)
@@ -60,6 +63,7 @@ final class MapStore: Store {
         var isShowingAddMessage: Bool = false
 
         var selectedNoPlaceMessages: [Message] = []
+        var carouselItems: [PlaceCarouselDisplayModel] = []
 
         var isLoading: Bool = false
         var isNetworkConnected = true
@@ -136,6 +140,15 @@ final class MapStore: Store {
                 continuation.yield(.setSelectedNoPlace(messages))
                 continuation.finish()
 
+            case .tapPlaceMarker(let messages):
+                let items = self.groupMessagesByPlace(messages)
+                continuation.yield(.setCarouselItems(items))
+                continuation.finish()
+
+            case .dismissPlaceCarousel:
+                continuation.yield(.setCarouselItems([]))
+                continuation.finish()
+
             case .dismissTimelineView:
                 continuation.yield(.setSelectedNoPlace([]))
                 continuation.finish()
@@ -173,6 +186,9 @@ final class MapStore: Store {
 
         case .setSelectedNoPlace(let messages):
             newState.selectedNoPlaceMessages = messages
+
+        case .setCarouselItems(let items):
+            newState.carouselItems = items
 
         case .setLoading(let isLoading):
             newState.isLoading = isLoading
@@ -237,5 +253,22 @@ final class MapStore: Store {
                 continuation.yield(.setError(error.localizedDescription))
             }
         }
+    }
+}
+
+private extension MapStore {
+    /// 메시지 배열을 Place별로 그룹화하여 캐러셀 아이템 배열로 변환
+    func groupMessagesByPlace(_ messages: [Message]) -> [PlaceCarouselDisplayModel] {
+        var placeMessages: [Place: [Message]] = [:]
+
+        for message in messages {
+            guard let place = message.placeTag else { continue }
+            placeMessages[place, default: []].append(message)
+        }
+
+        return placeMessages.map { place, messages in
+            PlaceCarouselDisplayModel(place: place, messageCount: messages.count)
+        }
+        .sorted { $0.messageCount > $1.messageCount }
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -65,7 +65,7 @@ struct MapView: View {
                             navigationPath.append(MapDestination.space(place: place))
                         }
                     )
-                    .padding(.bottom, 100)
+                    .padding(.bottom, 90)
                 }
             }
             .overlay {

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -52,30 +52,28 @@ struct MapView: View {
                 }
                 .padding(.top, 12)
             }
+            .overlay(alignment: .bottomTrailing) {
+                writeButton
+                    .padding(.bottom, 96)
+            }
+            .overlay(alignment: .bottom) {
+                if !store.state.carouselItems.isEmpty {
+                    PlaceCarousel(
+                        items: store.state.carouselItems,
+                        onTapped: { place in
+                            send(.dismissPlaceCarousel)
+                            navigationPath.append(MapDestination.space(place: place))
+                        }
+                    )
+                    .padding(.bottom, 100)
+                }
+            }
             .overlay {
                 if !store.state.isNetworkConnected {
                     AlertView(type: .network) {
                         send(.tapNetworkRefresh)
                     }
                     .ignoresSafeArea()
-                }
-            }
-            .safeAreaInset(edge: .bottom) {
-                if !store.state.carouselItems.isEmpty {
-                    PlaceCarousel(
-                        items: store.state.carouselItems,
-                        onTapped: { place in
-                            send(.dismissPlaceCarousel)
-                            setTabBarHidden(true)
-                            navigationPath.append(MapDestination.space(place: place))
-                        }
-                    )
-                } else {
-                    HStack {
-                        Spacer()
-                        writeButton
-                    }
-                    .padding(.bottom, 96)
                 }
             }
             .task {
@@ -86,11 +84,6 @@ struct MapView: View {
             }
             .onDisappear {
                 send(.onDisappear)
-            }
-            .onChange(of: store.state.carouselItems.isEmpty) { _, isEmpty in
-                if navigationPath.isEmpty {
-                    setTabBarHidden(!isEmpty)
-                }
             }
             .simultaneousGesture(
                 TapGesture()
@@ -137,7 +130,6 @@ private extension MapView {
             markerManager: messageMarkerManager,
             messages: store.state.messages,
             cameraMoveTarget: store.state.cameraMoveTarget,
-            isLocationButtonHidden: !store.state.carouselItems.isEmpty,
             onCameraMoveConsumed: {
                 send(.cameraMoveConsumed)
             },

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -48,22 +48,34 @@ struct MapView: View {
 
                 VStack {
                     floatingNavigationBar
-
                     Spacer()
-
-                    HStack {
-                        Spacer()
-                        writeButton
-                    }
                 }
                 .padding(.top, 12)
-                .padding(.bottom, 96)
-                .ignoresSafeArea(.keyboard, edges: .bottom)
-
+            }
+            .overlay {
                 if !store.state.isNetworkConnected {
                     AlertView(type: .network) {
                         send(.tapNetworkRefresh)
                     }
+                    .ignoresSafeArea()
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                if !store.state.carouselItems.isEmpty {
+                    PlaceCarousel(
+                        items: store.state.carouselItems,
+                        onTapped: { place in
+                            send(.dismissPlaceCarousel)
+                            setTabBarHidden(true)
+                            navigationPath.append(MapDestination.space(place: place))
+                        }
+                    )
+                } else {
+                    HStack {
+                        Spacer()
+                        writeButton
+                    }
+                    .padding(.bottom, 96)
                 }
             }
             .task {
@@ -75,6 +87,17 @@ struct MapView: View {
             .onDisappear {
                 send(.onDisappear)
             }
+            .onChange(of: store.state.carouselItems.isEmpty) { _, isEmpty in
+                if navigationPath.isEmpty {
+                    setTabBarHidden(!isEmpty)
+                }
+            }
+            .simultaneousGesture(
+                TapGesture()
+                    .onEnded { _ in
+                        send(.dismissPlaceCarousel)
+                    }
+            )
             .navigationDestination(for: MapDestination.self) { destination in
                 switch destination {
                 case .space(let place):

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -28,14 +28,10 @@ struct MapView: View {
 
     init(
         userLocation: Coordinate,
-        messageMarkerManager: MessageMarkerManager
+        messageMarkerManager: MessageMarkerManager,
+        store: MapStore
     ) {
-        _store = StateObject(wrappedValue: MapStore(
-            getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(
-                messageRepository: MessageRepositoryImpl()
-            ),
-            networkMonitor: NetworkMonitor()
-        ))
+        self._store = .init(wrappedValue: store)
         self.messageMarkerManager = messageMarkerManager
         self.initialUserLocation = userLocation
     }
@@ -247,8 +243,14 @@ private extension MapView {
         bubbleImageRenderer: bubbleImageRenderer
     )
 
-    return MapView(
+    MapView(
         userLocation: .init(latitude: 37.5665, longitude: 126.9780),
-        messageMarkerManager: messageMarkerManager
+        messageMarkerManager: messageMarkerManager,
+        store: .init(
+            getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(
+                messageRepository: MessageRepositoryImpl(storage: MessageInMemoryStorage.shared)
+            ),
+            networkMonitor: .init()
+        )
     )
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -117,8 +117,8 @@ private extension MapView {
             onCameraMoveConsumed: {
                 send(.cameraMoveConsumed)
             },
-            onTapPlace: { place in
-                navigationPath.append(MapDestination.space(place: place))
+            onTapPlace: { messages in
+                send(.tapPlaceMarker(messages))
             },
             onTapNoPlace: { messages in
                 send(.tapNoPlaceMarker(messages))

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -43,52 +43,17 @@ struct MapView: View {
     var body: some View {
         NavigationStack(path: $navigationPath) {
             ZStack {
-                MapViewWrapper(
-                    userLocation: initialUserLocation,
-                    markerManager: messageMarkerManager,
-                    messages: store.state.messages,
-                    cameraMoveTarget: store.state.cameraMoveTarget,
-                    onCameraMoveConsumed: {
-                        send(.cameraMoveConsumed)
-                    },
-                    onTapPlace: { place in
-                        navigationPath.append(MapDestination.space(place: place))
-                    },
-                    onTapNoPlace: { messages in
-                        send(.tapNoPlaceMarker(messages))
-                    },
-                    onCameraIdle: { coordinate, bounds in
-                        send(.cameraDidIdle(coordinate, bounds))
-                    },
-                    onCameraChangedByLocation: { coordinate, bounds in
-                        send(.cameraChangedByLocation(coordinate, bounds))
-                    }
-                )
-                .ignoresSafeArea()
+                mapViewWrapper
+                    .ignoresSafeArea()
 
                 VStack {
-                    FloatingNavigationBar(
-                        title: Constants.navigationTitle,
-                        onTapSearch: { send(.tapSearch) }
-                    )
+                    floatingNavigationBar
 
                     Spacer()
 
                     HStack {
                         Spacer()
-
-                        WriteButton {
-                            if let current = locationProvider.current {
-                                navigationPath.append(
-                                    MapDestination.messageComposer(
-                                        location: current,
-                                        place: nil
-                                    )
-                                )
-                            } else {
-                                send(.setToast(Constants.locationToastMessage))
-                            }
-                        }
+                        writeButton
                     }
                 }
                 .padding(.top, 12)
@@ -101,78 +66,34 @@ struct MapView: View {
                     }
                 }
             }
-            .sheet(
-                isPresented: Binding(
-                    get: { store.state.selectedNoPlaceMessages.isEmpty == false },
-                    set: { isPresented in
-                        if !isPresented {
-                            send(.dismissTimelineView)
-                        }
-                    }
-                )
-            ) {
-                TimelineListView(
-                    store: TimelineListStore(
-                        fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
-                            repository: MessageRepositoryImpl()
-                        ),
-                        deleteMessagesUseCase: DeleteMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl())
-                    ),
-                    configuration: .bottomSheet
-                )
-                    .presentationDetents(.init(arrayLiteral: .medium, .large))
-                    .presentationDragIndicator(.visible)
+            .task {
+                await store.send(intent: .onAppear(initialUserLocation))
+            }
+            .onAppear {
+                setTabBarHidden(false)
+            }
+            .onDisappear {
+                send(.onDisappear)
             }
             .navigationDestination(for: MapDestination.self) { destination in
                 switch destination {
                 case .space(let place):
-                    SpaceView(
-                        store: .init(
-                            fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCaseImpl(
-                                messageRepository: MessageRepositoryImpl()
-                            ),
-                            place: place
-                        ),
-                        domeEnvironment: .init(dayPart: .afternoon),
-                        place: place,
-                        onNavigate: { coordinate, place in
-                            navigationPath.append(
-                                MapDestination.messageComposer(
-                                    location: coordinate,
-                                    place: place
-                                )
-                            )
-                        }
-                    )
+                    spaceView(place: place) { coordinate, place in
+                        navigationPath.append(MapDestination.messageComposer(location: coordinate, place: place))
+                    }
                     .onAppear { setTabBarHidden(true) }
 
                 case .messageComposer(let location, let place):
-                    MessageComposerView(
-                        store: .init(
-                            currentLocation: location,
-                            currentPlace: place,
-                            createMessage: CreateMessageUseCaseImpl(
-                                messageRepository: MessageRepositoryImpl()
-                            ),
-                            reverseGeocoding: ReverseGeocodeUseCaseImpl(
-                                repository: ReverseGeocodeRepositoryImpl(
-                                    client: NetworkClientImpl()
-                                )
-                            ),
-                            onClose: { _ in
-                                navigationPath.removeLast()
-                            }
-                        )
-                    )
+                    messageComposerView(location: location, place: place) {
+                        navigationPath.removeLast()
+                    }
                     .onAppear { setTabBarHidden(true) }
                 }
             }
-            .task {
-                await store.send(intent: .onAppear(initialUserLocation))
-            }
-            .onAppear { setTabBarHidden(false) }
-            .onDisappear {
-                send(.onDisappear)
+            .sheet(isPresented: isTimelineListPresentedBinding) {
+                timeLineListView
+                    .presentationDetents(.init(arrayLiteral: .medium, .large))
+                    .presentationDragIndicator(.visible)
             }
             .fullScreenCover(isPresented: isPlaceSearchPresentedBinding) {
                 placeSearchOverlay
@@ -183,6 +104,98 @@ struct MapView: View {
         .toast(toastBinding, bottomPadding: 100)
     }
 }
+
+// MARK: - SubViews
+
+private extension MapView {
+    var mapViewWrapper: some View {
+        MapViewWrapper(
+            userLocation: initialUserLocation,
+            markerManager: messageMarkerManager,
+            messages: store.state.messages,
+            cameraMoveTarget: store.state.cameraMoveTarget,
+            onCameraMoveConsumed: {
+                send(.cameraMoveConsumed)
+            },
+            onTapPlace: { place in
+                navigationPath.append(MapDestination.space(place: place))
+            },
+            onTapNoPlace: { messages in
+                send(.tapNoPlaceMarker(messages))
+            },
+            onCameraIdle: { coordinate, bounds in
+                send(.cameraDidIdle(coordinate, bounds))
+            },
+            onCameraChangedByLocation: { coordinate, bounds in
+                send(.cameraChangedByLocation(coordinate, bounds))
+            }
+        )
+    }
+
+    var floatingNavigationBar: some View {
+        FloatingNavigationBar(
+            title: Constants.navigationTitle,
+            onTapSearch: { send(.tapSearch) }
+        )
+    }
+
+    var writeButton: some View {
+        WriteButton {
+            if let current = locationProvider.current {
+                navigationPath.append(
+                    MapDestination.messageComposer(
+                        location: current,
+                        place: nil
+                    )
+                )
+            } else {
+                send(.setToast(Constants.locationToastMessage))
+            }
+        }
+    }
+}
+
+// MARK: - Navigation Destination
+
+private extension MapView {
+    private func messageComposerView(location: Coordinate, place: Place?, onClose: @escaping () -> Void) -> some View {
+        MessageComposerView(
+            store: .init(
+                currentLocation: location,
+                currentPlace: place,
+                createMessage: CreateMessageUseCaseImpl(
+                    messageRepository: MessageRepositoryImpl()
+                ),
+                reverseGeocoding: ReverseGeocodeUseCaseImpl(
+                    repository: ReverseGeocodeRepositoryImpl(
+                        client: NetworkClientImpl()
+                    )
+                ),
+                onClose: { _ in
+                    onClose()
+                }
+            )
+        )
+    }
+
+    private func spaceView(place: Place, onNavigate: @escaping (Coordinate, Place) -> Void) -> some View {
+        SpaceView(
+            store: .init(
+                fetchPlaceMessagesUseCase: FetchPlaceMessagesUseCaseImpl(
+                    messageRepository: MessageRepositoryImpl()
+                ),
+                place: place
+            ),
+            domeEnvironment: .init(dayPart: .afternoon),
+            place: place,
+            onNavigate: { coordinate, place in
+                onNavigate(coordinate, place)
+            }
+        )
+    }
+}
+
+// MARK: - Sheet & Overlay
 
 private extension MapView {
     @ViewBuilder
@@ -222,6 +235,28 @@ private extension MapView {
                 if !isPresented {
                     send(.dismissPlaceSearch)
             }}
+        )
+    }
+
+    var timeLineListView: some View {
+        TimelineListView(
+            store: TimelineListStore(
+                fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
+                    repository: MessageRepositoryImpl()
+                ),
+                deleteMessagesUseCase: DeleteMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl())
+            ),
+            configuration: .bottomSheet
+        )
+    }
+    var isTimelineListPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { store.state.selectedNoPlaceMessages.isEmpty == false },
+            set: { isPresented in
+                if !isPresented {
+                    send(.dismissTimelineView)
+                }
+            }
         )
     }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -114,6 +114,7 @@ private extension MapView {
             markerManager: messageMarkerManager,
             messages: store.state.messages,
             cameraMoveTarget: store.state.cameraMoveTarget,
+            isLocationButtonHidden: !store.state.carouselItems.isEmpty,
             onCameraMoveConsumed: {
                 send(.cameraMoveConsumed)
             },

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -188,6 +188,14 @@ extension MapViewController {
     }
 }
 
+// MARK: - Map UI
+
+extension MapViewController {
+    func setLocationButtonHidden(_ hidden: Bool) {
+        naverMapView.showLocationButton = !hidden
+    }
+}
+
 // MARK: - UserLocation
 
 extension MapViewController {
@@ -314,6 +322,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     private let messages: [Message]
     private let userLocation: Coordinate?
     private let cameraMoveTarget: Coordinate?
+    private let isLocationButtonHidden: Bool
     private let onCameraMoveConsumed: () -> Void
     private let onTapPlace: (([Message]) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
@@ -327,6 +336,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         markerManager: MessageMarkerManager,
         messages: [Message],
         cameraMoveTarget: Coordinate?,
+        isLocationButtonHidden: Bool = false,
         onCameraMoveConsumed: @escaping () -> Void,
         onTapPlace: (([Message]) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
@@ -337,6 +347,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         self.messageMarkerManager = markerManager
         self.messages = messages
         self.cameraMoveTarget = cameraMoveTarget
+        self.isLocationButtonHidden = isLocationButtonHidden
         self.onCameraMoveConsumed = onCameraMoveConsumed
         self.onTapPlace = onTapPlace
         self.onTapNoPlace = onTapNoPlace
@@ -374,6 +385,9 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
+        // 위치 버튼 표시/숨김 업데이트
+        uiViewController.setLocationButtonHidden(isLocationButtonHidden)
+
         if let target = cameraMoveTarget {
             // 동일 target인 경우 호출 X
             if context.coordinator.lastCameraMoveTarget?.latitude != target.latitude ||

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -25,7 +25,7 @@ final class MapViewController: UIViewController {
 
     // MARK: - Callback
 
-    private let onTapPlace: ((Place) -> Void)?
+    private let onTapPlace: (([Message]) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
     private let onCameraIdle: ((Coordinate, BoundingBox) -> Void)?
     private let onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)?
@@ -39,7 +39,7 @@ final class MapViewController: UIViewController {
 
     init(
         messageMarkerManager: MessageMarkerManager,
-        onTapPlace: ((Place) -> Void)? = nil,
+        onTapPlace: (([Message]) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
         onCameraIdle: ((Coordinate, BoundingBox) -> Void)? = nil,
         onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)? = nil
@@ -315,7 +315,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     private let userLocation: Coordinate?
     private let cameraMoveTarget: Coordinate?
     private let onCameraMoveConsumed: () -> Void
-    private let onTapPlace: ((Place) -> Void)?
+    private let onTapPlace: (([Message]) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
     private let onCameraIdle: ((Coordinate, BoundingBox) -> Void)?
     private let onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)?
@@ -328,7 +328,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         messages: [Message],
         cameraMoveTarget: Coordinate?,
         onCameraMoveConsumed: @escaping () -> Void,
-        onTapPlace: ((Place) -> Void)? = nil,
+        onTapPlace: (([Message]) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
         onCameraIdle: ((Coordinate, BoundingBox) -> Void)? = nil,
         onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)? = nil

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -187,14 +187,6 @@ extension MapViewController {
     }
 }
 
-// MARK: - Map UI
-
-extension MapViewController {
-    func setLocationButtonHidden(_ hidden: Bool) {
-        naverMapView.showLocationButton = !hidden
-    }
-}
-
 // MARK: - UserLocation
 
 extension MapViewController {
@@ -339,7 +331,6 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     private let messages: [Message]
     private let userLocation: Coordinate?
     private let cameraMoveTarget: MapCameraMoveCommand?
-    private let isLocationButtonHidden: Bool
     private let onCameraMoveConsumed: () -> Void
     private let onTapPlace: (([Message]) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
@@ -353,7 +344,6 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         markerManager: MessageMarkerManager,
         messages: [Message],
         cameraMoveTarget: MapCameraMoveCommand?,
-        isLocationButtonHidden: Bool = false,
         onCameraMoveConsumed: @escaping () -> Void,
         onTapPlace: (([Message]) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
@@ -364,7 +354,6 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         self.messageMarkerManager = markerManager
         self.messages = messages
         self.cameraMoveTarget = cameraMoveTarget
-        self.isLocationButtonHidden = isLocationButtonHidden
         self.onCameraMoveConsumed = onCameraMoveConsumed
         self.onTapPlace = onTapPlace
         self.onTapNoPlace = onTapNoPlace
@@ -402,8 +391,6 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
-        uiViewController.setLocationButtonHidden(isLocationButtonHidden)
-
         if let target = cameraMoveTarget, context.coordinator.lastCameraMoveTarget != target {
             // 동일 target인 경우 호출 X
             context.coordinator.lastCameraMoveTarget = target

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -95,7 +95,7 @@ final class MessageMarkerManager {
 
     /// 외부 바인딩(카메라 이벤트에서 모드 전환용)
     private weak var boundMapView: NMFMapView?
-    private var boundOnTapPlace: ((Place) -> Void)?
+    private var boundOnTapPlace: (([Message]) -> Void)?
     private var boundOnTapNoPlace: (([Message]) -> Void)?
 
     // MARK: - Dependencies
@@ -142,12 +142,12 @@ extension MessageMarkerManager {
     /// Place 메시지를 먼저 저장한 후 NoPlace 메시지를 저장하여 좌표 겹침 시 오프셋을 적용합니다.
     ///
     /// - Parameters:
-    ///   - onTapPlace: Place 마커 탭 시 콜백 (장소 정보 전달)
+    ///   - onTapPlace: Place 마커 탭 시 콜백 (해당 좌표의 모든 메시지 전달)
     ///   - onTapNoPlace: NoPlace 마커 탭 시 콜백 (메시지 배열 전달)
     func loadMessages(
         _ messages: [Message],
         mapView: NMFMapView,
-        onTapPlace: ((Place) -> Void)?,
+        onTapPlace: (([Message]) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
         // 바인딩 저장
@@ -185,7 +185,7 @@ extension MessageMarkerManager {
     private func applySnapshot(
         _ messages: [Message],
         mapView: NMFMapView,
-        onTapPlace: ((Place) -> Void)?,
+        onTapPlace: (([Message]) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
         // 0) 이전 상태 기반 좌표 집합(Place + NoPlace)
@@ -433,7 +433,7 @@ extension MessageMarkerManager {
     /// 각 좌표에 대해 마커를 생성합니다.
     private func rebuildAllMarkers(
         mapView: NMFMapView,
-        onTapPlace: ((Place) -> Void)?,
+        onTapPlace: (([Message]) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
         // Place와 NoPlace 좌표를 합집합으로 구함
@@ -452,7 +452,7 @@ extension MessageMarkerManager {
     private func updateMarkersForCoordinate(
         _ coord: Coordinate,
         mapView: NMFMapView,
-        onTapPlace: ((Place) -> Void)?,
+        onTapPlace: (([Message]) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
         // Place가 없고, 기존 place 마커도 없다면 스킵
@@ -461,12 +461,10 @@ extension MessageMarkerManager {
             // 아무 동작 X
         } else {
             updateMarker(coord: coord, isPlace: true, mapView: mapView) { messages in
-                guard let place = messages.first?.placeTag else { return }
-
-                let uniquePlaces = Set(messages.compactMap(\.placeTag))
-                if uniquePlaces.count == 1 {
-                    onTapPlace?(place)
-                }
+                // Place가 있는 메시지만 필터링하여 전달
+                let placeMessages = messages.filter { $0.placeTag != nil }
+                guard !placeMessages.isEmpty else { return }
+                onTapPlace?(placeMessages)
             }
         }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Model/PlaceCarouselDisplayModel.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Model/PlaceCarouselDisplayModel.swift
@@ -1,0 +1,13 @@
+//
+//  PlaceCarouselDisplayModel.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/28/26.
+//
+
+/// 지도 캐러셀에 표시할 장소 정보를 담는 모델
+struct PlaceCarouselDisplayModel: Identifiable, Hashable, Sendable {
+    var id: PlaceID { place.id }
+    let place: Place
+    let messageCount: Int
+}


### PR DESCRIPTION
## 배경
- closed #75 
- closed #162 

## 작업 요약
- 공간 화면 진입을 위한 캐러셀 UI 구현

## 작업 내용
- 공간 화면 진입을 위한 캐러셀 UI를 구현합니다.

## 스크린샷
https://github.com/user-attachments/assets/36bc1ff1-479d-44db-8767-0df1dab1d1ef


## 리뷰 요구사항
- `PlaceCarouselDiplayModel` 프레젠테이션 모델을 정의했습니다.
  - 네이밍을 고민하다가 우선 이걸로 결정했는데, 다른 의견 있으시면 알려주세요!

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지도에 장소 캐러셀 추가 — 여러 장소를 스와이프로 탐색 가능
  * 캐러셀에서 장소별 메시지 수 표시 및 카드 탭으로 장소 선택 가능
  * 하단 오버레이(작성 버튼, 네트워크 알림, 타임라인 등) 개선

* **버그 수정**
  * 장소 주소 데이터 매핑 오류 수정하여 주소가 올바르게 표시됨

* **리팩토링**
  * 지도 화면 구성 요소 구조화 및 모듈화로 유지보수성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->