### PR TITLE
공간 화면에 시간에 따른 분기 적용

### DIFF
--- a/Meomun/Meomun/Domain/Entity/DomeEnvironment/DayPart.swift
+++ b/Meomun/Meomun/Domain/Entity/DomeEnvironment/DayPart.swift
@@ -5,6 +5,8 @@
 //  Created by MinwooJe on 1/8/26.
 //
 
+import Foundation
+
 enum DayPart {
     /// 0-5 시
     case dawn
@@ -23,4 +25,42 @@ enum DayPart {
 
     /// 21-24 시
     case night
+}
+
+extension DayPart {
+    /// Date → hour 추출 후 from(hour:)를 사용해 DayPart를 계산합니다.
+    static func current(date: Date = Date(), calendar: Calendar = .current) -> DayPart {
+        let hour = calendar.component(.hour, from: date) // 0...23
+        return from(hour: hour)
+    }
+
+    /// 현재 시각(Date)을 기준으로 DayPart를 계산합니다.
+    ///
+    /// 경계는 다음과 같이 "앞은 포함, 뒤는 미포함"(half-open)으로 처리합니다.
+    /// - dawn:     [0, 5)
+    /// - daybreak: [5, 7)
+    /// - morning:  [7, 12)
+    /// - afternoon:[12, 17)
+    /// - evening:  [17, 21)
+    /// - night:    [21, 24)
+    private static func from(hour: Int) -> DayPart {
+        switch hour {
+        case 0..<5:
+            return .dawn
+        case 5..<7:
+            return .daybreak
+        case 7..<12:
+            return .morning
+        case 12..<17:
+            return .afternoon
+        case 17..<21:
+            return .evening
+        case 21..<24:
+            return .night
+        default:
+            // 도메인 안전장치: hour는 원칙적으로 0...23 이어야 함
+            assertionFailure("Invalid hour: \(hour). Expected 0...23.")
+            return .night
+        }
+    }
 }

--- a/Meomun/Meomun/Domain/Entity/DomeEnvironment/DomeEnvironment.swift
+++ b/Meomun/Meomun/Domain/Entity/DomeEnvironment/DomeEnvironment.swift
@@ -5,6 +5,6 @@
 //  Created by MinwooJe on 1/8/26.
 //
 
-struct DomeEnvironment {
+struct DomeEnvironment: Equatable {
     let dayPart: DayPart
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -222,7 +222,6 @@ private extension MapView {
                 ),
                 place: place
             ),
-            domeEnvironment: .init(dayPart: .current()),
             place: place,
             onNavigate: { coordinate, place in
                 onNavigate(coordinate, place)

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -222,7 +222,7 @@ private extension MapView {
                 ),
                 place: place
             ),
-            domeEnvironment: .init(dayPart: .afternoon),
+            domeEnvironment: .init(dayPart: .current()),
             place: place,
             onNavigate: { coordinate, place in
                 onNavigate(coordinate, place)

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -56,16 +56,30 @@ final class SpaceController {
                 AppLog.debug("S3. Dome loaded", category: .space)
                 let domeEntity = try await Entity(named: "Dome.usdz")
                 domeEntity.name = "Dome"
-                root.addChild(domeEntity)
                 self.domeEntity = domeEntity
 
+                // 머테리얼 세팅
+                if let domeEnvironment = domeEnvironment {
+                    AppLog.debug("S4. Materials configured", category: .space)
+                    materialConfigurator.configureDome(
+                        domeEntity: domeEntity,
+                        dayPart: domeEnvironment.dayPart
+                    )
+
+                    materialConfigurator.configureGround(
+                        domeEntity: domeEntity,
+                        dayPart: domeEnvironment.dayPart
+                    )
+                }
+
+                root.addChild(domeEntity)
+
                 // Message template 로드
-                AppLog.debug("S4. Message template loaded", category: .space)
+                AppLog.debug("S5. Message template loaded", category: .space)
                 let messageEntity = try await Entity(named: "Message.usdz")
                 messageEntity.name = "MessageBubble"
                 messageBubbleTemplateEntity = messageEntity
                 trySyncIfPossible()
-
             } catch {
                 AppLog.error(
                     "Failed to configure Space scene",
@@ -92,8 +106,8 @@ extension SpaceController {
 
         guard let domeEntity else { return }
 
-        // 머테리얼 세팅
-        AppLog.debug("S5. Materials configured", category: .space)
+        // 머테리얼 업데이트
+        AppLog.debug("Dome Materials updated", category: .space)
         materialConfigurator.configureDome(
             domeEntity: domeEntity,
             dayPart: domeEnvironment.dayPart

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -10,11 +10,13 @@ import SwiftUI
 
 @MainActor
 final class SpaceController {
-    private var domeEnvironment: DomeEnvironment
+    private var domeEnvironment: DomeEnvironment?
     private var rotationCamera: RotationCamera
 
     private var spaceRootEntity: Entity?
     private var messageBubbleTemplateEntity: Entity?
+    private var domeEntity: Entity?
+
     private var syncTask: Task<Void, Never>?
     private var pendingMessages: [Message] = []
 
@@ -22,13 +24,11 @@ final class SpaceController {
     private let materialConfigurator: SpaceMaterialConfigurator
 
     init(
-        domeEnvironment: DomeEnvironment,
         rotationCamera: RotationCamera = .init(
             position: .init(x: 0, y: 0.7, z: 0),
             rotateSensitivity: 0.003
         )
     ) {
-        self.domeEnvironment = domeEnvironment
         self.rotationCamera = rotationCamera
         self.bubbleSynchronizer = SpaceMessageBubbleSynchronizer()
         self.materialConfigurator = SpaceMaterialConfigurator()
@@ -57,6 +57,7 @@ final class SpaceController {
                 let domeEntity = try await Entity(named: "Dome.usdz")
                 domeEntity.name = "Dome"
                 root.addChild(domeEntity)
+                self.domeEntity = domeEntity
 
                 // Message template 로드
                 AppLog.debug("S4. Message template loaded", category: .space)
@@ -65,16 +66,6 @@ final class SpaceController {
                 messageBubbleTemplateEntity = messageEntity
                 trySyncIfPossible()
 
-                // 머테리얼 세팅
-                AppLog.debug("S5. Materials configured", category: .space)
-                materialConfigurator.configureDome(
-                    domeEntity: domeEntity,
-                    dayPart: domeEnvironment.dayPart
-                )
-                materialConfigurator.configureGround(
-                    domeEntity: domeEntity,
-                    dayPart: domeEnvironment.dayPart
-                )
             } catch {
                 AppLog.error(
                     "Failed to configure Space scene",
@@ -87,12 +78,31 @@ final class SpaceController {
 }
 
 // MARK: - Message Sync
+
 extension SpaceController {
     func sync(messages: [Message]) {
         AppLog.debug("SpaceController sync: \(messages.count)", category: .space)
 
         pendingMessages = messages
         trySyncIfPossible()
+    }
+
+    func update(domeEnvironment: DomeEnvironment) {
+        self.domeEnvironment = domeEnvironment
+
+        guard let domeEntity else { return }
+
+        // 머테리얼 세팅
+        AppLog.debug("S5. Materials configured", category: .space)
+        materialConfigurator.configureDome(
+            domeEntity: domeEntity,
+            dayPart: domeEnvironment.dayPart
+        )
+
+        materialConfigurator.configureGround(
+            domeEntity: domeEntity,
+            dayPart: domeEnvironment.dayPart
+        )
     }
 
     private func trySyncIfPossible() {
@@ -121,6 +131,7 @@ extension SpaceController {
 }
 
 // MARK: - Camera Input
+
 extension SpaceController {
     func handleDrag(_ translation: CGSize) {
         rotationCamera.handleDrag(

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
@@ -17,6 +17,7 @@ final class SpaceStore: Store {
     enum Action {
         case setLoading(Bool)
         case setMessages([Message])
+        case setDomeEnvironment(DomeEnvironment)
         case setError(String)
         case setUserLocation(Coordinate)
         case setCurrentPlaceID(PlaceID)
@@ -27,6 +28,7 @@ final class SpaceStore: Store {
         var isLoading: Bool = false
         var errorMessage: String = ""
         var messages: [Message] = []
+        var domeEnvironment: DomeEnvironment?
         var userLocation: Coordinate?           // TODO: - 지도 > 공간 진입 시점 좌표 넘겨주고, 옵셔널 지우기
         var currentPlaceID: PlaceID?
         var toastMessage: String?
@@ -54,6 +56,7 @@ final class SpaceStore: Store {
             switch intent {
             case .onAppear(let placeID):
                 continuation.yield(.setCurrentPlaceID(placeID))
+                continuation.yield(.setDomeEnvironment(.init(dayPart: .current())))
                 fetchMessages(for: placeID, continuation: continuation)
 
             case .setToast(let message):
@@ -72,6 +75,9 @@ final class SpaceStore: Store {
 
         case .setMessages(let messages):
             newState.messages = messages
+
+        case .setDomeEnvironment(let environment):
+            newState.domeEnvironment = environment
 
         case .setError(let message):
             newState.errorMessage = message

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -20,13 +20,12 @@ struct SpaceView: View {
 
     init(
         store: SpaceStore,
-        domeEnvironment: DomeEnvironment,
         place: Place,
         onNavigate: @escaping (Coordinate, Place) -> Void
     ) {
         _store = StateObject(wrappedValue: store)
         _spaceController = State(
-            wrappedValue: SpaceController(domeEnvironment: domeEnvironment)
+            wrappedValue: SpaceController()
         )
         self.place = place
         self.onNavigate = onNavigate
@@ -68,6 +67,10 @@ struct SpaceView: View {
         }
         .onChange(of: store.state.messages.map(\.id)) {
             spaceController.sync(messages: store.state.messages)
+        }
+        .onChange(of: store.state.domeEnvironment) { _, newValue in
+            guard let newValue else { return }
+            spaceController.update(domeEnvironment: newValue)
         }
     }
 }
@@ -128,7 +131,6 @@ private extension SpaceView {
                     coordinate: .init(latitude: 0, longitude: 0)
                 )
             ),
-            domeEnvironment: .init(dayPart: .afternoon),
             place: .init(
                 id: .init(value: .init()),
                 name: "광화문",


### PR DESCRIPTION
## 배경

- closed #306 

## 작업 요약

- [x] 시간에 따른 돔 배경 변경

## 작업 내용

### 공간 화면 시간대(DayPart) 기반 배경 처리

배경

공간 화면(SpaceView)은 단순히 메시지를 나열하는 화면이 아니라, **사용자가 머무는 시간대의 분위기와 맥락을 시각적으로 전달하는 공간**을 목표로 합니다.

기존에는 공간 화면의 돔 배경 및 머티리얼이 **항상 동일한 상태**로 렌더링되어, 아침·오후·저녁 등 시간 흐름에 따른 공간 감각을 표현할 수 없었습니다.

이에 따라 “현재 시간대”를 의미 단위로 추상화하고, 이를 공간 연출의 입력 값으로 사용하는 구조가 필요하다고 판단하였습니다.

기존 문제

- 공간 화면의 배경/머티리얼이 시간과 무관하게 고정됨
- “언제 머물렀는지”에 대한 감각적 단서 부족
- 시간 계산 로직이 UI 또는 화면 전환 로직에 섞일 가능성
- 추후 시간 정책 확장(저녁/밤/새벽 분위기 차이)에 대응하기 어려운 구조

개선 방향

- **시간을 직접 사용하지 않고, 의미 단위(DayPart)로 추상화**
- DayPart를 기반으로 공간 환경(DomeEnvironment)을 정의
- DomeEnvironment를 MVI State로 관리하여,
    - View는 상태를 관찰하고
    - 실제 렌더링은 Controller/Renderer가 담당하도록 역할 분리
- 시간 → 환경 결정 로직과 렌더링 로직을 명확히 분리

구현

1) Domain에 시간대 개념(DayPart) 정의

시간을 단순 숫자(hour)가 아닌 **의미 단위**로 표현하기 위해 `DayPart`를 도메인 모델로 도입하였습니다.

```swift
enum DayPart {
    case dawn// 0-5
    case daybreak// 5-7
    case morning// 7-12
    case afternoon// 12-17
    case evening// 17-21
    case night// 21-24
}
```

또한 시간 계산 정책은 Domain 내부에만 위치하도록 하여, UI 레이어에서 시간 계산 로직이 퍼지지 않도록 하였습니다.

```swift
extension DayPart {
    static func current(date: Date = Date(), calendar: Calendar = .current) -> DayPart {
        let hour = calendar.component(.hour, from: date)
        return from(hour: hour)
    }

    private static func from(hour: Int) -> DayPart {
        switch hour {
            case0..<5: return .dawn
            case5..<7: return .daybreak
            case7..<12: return .morning
            case12..<17: return .afternoon
            case17..<21: return .evening
            default: return .night
        }
    }
}
```

2) DomeEnvironment를 SpaceStore(State)에서 관리

기존에는 공간 화면 전환 시점(MapView)에서 환경 값을 만들어 전달하고 있었으나, 이는 “지도 화면이 공간 연출 책임을 일부 갖는 구조”로 이어질 수 있었습니다.

이를 개선하기 위해:

- DomeEnvironment를 `SpaceStore.State`의 일부로 편입
- 공간 화면의 환경 결정 책임을 **Space Feature 내부로 이동**

```swift
struct State {
    var messages: [Message] = []
    var domeEnvironment: DomeEnvironment?
}
```

공간 화면 진입 시(`onAppear`) 현재 시간 기준으로 환경을 결정하여 State에 반영합니다.

```swift
case .onAppear:
    continuation.yield(
        .setDomeEnvironment(.init(dayPart: .current()))
    )
```

3) View는 상태를 관찰하고, Controller에 반영만 수행

`SpaceView`는 더 이상 DomeEnvironment를 외부에서 주입받지 않고, **Store의 State 변화를 관찰하여 SpaceController에 전달**하는 역할만 수행합니다.

```swift
.onChange(of: store.state.domeEnvironment) {_, newValue in
    guard let newValue else { return }
    spaceController.update(domeEnvironment: newValue)
}
```

이를 통해 View는 상태 관찰 및 전달이라는 명확한 역할을 갖게 되었습니다.

4) SpaceController에서 머티리얼 재적용 방식으로 반영

RealityKit 씬은 최초 구성 이후 재생성이 비용이 크기 때문에, 환경 변경 시 **씬 전체를 다시 만들지 않고 머티리얼만 갱신**하도록 설계하였습니다.

```swift
func update(domeEnvironment: DomeEnvironment) {
    self.domeEnvironment = domeEnvironment
    
    guard let domeEntity else { return }
		
    materialConfigurator.configureDome(
        domeEntity: domeEntity,
        dayPart: domeEnvironment.dayPart
    )
    materialConfigurator.configureGround(
        domeEntity: domeEntity,
        dayPart: domeEnvironment.dayPart
    )
}
```

결과

- 공간 화면의 돔 배경이 **시간대(DayPart)에 따라 동적으로 변경**될 수 있는 구조 확보
- 시간 계산 / 환경 결정 / 렌더링 책임이 명확히 분리됨
- MVI 구조에서
    - Store는 “환경 상태 관리”
    - View는 “상태 반영”
    - Controller는 “렌더링 처리”        
    역할이 자연스럽게 정렬됨

## 스크린샷

https://github.com/user-attachments/assets/daa2fd6d-3913-4081-9c72-0b3b03eb2067

## 리뷰 요구사항

작업을 하고나니 이전에 있었던 아래 탭바 부분에 버벅이는 현상도 비교적 없어진 것 같습니다.
사용자가 공간 화면에 오래 머물러 시간대가 달라져 공간 화면에 변화를 줘야 하는 부분은 이번 내용에 포함되지 않았습니다.
현재 공간 화면 배경을 업데이트 하는 로직은 구현되었기 때문에 시간에 따라 주기적으로 이 메서드를 호출하여 해결해 볼 수 있을 것 같습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 돔 환경(낮/밤/조명)을 런타임에 동적으로 적용할 수 있도록 Space 컨트롤러가 업데이트를 수신합니다.

* **개선 사항**
  * 시간 기반 DayPart 계산 로직이 추가·개선되어 시각 표현이 더 정교해졌습니다.
  * 환경 상태가 스토어에서 관리되어 뷰와 컨트롤러 간 동기화가 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->