### PR TITLE
일반 메시지 스택 클릭 시 타임라인 뷰 데이터 이슈

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -266,6 +266,7 @@ private extension MapView {
     var timeLineListView: some View {
         TimelineListView(
             store: TimelineListStore(
+                initialMessages: store.state.selectedNoPlaceMessages,
                 fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                     repository: MessageRepositoryImpl()
                 ),
@@ -274,6 +275,7 @@ private extension MapView {
             configuration: .bottomSheet
         )
     }
+
     var isTimelineListPresentedBinding: Binding<Bool> {
         Binding(
             get: { store.state.selectedNoPlaceMessages.isEmpty == false },

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -69,6 +69,11 @@ final class TimelineListStore: Store {
         switch intent {
         case .onAppear:
             return .init { continuation in
+                guard state.messages.isEmpty else {
+                    continuation.finish()
+                    return
+                }
+
                 Task {
                     do {
                         // TODO: 페이지네이션 구현


### PR DESCRIPTION
## 배경
- closed #323 

## 작업 요약
- [x] 이슈 원인 파악 및 해소

## 작업 내용
### 문제 원인 1: MapView에서 스택 뷰 메시지 내용 전달 안함

```swift
    var timeLineListView: some View {
        TimelineListView(
            store: TimelineListStore(
                **initialMessages: store.state.selectedNoPlaceMessages,**  // 해당 부분 추가해서 데이터 전달 이슈 해소
                fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                    repository: MessageRepositoryImpl()
                ),
                deleteMessagesUseCase: DeleteMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl())
            ),
            configuration: .bottomSheet
        )
    }
```

- `MapView.timeLineListView`가 `selectedNoPlaceMessages`를 Store에 전달하지 않았음

### 문제 원인 2: TimelineStore에서 onAppear 동작이 전체 데이터 fetch만 존재

```swift
        case .onAppear:
            return .init { continuation in
                // guard 문으로 초기 메시지가 있으면 데이터 fetch 진행하지 않음
                **guard state.messages.isEmpty else {
                    continuation.finish()
                    return
                }**

                Task {
                    do {
                        // TODO: 페이지네이션 구현
                        let messages = try await fetchRecentMessagesUseCase.execute(page: 0, pageSize: 10)
                        continuation.yield(.addMessages(messages))
                    } catch {
                        AppLog.debug(error.localizedDescription, category: .store)
                    }

                    continuation.finish()
                }
            }
```

- `TimelineListView`는 `.onAppear { send(.onAppear) }`에서 무조건 `fetchRecentMessagesUseCase.execute(...)`를 호출
- 결과적으로 “전체 메시지”가 출력됨
- guard 문으로 initialMessages가 있으면(=sheet 모드) fetch 스킵

## 스크린샷

https://github.com/user-attachments/assets/a555b612-3c4a-4ab3-aeae-f95fc89d50e7


## 리뷰 요구사항
- 스크린샷에서 일반 메시지 추가했는데 스택이 안합쳐지네요.. 스택 통합 기준 변경이 필요해 보입니다~

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **성능 개선**
  * 메시지 목록 로딩이 최적화되었습니다. 이미 로드된 메시지가 존재할 경우 불필요한 재요청을 방지하여 앱의 응답 속도가 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->