### PR TITLE
경로 기록 뷰 구현

### DIFF
--- a/Meomun/Meomun/Domain/Entity/YearMonth.swift
+++ b/Meomun/Meomun/Domain/Entity/YearMonth.swift
@@ -1,0 +1,31 @@
+//
+//  YearMonth.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+import Foundation
+
+struct YearMonth: Hashable, Comparable {
+    let year: Int
+    let month: Int
+
+    static func < (lhs: YearMonth, rhs: YearMonth) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        return lhs.month < rhs.month
+    }
+}
+
+extension YearMonth {
+    init(date: Date, calendar: Calendar = .current) {
+        let comps = calendar.dateComponents([.year, .month], from: date)
+        self.year = comps.year ?? 0
+        self.month = comps.month ?? 0
+    }
+
+    func startDate(in calendar: Calendar = .current) -> Date {
+        let comps = DateComponents(year: year, month: month, day: 1)
+        return calendar.date(from: comps) ?? Date(timeIntervalSince1970: 0)
+    }
+}

--- a/Meomun/Meomun/Domain/Extension/Array+extension.swift
+++ b/Meomun/Meomun/Domain/Extension/Array+extension.swift
@@ -1,0 +1,13 @@
+//
+//  Array+extension.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard indices.contains(index) else { return nil }
+        return self[index]
+    }
+}

--- a/Meomun/Meomun/Domain/MessageTimelineGrouper.swift
+++ b/Meomun/Meomun/Domain/MessageTimelineGrouper.swift
@@ -7,29 +7,6 @@
 
 import Foundation
 
-struct YearMonth: Hashable, Comparable {
-    let year: Int
-    let month: Int
-
-    static func < (lhs: YearMonth, rhs: YearMonth) -> Bool {
-        if lhs.year != rhs.year { return lhs.year < rhs.year }
-        return lhs.month < rhs.month
-    }
-}
-
-extension YearMonth {
-    init(date: Date, calendar: Calendar = .current) {
-        let comps = calendar.dateComponents([.year, .month], from: date)
-        self.year = comps.year ?? 0
-        self.month = comps.month ?? 0
-    }
-
-    func startDate(in calendar: Calendar = .current) -> Date {
-        let comps = DateComponents(year: year, month: month, day: 1)
-        return calendar.date(from: comps) ?? Date(timeIntervalSince1970: 0)
-    }
-}
-
 struct MessageTimelineGrouper {
     static func groupByYearMonth(
         _ messages: [Message],

--- a/Meomun/Meomun/Presentation/Common/MarkerAssets.swift
+++ b/Meomun/Meomun/Presentation/Common/MarkerAssets.swift
@@ -15,7 +15,7 @@ enum MarkerAssets {
         let uiImage = UIImage(systemName: "mappin", withConfiguration: config)?
             .withTintColor(.systemRed, renderingMode: .alwaysOriginal)
 
-        return NMFOverlayImage(image: uiImage ?? UIImage.checkmark)
+        return NMFOverlayImage(image: uiImage ?? UIImage())
     }()
 
     static let pin: NMFOverlayImage = {
@@ -24,6 +24,6 @@ enum MarkerAssets {
         let uiImage = UIImage(systemName: "pin.fill", withConfiguration: config)?
             .withTintColor(.systemRed, renderingMode: .alwaysOriginal)
 
-        return NMFOverlayImage(image: uiImage ?? UIImage.checkmark)
+        return NMFOverlayImage(image: uiImage ?? UIImage())
     }()
 }

--- a/Meomun/Meomun/Presentation/Common/MarkerAssets.swift
+++ b/Meomun/Meomun/Presentation/Common/MarkerAssets.swift
@@ -1,0 +1,29 @@
+//
+//  MarkerAssets.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+import UIKit
+import NMapsMap
+
+enum MarkerAssets {
+    static let mappin: NMFOverlayImage = {
+        let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+
+        let uiImage = UIImage(systemName: "mappin", withConfiguration: config)?
+            .withTintColor(.systemRed, renderingMode: .alwaysOriginal)
+
+        return NMFOverlayImage(image: uiImage ?? UIImage.checkmark)
+    }()
+
+    static let pin: NMFOverlayImage = {
+        let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+
+        let uiImage = UIImage(systemName: "pin.fill", withConfiguration: config)?
+            .withTintColor(.systemRed, renderingMode: .alwaysOriginal)
+
+        return NMFOverlayImage(image: uiImage ?? UIImage.checkmark)
+    }()
+}

--- a/Meomun/Meomun/Presentation/Common/PathMarkerModel.swift
+++ b/Meomun/Meomun/Presentation/Common/PathMarkerModel.swift
@@ -1,0 +1,13 @@
+//
+//  PathMarkerModel.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+import NMapsMap
+
+struct PathMarkerModel {
+    let positions: [NMGLatLng]
+    let dayLabels: [String]
+}

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionHeaderView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionHeaderView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TimelineSectionHeaderView: View {
     let yearMonth: YearMonth
+    let onTapButton: () -> Void
 
     var body: some View {
         let date = yearMonth.startDate()
@@ -23,13 +24,23 @@ struct TimelineSectionHeaderView: View {
                 .foregroundStyle(Color.meomunPrimaryColor.opacity(0.45))
                 .padding(.leading, 6)
 
-            Image(systemName: "chevron.right")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(Color.tabActive)
-                .opacity(0.75)
-
             Spacer()
 
+            Button(action: onTapButton) {
+                HStack(spacing: 6) {
+                    Text("흔적 따라가기")
+                        .font(.footnote.weight(.semibold))
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 18, weight: .semibold))
+                }
+                .foregroundStyle(Color.tabActive)
+                .opacity(0.75)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 10)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, 30)
         .padding(.top, 8)
@@ -39,5 +50,5 @@ struct TimelineSectionHeaderView: View {
 }
 
 #Preview {
-    TimelineSectionHeaderView(yearMonth: YearMonth(date: Date.now))
+    TimelineSectionHeaderView(yearMonth: YearMonth(date: Date.now), onTapButton: {})
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
@@ -10,24 +10,20 @@ import NMapsMap
 
 final class MiniMapViewController: UIViewController {
     // MARK: - Init
-    private let miniMapView: NMFNaverMapView = {
-        let miniMapView = NMFNaverMapView()
+    private let miniMapView: NMFMapView = {
+        let miniMapView = NMFMapView()
 
         // 지도 UI 설정
-        miniMapView.showCompass = false
-        miniMapView.showScaleBar = false
-        miniMapView.showZoomControls = false
-        miniMapView.showLocationButton = false
-        miniMapView.mapView.logoInteractionEnabled = false
+        miniMapView.logoInteractionEnabled = false
 
         // 유저 상호작용
         miniMapView.isUserInteractionEnabled = false
 
         // 최소 및 최대 줌 레벨 설정
-        miniMapView.mapView.minZoomLevel = 8
-        miniMapView.mapView.maxZoomLevel = 18
+        miniMapView.minZoomLevel = 5
+        miniMapView.maxZoomLevel = 18
 
-        miniMapView.mapView.customStyleId = "bf0bd9ae-f750-4895-8246-2744297005d0"
+        miniMapView.customStyleId = "bf0bd9ae-f750-4895-8246-2744297005d0"
 
         return miniMapView
     }()

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
@@ -30,11 +30,18 @@ final class MiniMapViewController: UIViewController {
 
     private var markers: [NMFMarker] = []
     private var pathOverlay: NMFPath?
+    private var pendingMessages: [Message] = []
+    private var didApplyOnce = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureSubviews()
         configureLayout()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        applyIfPossible()
     }
 }
 
@@ -53,6 +60,159 @@ extension MiniMapViewController {
             miniMapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             miniMapView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+}
+
+// MARK: - Route Overlay
+extension MiniMapViewController {
+    func render(messages: [Message]) {
+        pendingMessages = messages
+        applyIfPossible()
+    }
+
+    private func applyIfPossible() {
+        guard view.bounds.width > 0, view.bounds.height > 0 else { return }
+        guard miniMapView.bounds.width > 0, miniMapView.bounds.height > 0 else { return }
+
+        guard !didApplyOnce else { return }
+        didApplyOnce = true
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.apply(messages: self.pendingMessages)
+        }
+    }
+
+    private func apply(messages: [Message]) {
+        clearOverlays()
+
+        let record = buildPaths(messages: messages)
+        addMarkers(positions: record.positions, dayLabels: record.dayLabels)
+
+        if record.positions.count >= 2 {
+            addPath(positions: record.positions)
+        }
+
+        fitCamera(messages: messages, positions: record.positions)
+    }
+
+    private func clearOverlays() {
+        // 마커 삭제
+        markers.forEach { $0.mapView = nil }
+        markers.removeAll()
+
+        // 경로선 삭제
+        pathOverlay?.mapView = nil
+        pathOverlay = nil
+    }
+
+    func buildPaths(messages: [Message], calendar: Calendar = .current) -> PathMarkerModel {
+        let sortedMessages = messages.sorted { $0.createdAt < $1.createdAt }
+
+        let positions = sortedMessages.map {
+            NMGLatLng(
+                lat: $0.coordinate.latitude,
+                lng: $0.coordinate.longitude
+            )
+        }
+        let dayLabels = sortedMessages.map { "\(calendar.component(.day, from: $0.createdAt))" }
+
+        return PathMarkerModel(positions: positions, dayLabels: dayLabels)
+    }
+
+    private func addMarkers(positions: [NMGLatLng], dayLabels: [String]) {
+        for (index, position) in positions.enumerated() {
+            let marker = NMFMarker(position: position)
+
+            marker.captionText = dayLabels[safe: index] ?? ""
+            marker.captionTextSize = 16
+            marker.captionMinZoom = 5
+            marker.captionMaxZoom = 18
+
+            marker.mapView = miniMapView
+
+            markers.append(marker)
+        }
+    }
+
+    private func addPath(positions: [NMGLatLng]) {
+        let overlay = NMFPath()
+        overlay.path = NMGLineString(points: positions)
+
+         overlay.width = 4
+         overlay.outlineWidth = 2
+
+        overlay.mapView = miniMapView
+        self.pathOverlay = overlay
+    }
+
+    private func fitCamera(messages: [Message], positions: [NMGLatLng]) {
+        guard let firstPosition = positions.first else { return }
+
+        // Case 1. 메시지 1개 → 고정 확대
+        if messages.count == 1 {
+            let zoom = miniMapView.maxZoomLevel
+            let update = NMFCameraUpdate(
+                scrollTo: firstPosition,
+                zoomTo: zoom
+            )
+            miniMapView.moveCamera(update)
+            return
+        }
+
+        // 메시지 분포 거리 계산
+        let spreadMeters = maxPairDistanceMeters(from: messages)
+
+        // Case 2. 가까운 경우 → 더 확대
+        if spreadMeters < 200 {
+            let update = NMFCameraUpdate(
+                scrollTo: firstPosition,
+                zoomTo: miniMapView.maxZoomLevel
+            )
+            miniMapView.moveCamera(update)
+            return
+        }
+
+        // Case 3. 더 먼 경우
+        var south = firstPosition.lat
+        var north = firstPosition.lat
+        var west = firstPosition.lng
+        var east = firstPosition.lng
+
+        for point in positions {
+            south = min(south, point.lat)
+            north = max(north, point.lat)
+            west = min(west, point.lng)
+            east = max(east, point.lng)
+        }
+
+        let bounds = NMGLatLngBounds(
+            southWest: NMGLatLng(lat: south, lng: west),
+            northEast: NMGLatLng(lat: north, lng: east)
+        )
+
+        let update = NMFCameraUpdate(fit: bounds)
+        miniMapView.moveCamera(update)
+    }
+}
+
+// MARK: - Marker Distance Helper
+extension MiniMapViewController {
+    private func maxPairDistanceMeters(from messages: [Message]) -> Double {
+        guard messages.count >= 2 else { return 0 }
+
+        var maxDistance: Double = 0
+
+        for i in 0..<(messages.count - 1) {
+            let target = messages[i].coordinate
+            for j in (i + 1)..<messages.count {
+                let compare = messages[j].coordinate
+                let distance = target.distance(to: compare)
+                maxDistance = max(maxDistance, distance)
+            }
+        }
+
+        return maxDistance
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
@@ -16,12 +16,9 @@ final class MiniMapViewController: UIViewController {
         // 지도 UI 설정
         miniMapView.logoInteractionEnabled = false
 
-        // 유저 상호작용
-        // miniMapView.isUserInteractionEnabled = false
-
         // 최소 및 최대 줌 레벨 설정
         miniMapView.minZoomLevel = 5
-        miniMapView.maxZoomLevel = 18
+        miniMapView.maxZoomLevel = 16
 
         miniMapView.customStyleId = "bf0bd9ae-f750-4895-8246-2744297005d0"
 
@@ -29,7 +26,7 @@ final class MiniMapViewController: UIViewController {
     }()
 
     private var markers: [NMFMarker] = []
-    private var pathOverlay: NMFPath?
+    private var polyOverlay: NMFPolylineOverlay?
     private var pendingMessages: [Message] = []
     private var didApplyOnce = false
 
@@ -102,8 +99,8 @@ extension MiniMapViewController {
         markers.removeAll()
 
         // 경로선 삭제
-        pathOverlay?.mapView = nil
-        pathOverlay = nil
+        polyOverlay?.mapView = nil
+        polyOverlay = nil
     }
 
     func buildPaths(messages: [Message], calendar: Calendar = .current) -> PathMarkerModel {
@@ -148,6 +145,8 @@ extension MiniMapViewController {
         polyline.capType = .round
         polyline.joinType = .round
         polyline.mapView = miniMapView
+
+        polyOverlay = polyline
     }
 
     private func fitCamera(messages: [Message], positions: [NMGLatLng]) {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
@@ -17,7 +17,7 @@ final class MiniMapViewController: UIViewController {
         miniMapView.logoInteractionEnabled = false
 
         // 유저 상호작용
-        miniMapView.isUserInteractionEnabled = false
+        // miniMapView.isUserInteractionEnabled = false
 
         // 최소 및 최대 줌 레벨 설정
         miniMapView.minZoomLevel = 5
@@ -124,11 +124,15 @@ extension MiniMapViewController {
         for (index, position) in positions.enumerated() {
             let marker = NMFMarker(position: position)
 
-            marker.captionText = dayLabels[safe: index] ?? ""
-            marker.captionTextSize = 16
-            marker.captionMinZoom = 5
-            marker.captionMaxZoom = 18
+            marker.iconImage = MarkerAssets.pin
+            marker.iconTintColor = .tabActive
+            marker.angle = CGFloat(Int.random(in: 0...15))
 
+            marker.captionText = dayLabels[safe: index] ?? ""
+            marker.captionTextSize = 14
+            marker.captionHaloColor = .white
+
+            marker.isHideCollidedMarkers = true
             marker.mapView = miniMapView
 
             markers.append(marker)
@@ -136,14 +140,14 @@ extension MiniMapViewController {
     }
 
     private func addPath(positions: [NMGLatLng]) {
-        let overlay = NMFPath()
-        overlay.path = NMGLineString(points: positions)
+        guard let polyline = NMFPolylineOverlay(positions) else { return }
 
-         overlay.width = 4
-         overlay.outlineWidth = 2
-
-        overlay.mapView = miniMapView
-        self.pathOverlay = overlay
+        polyline.width = 2
+        polyline.color = UIColor.tabActive
+        polyline.pattern = [6, 3]
+        polyline.capType = .round
+        polyline.joinType = .round
+        polyline.mapView = miniMapView
     }
 
     private func fitCamera(messages: [Message], positions: [NMGLatLng]) {
@@ -160,20 +164,7 @@ extension MiniMapViewController {
             return
         }
 
-        // 메시지 분포 거리 계산
-        let spreadMeters = maxPairDistanceMeters(from: messages)
-
-        // Case 2. 가까운 경우 → 더 확대
-        if spreadMeters < 200 {
-            let update = NMFCameraUpdate(
-                scrollTo: firstPosition,
-                zoomTo: miniMapView.maxZoomLevel
-            )
-            miniMapView.moveCamera(update)
-            return
-        }
-
-        // Case 3. 더 먼 경우
+        // Case 2. 여러개 있다면 카메라 조정
         var south = firstPosition.lat
         var north = firstPosition.lat
         var west = firstPosition.lng
@@ -191,7 +182,7 @@ extension MiniMapViewController {
             northEast: NMGLatLng(lat: north, lng: east)
         )
 
-        let update = NMFCameraUpdate(fit: bounds)
+        let update = NMFCameraUpdate(fit: bounds, padding: 40)
         miniMapView.moveCamera(update)
     }
 }
@@ -215,4 +206,3 @@ extension MiniMapViewController {
         return maxDistance
     }
 }
-

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapViewController.swift
@@ -1,0 +1,62 @@
+//
+//  MiniMapViewController.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+import UIKit
+import NMapsMap
+
+final class MiniMapViewController: UIViewController {
+    // MARK: - Init
+    private let miniMapView: NMFNaverMapView = {
+        let miniMapView = NMFNaverMapView()
+
+        // 지도 UI 설정
+        miniMapView.showCompass = false
+        miniMapView.showScaleBar = false
+        miniMapView.showZoomControls = false
+        miniMapView.showLocationButton = false
+        miniMapView.mapView.logoInteractionEnabled = false
+
+        // 유저 상호작용
+        miniMapView.isUserInteractionEnabled = false
+
+        // 최소 및 최대 줌 레벨 설정
+        miniMapView.mapView.minZoomLevel = 8
+        miniMapView.mapView.maxZoomLevel = 18
+
+        miniMapView.mapView.customStyleId = "bf0bd9ae-f750-4895-8246-2744297005d0"
+
+        return miniMapView
+    }()
+
+    private var markers: [NMFMarker] = []
+    private var pathOverlay: NMFPath?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureSubviews()
+        configureLayout()
+    }
+}
+
+// MARK: - Configure UI
+
+extension MiniMapViewController {
+    private func configureSubviews() {
+        view.addSubview(miniMapView)
+        miniMapView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func configureLayout() {
+        NSLayoutConstraint.activate([
+            miniMapView.topAnchor.constraint(equalTo: view.topAnchor),
+            miniMapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            miniMapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            miniMapView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}
+

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapWrapper.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapWrapper.swift
@@ -1,0 +1,24 @@
+//
+//  MiniMapWrapper.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+import SwiftUI
+
+struct MiniMapWrapper: UIViewControllerRepresentable {
+    private let messages: [Message]
+
+    init(messages: [Message]) {
+        self.messages = messages
+    }
+
+    func makeUIViewController(context: Context) -> MiniMapViewController {
+        let viewController = MiniMapViewController()
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: MiniMapViewController, context: Context) {
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapWrapper.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapWrapper.swift
@@ -19,5 +19,6 @@ struct MiniMapWrapper: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: MiniMapViewController, context: Context) {
+        uiViewController.render(messages: messages)
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapWrapper.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/MiniMapWrapper.swift
@@ -15,8 +15,7 @@ struct MiniMapWrapper: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> MiniMapViewController {
-        let viewController = MiniMapViewController()
-        return viewController
+        MiniMapViewController()
     }
 
     func updateUIViewController(_ uiViewController: MiniMapViewController, context: Context) {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordMiniMapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordMiniMapView.swift
@@ -1,0 +1,52 @@
+//
+//  PathRecordMiniMapView.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 1/29/26.
+//
+
+import SwiftUI
+
+struct PathRecordMiniMapView: View {
+    let messages: [Message]
+
+    var body: some View {
+        MiniMapWrapper(messages: messages)
+            .clipShape(Rectangle())
+            .overlay(
+                Rectangle()
+                    .stroke(Color.black.opacity(0.08), lineWidth: 1)
+            )
+    }
+}
+
+#Preview {
+    let messages: [Message] =  [
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-7 * 60),
+            content: "[Case4] NoPlace 스택 메시지 1",
+            coordinate: Coordinate.seoulCity,
+            address: "가람로 109",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-30 * 60),
+            content: "[Case4] NoPlace 스택 메시지 2",
+            coordinate: Coordinate.seoulCity,
+            address: "가람로 109",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-15000 * 60),
+            content: "[Case4] NoPlace 스택 메시지 3",
+            coordinate: Coordinate.seoulCity,
+            address: "가람로 109",
+            placeTag: nil
+        )
+    ]
+
+    PathRecordMiniMapView(messages: messages)
+}

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
@@ -13,7 +13,7 @@ fileprivate enum Constants {
     static let miniMapTopPadding: CGFloat = 36
 
     static let frameInnerBottomPadding: CGFloat = 14
-    static let frameHoriziontalPadding: CGFloat = 40
+    static let frameHorizontalPadding: CGFloat = 40
     static let frameVerticalPadding: CGFloat = 160
     static let frameCornerRadius: CGFloat = 3
 
@@ -73,7 +73,7 @@ private extension PathRecordOverlayView {
             RoundedRectangle(cornerRadius: Constants.frameCornerRadius, style: .continuous)
                 .stroke(Color.black.opacity(0.06), lineWidth: 1)
         )
-        .padding(.horizontal, Constants.frameHoriziontalPadding)
+        .padding(.horizontal, Constants.frameHorizontalPadding)
         .padding(.vertical, Constants.frameVerticalPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
@@ -8,6 +8,18 @@
 import SwiftUI
 import Foundation
 
+fileprivate enum Constants {
+    static let miniMapPadding: CGFloat = 20
+    static let miniMapTopPadding: CGFloat = 36
+
+    static let frameInnerBottomPadding: CGFloat = 14
+    static let frameHoriziontalPadding: CGFloat = 40
+    static let frameVerticalPadding: CGFloat = 160
+    static let frameCornerRadius: CGFloat = 3
+
+    static let titlePadding: CGFloat = 14
+}
+
 struct PathRecordOverlayView: View {
     private let section: YearMonth
     private let messages: [Message]
@@ -32,32 +44,45 @@ struct PathRecordOverlayView: View {
                 .onTapGesture { onDismiss() }
 
             if isPresented {
-                VStack {
-                    header
-                    content
-                }
-                .padding(28)
-                .frame(width: 320, height: 400)
-                .background(Color.white)
-                .transition(.opacity.combined(with: .scale(scale: 0.98)))
-                .onTapGesture { }
+                content
+                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
         .onAppear {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                isPresented = true
-            }
+            withAnimation(.easeInOut(duration: 0.3)) { isPresented = true }
         }
         .onDisappear { isPresented = false }
     }
 }
 
 private extension PathRecordOverlayView {
-    var header: some View {
+    var content: some View {
+        VStack(spacing: 12) {
+            PathRecordMiniMapView(messages: messages)
+                .padding(.top, Constants.miniMapTopPadding)
+                .padding(.bottom, Constants.miniMapPadding)
+                .padding(.horizontal, Constants.miniMapPadding)
+                .background(Color.black.opacity(0.02))
+            title
+        }
+        .padding(.bottom, Constants.frameInnerBottomPadding)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: Constants.frameCornerRadius, style: .continuous))
+        .shadow(color: .black.opacity(0.08), radius: 8, x: 0, y: 4)
+        .overlay(
+            RoundedRectangle(cornerRadius: Constants.frameCornerRadius, style: .continuous)
+                .stroke(Color.black.opacity(0.06), lineWidth: 1)
+        )
+        .padding(.horizontal, Constants.frameHoriziontalPadding)
+        .padding(.vertical, Constants.frameVerticalPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+
+    }
+
+    var title: some View {
         ZStack {
             Text("\(monthText), 머문 흔적 따라가기")
-                .font(.headline)
-                .padding(.bottom, 8)
+                .font(.headline.italic())
 
             HStack {
                 Spacer()
@@ -66,41 +91,12 @@ private extension PathRecordOverlayView {
                     Image(systemName: "xmark")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(Color.meomunSecondaryColor)
-                        .padding(10)
                         .contentShape(Rectangle())
                 }
+                .padding(.horizontal, 16)
             }
         }
-    }
-    var content: some View {
-        let calendar = Calendar.current
-
-        return ScrollView {
-            VStack {
-                ForEach(messages) { message in
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(message.content)
-                            .font(.footnote)
-
-                        Text("위도: \(message.coordinate.latitude)")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        Text("경도: \(message.coordinate.longitude)")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        let day = calendar.component(.day, from: message.createdAt)
-                        Text("일자: \(day.description)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 8)
-
-                    Divider()
-                }
-            }
-        }
+        .padding(Constants.titlePadding)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
@@ -109,32 +109,65 @@ private extension PathRecordOverlayView {
 }
 
 #Preview {
-    let messages: [Message] =  [
+    let messages: [Message] = [
         Message(
             id: MessageID(value: UUID()),
-            createdAt: Date().addingTimeInterval(-7 * 60),
-            content: "[Case4] NoPlace 스택 메시지 1",
-            coordinate: Coordinate.seoulCity,
-            address: "가람로 109",
+            createdAt: Date().addingTimeInterval(-40 * 60),
+            content: "벤치에 앉아 잠깐 쉬어요",
+            coordinate: .init(latitude: 37.5698, longitude: 126.9775),
+            address: "서판교로29",
             placeTag: nil
         ),
         Message(
             id: MessageID(value: UUID()),
-            createdAt: Date().addingTimeInterval(-30 * 60),
-            content: "[Case4] NoPlace 스택 메시지 2",
-            coordinate: Coordinate.seoulCity,
-            address: "가람로 109",
+            createdAt: Date().addingTimeInterval(-4000 * 60),
+            content: "페이드인 되고 있어?",
+            coordinate: .init(latitude: 37.5665, longitude: 126.9780),
+            address: "서판교로29",
             placeTag: nil
         ),
         Message(
             id: MessageID(value: UUID()),
-            createdAt: Date().addingTimeInterval(-15000 * 60),
-            content: "[Case4] NoPlace 스택 메시지 3",
-            coordinate: Coordinate.seoulCity,
-            address: "가람로 109",
+            createdAt: Date().addingTimeInterval(-1000 * 60 * 60),
+            content: "따뜻한 커피 향이 지나간다☕️",
+            coordinate: .init(latitude: 37.5704, longitude: 126.9766),
+            address: "서판교로29",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-300 * 60 * 60),
+            content: "멀리서 버스 브레이크 소리🚍",
+            coordinate: .init(latitude: 37.5718, longitude: 126.9792),
+            address: "서판교로29",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-20000 * 60),
+            content: "바닥에 그림자가 길게 늘어져요🌒",
+            coordinate: .init(latitude: 37.5728, longitude: 126.9756),
+            address: "서판교로29",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-1500 * 60),
+            content: "누군가 웃는 소리 지나갔다🙂",
+            coordinate: .init(latitude: 37.5709, longitude: 126.9786),
+            address: "서판교로29",
+            placeTag: nil
+        ),
+        Message(
+            id: MessageID(value: UUID()),
+            createdAt: Date().addingTimeInterval(-100 * 60 * 60),
+            content: "새벽 공기가 차갑고 맑다🌙",
+            coordinate: .init(latitude: 37.5692, longitude: 126.9798),
+            address: "서판교로29",
             placeTag: nil
         )
     ]
+
 
     PathRecordOverlayView(section: YearMonth(date: Date.now), messages: messages)
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
@@ -81,7 +81,7 @@ private extension PathRecordOverlayView {
 
     var title: some View {
         ZStack {
-            Text("\(monthText), 머문 흔적 따라가기")
+            Text("\(dateText)")
                 .font(.headline.italic())
 
             HStack {
@@ -102,9 +102,9 @@ private extension PathRecordOverlayView {
 
 // MARK: Computed Property
 private extension PathRecordOverlayView {
-    var monthText: String {
+    var dateText: String {
         let date = section.startDate()
-        return date.formatted(.dateTime.month(.abbreviated))
+        return date.formatted(.dateTime.year().month())
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/PathRecord/PathRecordOverlayView.swift
@@ -128,9 +128,9 @@ private extension PathRecordOverlayView {
         ),
         Message(
             id: MessageID(value: UUID()),
-            createdAt: Date().addingTimeInterval(-1000 * 60 * 60),
+            createdAt: Date().addingTimeInterval(-100 * 60 * 60),
             content: "따뜻한 커피 향이 지나간다☕️",
-            coordinate: .init(latitude: 37.5704, longitude: 126.9766),
+            coordinate: .init(latitude: 37.0724, longitude: 126.0746),
             address: "서판교로29",
             placeTag: nil
         ),
@@ -138,7 +138,7 @@ private extension PathRecordOverlayView {
             id: MessageID(value: UUID()),
             createdAt: Date().addingTimeInterval(-300 * 60 * 60),
             content: "멀리서 버스 브레이크 소리🚍",
-            coordinate: .init(latitude: 37.5718, longitude: 126.9792),
+            coordinate: .init(latitude: 37.508, longitude: 126.992),
             address: "서판교로29",
             placeTag: nil
         ),
@@ -146,7 +146,7 @@ private extension PathRecordOverlayView {
             id: MessageID(value: UUID()),
             createdAt: Date().addingTimeInterval(-20000 * 60),
             content: "바닥에 그림자가 길게 늘어져요🌒",
-            coordinate: .init(latitude: 37.5728, longitude: 126.9756),
+            coordinate: .init(latitude: 36.928, longitude: 126.656),
             address: "서판교로29",
             placeTag: nil
         ),
@@ -154,7 +154,7 @@ private extension PathRecordOverlayView {
             id: MessageID(value: UUID()),
             createdAt: Date().addingTimeInterval(-1500 * 60),
             content: "누군가 웃는 소리 지나갔다🙂",
-            coordinate: .init(latitude: 37.5709, longitude: 126.9786),
+            coordinate: .init(latitude: 37.5709, longitude: 125.9786),
             address: "서판교로29",
             placeTag: nil
         ),
@@ -162,12 +162,11 @@ private extension PathRecordOverlayView {
             id: MessageID(value: UUID()),
             createdAt: Date().addingTimeInterval(-100 * 60 * 60),
             content: "새벽 공기가 차갑고 맑다🌙",
-            coordinate: .init(latitude: 37.5692, longitude: 126.9798),
+            coordinate: .init(latitude: 36.5672, longitude: 126.9708),
             address: "서판교로29",
             placeTag: nil
         )
     ]
-
 
     PathRecordOverlayView(section: YearMonth(date: Date.now), messages: messages)
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -122,14 +122,15 @@ private extension TimelineListView {
                             .onTapGesture { send(.tapMessage(message.id)) }
                         }
                     } header: {
-                        TimelineSectionHeaderView(yearMonth: section.key)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
+                        TimelineSectionHeaderView(
+                            yearMonth: section.key,
+                            onTapButton: {
                                 Task {
                                     guard !store.state.isEditing else { return }
                                     await store.send(intent: .tapSection(section.key))
                                 }
                             }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## 배경
- closed #268

## 작업 요약

- [x]  타임라인 섹션 헤더 클릭 영역 개선
- [x]  PathRecord 오버레이 UI 설계 및 폴라로이드 스타일 카드 구현
- [x]  MiniMap 전용 MapView 구성 및 SwiftUI–UIKit 브릿지 구조 설계
- [x]  메시지 좌표 기반 마커 + 경로선(Path) 렌더링
- [x]  카메라 자동 이동 및 bounds-fit 로직 구현
- [x]  SF Symbols(mappin) 기반 마커 아이콘 캐싱 및 재사용


## 작업 내용

### 타임라인 섹션 헤더 클릭 범위 개선 (Button 분리)

- **기존**: 섹션 헤더 전체 `onTapGesture`로 클릭 가능
- **변경**: `흔적 따라가기 + chevron` 영역만 `Button`으로 클릭 가능

#### 코드

```swift
TimelineSectionHeaderView(
    yearMonth: section.key,
    onTapButton: {
				Task {
						guard!store.state.isEditingelse {return }
						await store.send(intent: .tapSection(section.key))
        }
    }
)
```

```swift
Button(action: onTapButton) {
		HStack(spacing:6) {
				Text("흔적 따라가기")
				Image(systemName:"chevron.right")
	  }
}
.buttonStyle(.plain)
```

### PathRecordOverlayView 설계 (폴라로이드 카드 UI)

#### 구조

- 전체 화면 dim (`Color.black.opacity(0.35)`)
- 중앙에 **카드 형태 컨테이너**
- 상단: MiniMap
- 하단: 연·월 타이틀 + 닫기 버튼

### MiniMap 전용 MapView 분리 및 SwiftUI Wrapper 구성

#### 설계 의도

- 기존 MapView와 **완전히 독립**
- PathRecord 전용 책임 (읽기 전용, 인터랙션 최소화)

#### 구성

- `MiniMapViewController` (UIKit)
- `MiniMapWrapper` (`UIViewControllerRepresentable`)
- `PathRecordMiniMapView` (SwiftUI View)

#### 흐름

```
PathRecordOverlayView
 └─ PathRecordMiniMapView
     └─ MiniMapWrapper
         └─ MiniMapViewController

```

```mermaid
sequenceDiagram
    autonumber
    actor User as User
    participant PRV as PathRecordOverlayView (SwiftUI)
    participant PMMV as PathRecordMiniMapView (SwiftUI)
    participant W as MiniMapWrapper (UIViewControllerRepresentable)
    participant VC as MiniMapViewController (UIKit)
    participant MV as NMFMapView (Naver Maps SDK)

    User->>PRV: "흔적 따라가기" 버튼 탭(섹션 헤더)
    PRV->>PRV: isPresented = true (overlay 표시)
    PRV->>PMMV: messages 전달 (PathRecord 데이터)

    PMMV->>W: MiniMapWrapper(messages)
    W->>VC: makeUIViewController() (초기 생성 시)
    VC->>MV: viewDidLoad() NMFMapView 생성/세팅

    Note over W,VC: SwiftUI 상태 변경 시 반복 호출
    W->>VC: updateUIViewController() render(messages)

    VC->>VC: pendingMessages 저장
    VC->>VC: viewDidLayoutSubviews() 또는 renderIfPossible()
    VC->>VC: bounds 체크 (width/height > 0)

    VC->>VC: 메시지 정렬/좌표 변환 [Message] -> [Coordinate] -> [NMGLatLng]
    VC->>MV: 기존 오버레이 제거 (marker.mapView=nil, path.mapView=nil)

    VC->>MV: 마커 추가 NMFMarker.position 지정 -> mapView 지정
    alt positions.count >= 2
        VC->>MV: 경로선 추가 NMFPath.path 지정 -> mapView 지정
    end

    VC->>VC: 카메라 정책 적용 (zoom 제한/fit 전략 선택)
    VC->>MV: moveCamera(update) - single: scrollTo+zoomTo - multi: fit(bounds,padding)

    MV-->>User: MiniMap 렌더링 완료 (마커/경로선/줌 반영)

```

### 메시지 좌표 기반 마커 + 경로선(Path) 렌더링

#### 처리 흐름

1. 메시지 시간순 정렬
2. 좌표 → `NMGLatLng` 변환
3. 마커 생성 (day label 포함)
4. 2개 이상일 경우 경로선 추가

#### 마커

```swift
let marker = NMFMarker(position: position)
marker.iconImage=MarkerAssets.pin
marker.captionText= dayLabels[index]
marker.mapView= miniMapView
```

#### 경로선

```swift
let polyline = NMFPolylineOverlay(positions)
polyline.pattern= [6,3]
polyline.mapView= miniMapView
```

### 카메라 이동 & bounds-fit 처리

#### 케이스 분기

- **메시지 1개** → 해당 좌표로 scroll + max zoom
- **여러 개** → 전체 좌표를 감싸는 bounds 계산 후 `fit`

```swift
let update=NMFCameraUpdate(fit: bounds, padding:40)
miniMapView.moveCamera(update)
```

#### 주의 포인트

- view / mapView bounds가 0일 때 이동하면 실패
- `viewDidLayoutSubviews` 이후 1회만 적용 (`didApplyOnce`)

### SF Symbols(mappin) 마커 이미지 캐싱

#### 목표

- 매번 이미지 생성 ❌
- 앱 생애주기 동안 **한 번만 생성 후 재사용**

#### 구현

```swift
enum MarkerAssets {
    static let mappin: NMFOverlayImage = {
        let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .regular)

        let uiImage = UIImage(systemName: "mappin", withConfiguration: config)?
            .withTintColor(.systemRed, renderingMode: .alwaysOriginal)

        return NMFOverlayImage(image: uiImage ?? UIImage.checkmark)
    }()
}
```

## 스크린샷
### 1개만 있을 때 (기본 줌 레벨 16)
https://github.com/user-attachments/assets/d48071d1-4c2b-4853-8820-c79726e46b69

- 줌 레벨 17, 18은 너무 확대당해서 어딘지 못알아보겠어서 16으로 조정했습니다 ㅎㅎ

### 비교적 가까이 모여있을 때
<img width="482" height="794" alt="image" src="https://github.com/user-attachments/assets/784f37fc-f63b-4295-96cf-0f880b90a767" />

### 멀리 떨어져 있을 때
<img width="477" height="788" alt="image" src="https://github.com/user-attachments/assets/3c23d93e-9d71-4c6d-bb99-9367fc51042d" />


## 리뷰 요구사항
- 폴라로이드 사진같은 느낌을 주고싶었습니다.. 느껴지나요?
- 유저 인터렉션 금지했다가, 마커가 너무 광범위하게 펼쳐져있거나 서로서로 붙어있거나 하면 확대를 하고싶어져서 다시 해제했습니다.
- 어떤 핀이 더 마음에 드시나요..?

<img width="375" alt="image" src="https://github.com/user-attachments/assets/d2692cc9-27fe-4e58-8808-f567f7cfcc1e" />

<img width="375" alt="image" src="https://github.com/user-attachments/assets/0b7907dc-26bf-4342-9ce7-77743a43ce7c" />

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 경로 기록 미니맵 추가 — 메시지 위치를 지도에 미니맵으로 표시
  * 타임라인 섹션 헤더에 인터랙티브 버튼 추가 — 섹션별 동작 트리거 가능

* **UI/스타일 개선**
  * 경로 기록 오버레이 재설계 — 정돈된 레이아웃, 그림자 및 경계 적용
  * 지도 마커 아이콘 및 스타일 개선 — 심볼 기반 마커 적용

* **코드 개선**
  * 안전한 배열 접근(subscript safe) 추가 — 범위 밖 접근 시 nil 반환

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->