### PR TITLE
공간 화면 사용성 개선

### DIFF
--- a/Meomun/Meomun/Assets.xcassets/Color/mmFloatingBackground.colorset/Contents.json
+++ b/Meomun/Meomun/Assets.xcassets/Color/mmFloatingBackground.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.850",
+          "alpha" : "1.000",
           "blue" : "1.000",
           "green" : "1.000",
           "red" : "1.000"

--- a/Meomun/Meomun/Presentation/Common/Modifier/FloatingContainerModifier.swift
+++ b/Meomun/Meomun/Presentation/Common/Modifier/FloatingContainerModifier.swift
@@ -8,6 +8,14 @@
 import SwiftUI
 
 struct FloatingContainerModifier: ViewModifier {
+    private let color: Color
+    private let opacity: CGFloat
+
+    init(color: Color, opacity: CGFloat) {
+        self.color = color
+        self.opacity = opacity
+    }
+
     func body(content: Content) -> some View {
         content
             .frame(minHeight: 25)  // FloatingTabItem 내용물 기준 최소 높이
@@ -20,7 +28,7 @@ struct FloatingContainerModifier: ViewModifier {
                     bottomLeft: 10,
                     bottomRight: 10
                 )
-                .fill(Color.mmFloatingBackground)
+                .fill(color.opacity(opacity))
                 .shadow(
                     color: .black.opacity(0.12),
                     radius: 18,
@@ -34,7 +42,10 @@ struct FloatingContainerModifier: ViewModifier {
 }
 
 extension View {
-    func floatingContainer() -> some View {
-        modifier(FloatingContainerModifier())
+    func floatingContainer(
+        color: Color = Color.mmFloatingBackground,
+        opacity: CGFloat = 0.85
+    ) -> some View {
+        modifier(FloatingContainerModifier(color: color, opacity: opacity))
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -82,10 +82,7 @@ struct SpaceView: View {
             buttons: { $0.buttons }
         )
         .overlay(alignment: .bottom) {
-            if store.state.selectedMessageID != nil {
-                selectionBar
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
+            selectionBar
         }
         .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.selectedMessageID)
         .allowsHitTesting(store.state.deleteStatus == .idle)
@@ -126,24 +123,34 @@ private extension SpaceView {
 // MARK: Subviews
 
 extension SpaceView {
+    @ViewBuilder
     var selectionBar: some View {
-        HStack {
-            Button { send(.selectMessage(nil)) } label: {
-                Text("취소")
-                    .font(.headline)
-                    .foregroundStyle(Color.mmPrimary)
-                    .padding(.horizontal, 16)
-            }
+        Group {
+            if store.state.selectedMessageID != nil {
+                HStack {
+                    Button { send(.selectMessage(nil)) } label: {
+                        Text("취소")
+                            .font(.headline)
+                            .foregroundStyle(Color.mmPrimary)
+                            .padding(.horizontal, 16)
+                    }
 
-            Spacer()
+                    Spacer()
 
-            if let messageID = store.state.selectedMessageID {
-                Button { send(.requestDeleteMessage(messageID)) } label: {
-                    Text("삭제")
-                        .font(.headline)
-                        .foregroundStyle(Color.red)
-                        .padding(.horizontal, 24)
+                    if let messageID = store.state.selectedMessageID {
+                        Button { send(.requestDeleteMessage(messageID)) } label: {
+                            Text("삭제")
+                                .font(.headline)
+                                .foregroundStyle(Color.red)
+                                .padding(.horizontal, 24)
+                        }
+                    }
                 }
+            } else {
+                Text("\(store.state.messages.count)개의 추억이 떠다니고 있어요")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Color.mmPrimary)
+                    .frame(maxWidth: .infinity)
             }
         }
         .floatingContainer()

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -156,7 +156,7 @@ extension SpaceView {
                     .frame(maxWidth: .infinity)
             }
         }
-        .floatingContainer()
+        .floatingContainer(color: Color.mmBackground, opacity: 0.8)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -45,6 +45,9 @@ struct SpaceView: View {
                     .onEnded { _ in spaceController.endDrag()}
             )
             .gesture(
+                TapGesture().onEnded { send(.selectMessage(nil)) }
+            )
+            .highPriorityGesture(
                 SpatialTapGesture()
                     .targetedToAnyEntity()
                     .onEnded { value in


### PR DESCRIPTION
## 배경
- closed #352

## 작업 요약
- 하단 바에 메시지 개수를 표시합니다.

## 작업 내용
- 하단바에 현재 공간의 메시지 개수를 표시합니다.
- 메시지 탭 시 삭제/취소 버튼이 표시되도록 전환됩니다.

## 스크린샷


https://github.com/user-attachments/assets/a15c759c-529b-4e4f-be5a-d5d28269cb8b


## 리뷰 요구사항


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 부동 컨테이너의 색상과 불투명도를 커스터마이징할 수 있도록 변경했습니다.
  * 메시지 선택 시 사용자 인터페이스의 반응성을 개선했습니다.

* **스타일**
  * 부동 배경 요소의 불투명도를 조정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->