### PR TITLE
지도 탭 재진입 시 마지막 카메라 위치로 복원 구현

### DIFF
--- a/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
+++ b/Meomun/Meomun/Presentation/Root/MainTabShellView.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 struct MainTabShellView: View {
     @EnvironmentObject private var locationProvider: LocationProvider
+    @StateObject private var mapStore = MapStore(
+        getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl()),
+        networkMonitor: NetworkMonitor()
+    )
 
     let userLocation: Coordinate
     @StateObject private var store = MainTabStore()
@@ -42,6 +46,7 @@ struct MainTabShellView: View {
         switch tab {
         case .map:
             MapView(
+                store: mapStore,
                 userLocation: userLocation,
                 messageMarkerManager: MessageMarkerManager(
                     rotationAnimator: .init(),

--- a/Meomun/Meomun/Presentation/Scene/Map/MapCameraMoveCommand.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapCameraMoveCommand.swift
@@ -1,0 +1,12 @@
+//
+//  MapCameraMoveCommand.swift
+//  Meomun
+//
+//  Created by 지연 on 1/29/26.
+//
+
+struct MapCameraMoveCommand: Equatable {
+    enum Reason: Equatable { case restore, userAction }
+    let snapshot: MapCameraSnapshot
+    let reason: Reason
+}

--- a/Meomun/Meomun/Presentation/Scene/Map/MapCameraSnapshot.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapCameraSnapshot.swift
@@ -1,0 +1,25 @@
+//
+//  MapCameraSnapshot.swift
+//  Meomun
+//
+//  Created by 지연 on 1/28/26.
+//
+
+struct MapCameraSnapshot: Equatable {
+    let coordinate: Coordinate
+    let zoom: Double
+    let tilt: Double
+    let heading: Double
+
+    init(
+        coordinate: Coordinate,
+        zoom: Double = 17,
+        tilt: Double = 45,
+        heading: Double = 0
+    ) {
+        self.coordinate = coordinate
+        self.zoom = zoom
+        self.tilt = tilt
+        self.heading = heading
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -13,8 +13,8 @@ final class MapStore: Store {
         case onAppear(Coordinate)
         case onDisappear
 
-        case cameraDidIdle(Coordinate, BoundingBox)
-        case cameraChangedByLocation(Coordinate, BoundingBox)
+        case cameraDidIdle(Coordinate, BoundingBox, MapCameraSnapshot)
+        case cameraChangedByLocation(Coordinate, BoundingBox, MapCameraSnapshot)
         case cameraMoveConsumed
 
         case tapSearch
@@ -34,7 +34,8 @@ final class MapStore: Store {
 
     enum Action {
         case setCameraCoordinate(Coordinate)
-        case setCameraMoveTarget(Coordinate?)
+        case setCameraMoveTarget(MapCameraMoveCommand?)
+        case setCameraSnapshot(MapCameraSnapshot?)
 
         case presentPlaceSearch(Bool)
 
@@ -51,11 +52,12 @@ final class MapStore: Store {
 
     struct State {
         var messages: [Message] = []
+        var cameraSnapshot: MapCameraSnapshot?
 
         var cameraCoordinate: Coordinate?
 
         var isPlaceSearchPresented: Bool = false
-        var cameraMoveTarget: Coordinate?
+        var cameraMoveTarget: MapCameraMoveCommand?
 
         var isShowingAddMessage: Bool = false
 
@@ -93,19 +95,41 @@ final class MapStore: Store {
                 let isConnected = networkMonitor.checkConnection()
                 continuation.yield(.setNetworkConnected(isConnected))
 
+                if let snapshot = state.cameraSnapshot {
+                    continuation.yield(.setCameraMoveTarget(.init(snapshot: snapshot, reason: .restore)))
+                } else {
+                    continuation.yield(
+                        .setCameraMoveTarget(
+                            .init(snapshot: .init(coordinate: coordinate), reason: .restore)
+                        )
+                    )
+                }
+
+                continuation.finish()
+
             case .onDisappear:
                 self.getNearbyMessageTask?.cancel()
                 self.getNearbyMessageTask = nil
                 continuation.yield(.setLoading(false))
                 continuation.finish()
 
-            case .cameraDidIdle(let coordinate, let boundingBox):
+            case .cameraDidIdle(let coordinate, let boundingBox, let snapshot):
                 continuation.yield(.setCameraCoordinate(coordinate))
-                self.getNearbyMessages(at: coordinate, bounds: boundingBox, continuation: continuation)
+                continuation.yield(.setCameraSnapshot(snapshot))
+                self.getNearbyMessages(
+                    at: coordinate,
+                    bounds: boundingBox,
+                    continuation: continuation
+                )
 
-            case .cameraChangedByLocation(let coordinate, let boundingBox):
+            case .cameraChangedByLocation(let coordinate, let boundingBox, let snapshot):
                 continuation.yield(.setCameraCoordinate(coordinate))
-                self.getNearbyMessages(at: coordinate, bounds: boundingBox, continuation: continuation)
+                continuation.yield(.setCameraSnapshot(snapshot))
+                self.getNearbyMessages(
+                    at: coordinate,
+                    bounds: boundingBox,
+                    continuation: continuation
+                )
 
             case .cameraMoveConsumed:
                 continuation.yield(.setCameraMoveTarget(nil))
@@ -121,7 +145,11 @@ final class MapStore: Store {
                 continuation.finish()
 
             case .selectPlace(let place):
-                continuation.yield(.setCameraMoveTarget(place.coordinate))
+                let target = MapCameraMoveCommand(
+                    snapshot: .init(coordinate: place.coordinate),
+                    reason: .userAction
+                )
+                continuation.yield(.setCameraMoveTarget(target))
                 continuation.finish()
 
             case .dismissAddMessage:
@@ -162,8 +190,11 @@ final class MapStore: Store {
         case .setCameraCoordinate(let coordinate):
             newState.cameraCoordinate = coordinate
 
-        case .setCameraMoveTarget(let coordinate):
-            newState.cameraMoveTarget = coordinate
+        case .setCameraSnapshot(let snapshot):
+            newState.cameraSnapshot = snapshot
+
+        case .setCameraMoveTarget(let snapshot):
+            newState.cameraMoveTarget = snapshot
 
         case .presentPlaceSearch(let isPresented):
             newState.isPlaceSearchPresented = isPresented

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -57,11 +57,11 @@ struct MapView: View {
                     onTapNoPlace: { messages in
                         send(.tapNoPlaceMarker(messages))
                     },
-                    onCameraIdle: { coordinate, bounds in
-                        send(.cameraDidIdle(coordinate, bounds))
+                    onCameraIdle: { coordinate, bounds, snapshot in
+                        send(.cameraDidIdle(coordinate, bounds, snapshot))
                     },
-                    onCameraChangedByLocation: { coordinate, bounds in
-                        send(.cameraChangedByLocation(coordinate, bounds))
+                    onCameraChangedByLocation: { coordinate, bounds, snapshot in
+                        send(.cameraChangedByLocation(coordinate, bounds, snapshot))
                     }
                 )
                 .ignoresSafeArea()

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -27,15 +27,11 @@ struct MapView: View {
     private let initialUserLocation: Coordinate
 
     init(
+        store: MapStore,
         userLocation: Coordinate,
         messageMarkerManager: MessageMarkerManager
     ) {
-        _store = StateObject(wrappedValue: MapStore(
-            getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(
-                messageRepository: MessageRepositoryImpl()
-            ),
-            networkMonitor: NetworkMonitor()
-        ))
+        _store = StateObject(wrappedValue: store)
         self.messageMarkerManager = messageMarkerManager
         self.initialUserLocation = userLocation
     }
@@ -248,6 +244,10 @@ private extension MapView {
     )
 
     return MapView(
+        store: MapStore(
+            getNearbyMessagesUseCase: GetNearbyMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl()),
+            networkMonitor: NetworkMonitor()
+        ),
         userLocation: .init(latitude: 37.5665, longitude: 126.9780),
         messageMarkerManager: messageMarkerManager
     )

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -27,12 +27,11 @@ final class MapViewController: UIViewController {
 
     private let onTapPlace: ((Place) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
-    private let onCameraIdle: ((Coordinate, BoundingBox) -> Void)?
-    private let onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)?
+    private let onCameraIdle: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)?
+    private let onCameraChangedByLocation: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)?
 
     // MARK: - Dependencies
 
-    private var locationManager = CLLocationManager()
     private let messageMarkerManager: MessageMarkerManager
 
     // MARK: - Init
@@ -41,8 +40,8 @@ final class MapViewController: UIViewController {
         messageMarkerManager: MessageMarkerManager,
         onTapPlace: ((Place) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
-        onCameraIdle: ((Coordinate, BoundingBox) -> Void)? = nil,
-        onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)? = nil
+        onCameraIdle: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)? = nil,
+        onCameraChangedByLocation: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)? = nil
     ) {
         self.messageMarkerManager = messageMarkerManager
         self.onTapPlace = onTapPlace
@@ -206,25 +205,41 @@ extension MapViewController {
 // MARK: - Camera Moving
 
 extension MapViewController {
-    func moveCamera(to coordinate: Coordinate, zoom: Double? = nil) {
-        let latLng = NMGLatLng(lat: coordinate.latitude, lng: coordinate.longitude)
-        let update = NMFCameraUpdate(scrollTo: latLng)
+    func moveCamera(to snapshot: MapCameraSnapshot, animated: Bool) {
+        naverMapView.mapView.positionMode = .disabled
 
-        update.animation = .easeIn
-        update.animationDuration = 0.35
-
-        guard let zoom else {
-            naverMapView.mapView.moveCamera(update)
-            return
-        }
+        let latLng = NMGLatLng(lat: snapshot.coordinate.latitude, lng: snapshot.coordinate.longitude)
 
         let position = NMFCameraPosition(
             latLng,
-            zoom: zoom,
-            tilt: 45,
-            heading: 0
+            zoom: snapshot.zoom,
+            tilt: snapshot.tilt,
+            heading: snapshot.heading
         )
-        naverMapView.mapView.moveCamera(NMFCameraUpdate(position: position))
+
+        let update = NMFCameraUpdate(position: position)
+
+        if animated {
+            update.animation = .easeIn
+            update.animationDuration = 0.35
+        } else {
+            update.animation = .none
+        }
+
+        naverMapView.mapView.moveCamera(update)
+    }
+
+    private func currentSnapshot(from mapView: NMFMapView) -> MapCameraSnapshot {
+        let position = mapView.cameraPosition
+        return MapCameraSnapshot(
+            coordinate: .init(
+                latitude: position.target.lat,
+                longitude: position.target.lng
+            ),
+            zoom: position.zoom,
+            tilt: position.tilt,
+            heading: position.heading
+        )
     }
 }
 
@@ -275,8 +290,9 @@ extension MapViewController: NMFMapViewCameraDelegate {
         let center = mapView.cameraPosition.target
         let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
         let domainBounds = makeBoundingBox(from: mapView)
+        let snapshot = currentSnapshot(from: mapView)
 
-        onCameraIdle?(coordinate, domainBounds)
+        onCameraIdle?(coordinate, domainBounds, snapshot)
         messageMarkerManager.updateClusterModeIfNeeded(zoomLevel: mapView.zoomLevel)
     }
 
@@ -292,8 +308,9 @@ extension MapViewController: NMFMapViewCameraDelegate {
         let center = mapView.cameraPosition.target
         let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
         let domainBounds = makeBoundingBox(from: mapView)
+        let snapshot = currentSnapshot(from: mapView)
 
-        onCameraChangedByLocation?(coordinate, domainBounds)
+        onCameraChangedByLocation?(coordinate, domainBounds, snapshot)
         messageMarkerManager.updateClusterModeIfNeeded(zoomLevel: mapView.zoomLevel)
     }
 
@@ -313,12 +330,12 @@ extension MapViewController: NMFMapViewCameraDelegate {
 struct MapViewWrapper: UIViewControllerRepresentable {
     private let messages: [Message]
     private let userLocation: Coordinate?
-    private let cameraMoveTarget: Coordinate?
+    private let cameraMoveTarget: MapCameraMoveCommand?
     private let onCameraMoveConsumed: () -> Void
     private let onTapPlace: ((Place) -> Void)?
     private let onTapNoPlace: (([Message]) -> Void)?
-    private let onCameraIdle: ((Coordinate, BoundingBox) -> Void)?
-    private let onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)?
+    private let onCameraIdle: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)?
+    private let onCameraChangedByLocation: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)?
 
     private let messageMarkerManager: MessageMarkerManager
 
@@ -326,12 +343,12 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         userLocation: Coordinate?,
         markerManager: MessageMarkerManager,
         messages: [Message],
-        cameraMoveTarget: Coordinate?,
+        cameraMoveTarget: MapCameraMoveCommand?,
         onCameraMoveConsumed: @escaping () -> Void,
         onTapPlace: ((Place) -> Void)? = nil,
         onTapNoPlace: (([Message]) -> Void)? = nil,
-        onCameraIdle: ((Coordinate, BoundingBox) -> Void)? = nil,
-        onCameraChangedByLocation: ((Coordinate, BoundingBox) -> Void)? = nil
+        onCameraIdle: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)? = nil,
+        onCameraChangedByLocation: ((Coordinate, BoundingBox, MapCameraSnapshot) -> Void)? = nil
     ) {
         self.userLocation = userLocation
         self.messageMarkerManager = markerManager
@@ -350,7 +367,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
 
     final class Coordinator {
         var lastMessagesSnapshot: Int?
-        var lastCameraMoveTarget: Coordinate?
+        var lastCameraMoveTarget: MapCameraMoveCommand?
         var didInitialLoad = false
     }
 
@@ -374,20 +391,16 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
-        if let target = cameraMoveTarget {
+        if let target = cameraMoveTarget, context.coordinator.lastCameraMoveTarget != target {
             // 동일 target인 경우 호출 X
-            if context.coordinator.lastCameraMoveTarget?.latitude != target.latitude ||
-                context.coordinator.lastCameraMoveTarget?.longitude != target.longitude {
+            context.coordinator.lastCameraMoveTarget = target
+            uiViewController.moveCamera(
+                to: target.snapshot,
+                animated: target.reason == .userAction
+            )
 
-                context.coordinator.lastCameraMoveTarget = target
-                uiViewController.moveCamera(
-                    to: target,
-                    zoom: 17
-                )
-
-                DispatchQueue.main.async {
-                    onCameraMoveConsumed()
-                }
+            DispatchQueue.main.async {
+                onCameraMoveConsumed()
             }
         }
 


### PR DESCRIPTION
## 배경
- closed #205

## 작업 요약
- 지도 탭 재진입 시 마지막 카메라 위치로 복원(고정)

## 작업 내용
### 1. 지도 탭 재진입 시 마지막 카메라 위치로 복원(고정)
#### 목표
* 사용자가 지도 탭에서 보고 있던 **마지막 카메라 상태(좌표/줌/틸트/헤딩)** 를 저장해두고, 다른 탭으로 이동했다가 **다시 지도 탭으로 돌아왔을 때**, 지도 화면이 **마지막 시점 그대로 복원**되도록 한다.
* 이때 복원 과정에서 현재 위치에서 저장된 위치로 이동하는 애니메이션이 보이지 않도록, **복원 이동은 애니메이션 없이 처리**한다.
* 반대로 장소 검색으로 이동할 때와 같은 사용자의 명시적 액션은 자연스러운 UX를 위해 **애니메이션 이동**을 사용한다.

#### 구현 내용
1) **카메라 이동을 명령(Command)으로 표현**
   - 카메라 이동을 단순 좌표 이동이 아닌, **왜 이동하는지**(복원/유저액션)를 포함한 커맨드로 모델링
     ```swift
     struct MapCameraMoveCommand: Equatable {
     	enum Reason: Equatable { case restore, userAction }
     	let snapshot: MapCameraSnapshot
     	let reason: Reason
     }
     ```
   - 실제 카메라 상태는 스냅샷으로 유지
     ```swift
     struct MapCameraSnapshot: Equatable {
     	let coordinate: Coordinate
     	let zoom: Double
     	let tilt: Double
     	let heading: Double
     }
     ```
2) **마지막 카메라 상태는 Store(State)에 저장**
   - cameraSnapshot: 마지막 카메라 상태 저장
   * cameraMoveTarget: 지도 화면에 이동 동작을 내려줄 1회성 명령
3) **카메라가 멈추는 시점에 snapshot을 갱신**
   - 지도 카메라가 idle이 될 때마다 최신 카메라 스냅샷을 Store에 저장한다.
     * `MapViewController.mapViewCameraIdle`에서 snapshot을 만들고 콜백으로 전달
     * MapView에서 `.cameraDidIdle(...)` intent로 Store에 전달
     * Store는 `setCameraSnapshot(snapshot)`으로 상태 갱신
   - -> 사용자가 지도에서 이동/줌/회전을 끝내는 순간마다 마지막 상태가 자동으로 축적됨.
4) **지도 화면이 다시 나타날 때(onAppear) restore 커맨드를 발행**
   - `MapStore.Intent.onAppear`에서 기존에 저장된 cameraSnapshot이 있으면 그걸로 복원
   * 없다면 초기 userLocation 기반 스냅샷을 복원값으로 설정
     ```swift
     case .onAppear(let coordinate):
     	if let snapshot = state.cameraSnapshot {
     		continuation.yield(.setCameraMoveTarget(.init(snapshot: snapshot, reason: .restore)))
     	} else {
     	 continuation.yield(.setCameraMoveTarget(.init(snapshot: .init(coordinate: coordinate), reason: .restore)))
     }
     ``` 
5) **UIViewControllerRepresentable에서 커맨드를 받아 실제 카메라 이동 실행**
   - MapViewWrapper.updateUIViewController에서 cameraMoveTarget이 오면 동일 커맨드는 중복 실행하지 않도록 lastCameraMoveTarget로 처리
   * 커맨드 reason에 따라 애니메이션 여부를 다르게 줌.
     ```swift
     uiViewController.moveCamera(
     	to: target.snapshot,
     	animated: target.reason == .userAction
     )
     ```
     * `.restore` → animated: false
     * `.userAction` → animated: true (유저가 장소 선택한 경우 등 자연스러운 애니메이션 적용)
6) **커맨드는 소비(consumed) 후 바로 nil 처리**
   - 커맨드는 1회성 이벤트이므로 이동 후에는 상태에서 제거한다.
   ```swift
   DispatchQueue.main.async {
    	onCameraMoveConsumed()
   }
   
   /// store:
   case .cameraMoveConsumed:
    	continuation.yield(.setCameraMoveTarget(nil))
   ```
     

## 스크린샷
![다른탭에서지도화면재진입시카메라유지](https://github.com/user-attachments/assets/dbaf4329-b0fe-4895-b92d-f89400449681)


## 리뷰 요구사항
- 지도 화면 첫 진입 시 나침반 버튼을 탭하지 않은 상태로도 사용자의 현재 좌표를 의미하는 파랑색 점이 바로 보여지도록 수정해서 해당 pr에 반영하려 했으나, 생각보다 변경점이 커지는 것 같고 다른 급한 이슈가 더 많다고 판단되어 포함하지 않았습니다. 추후 작업하면 될 것 같습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **맵 카메라 상태 관리 개선** - 맵 화면의 카메라 위치(확대/축소, 각도, 방향)를 저장하고 복원하는 기능이 추가되었습니다. 사용자 조작으로 인한 움직임과 시스템 자동 복원을 구분하여 더 나은 사용자 경험을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->