### PR TITLE
MapStoreTests 테스트 코드 수정

### DIFF
--- a/.github/workflows/build_test_on_develop.yml
+++ b/.github/workflows/build_test_on_develop.yml
@@ -4,7 +4,7 @@ name: Build and Test
 on:
   # develop 브랜치에 push 나 pull request 이벤트가 일어났을때 해당 workflow를 트리거
   push:
-    branches: [ develop ]
+    branches: [ test/MapStoreTests-fix ]
   pull_request:
     branches: [ develop ]
 
@@ -69,7 +69,22 @@ jobs:
 
         xcodebuild clean build -"$filetype_parameter" "$file_to_build" -scheme "$SCHEME_NAME" -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -skipPackagePluginValidation -skipMacroValidation
     
-#    - name: Run tests 🧪
-#      run: |
-#        cd "$PROJECT_DIR"
-#        xcodebuild test -project "$SCHEME_NAME.xcodeproj" -scheme "$SCHEME_NAME" -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -skipPackagePluginValidation -skipMacroValidation
+    - name: Run tests 🧪
+      run: |
+        cd "$PROJECT_DIR"
+
+        # .xcworkspace 또는 .xcodeproj 파일 찾기
+        if [ -d *.xcworkspace ] 2>/dev/null; then
+          filetype_parameter="workspace"
+          file_to_build=$(ls -d *.xcworkspace | head -1)
+        elif [ -d *.xcodeproj ] 2>/dev/null; then
+          filetype_parameter="project"
+          file_to_build=$(ls -d *.xcodeproj | head -1)
+        else
+          echo "❌ No .xcworkspace or .xcodeproj found"
+          exit 1
+        fi
+
+        echo "Running tests on $file_to_build..."
+
+        xcodebuild test -"$filetype_parameter" "$file_to_build" -scheme "$SCHEME_NAME" -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -skipPackagePluginValidation -skipMacroValidation

--- a/.github/workflows/build_test_on_develop.yml
+++ b/.github/workflows/build_test_on_develop.yml
@@ -53,11 +53,11 @@ jobs:
         # 프로젝트 디렉토리로 이동
         cd "$PROJECT_DIR"
         
-        # .xcworkspace 또는 .xcodeproj 파일 찾기
-        if [ -d *.xcworkspace ] 2>/dev/null; then
+        # .xcworkspace 또는 .xcodeproj 파일 찾기 (글롭 확장 안전성 개선)
+        if compgen -G "*.xcworkspace" > /dev/null 2>&1; then
           filetype_parameter="workspace"
           file_to_build=$(ls -d *.xcworkspace | head -1)
-        elif [ -d *.xcodeproj ] 2>/dev/null; then
+        elif compgen -G "*.xcodeproj" > /dev/null 2>&1; then
           filetype_parameter="project"
           file_to_build=$(ls -d *.xcodeproj | head -1)
         else
@@ -73,11 +73,11 @@ jobs:
       run: |
         cd "$PROJECT_DIR"
 
-        # .xcworkspace 또는 .xcodeproj 파일 찾기
-        if [ -d *.xcworkspace ] 2>/dev/null; then
+        # .xcworkspace 또는 .xcodeproj 파일 찾기 (글롭 확장 안전성 개선)
+        if compgen -G "*.xcworkspace" > /dev/null 2>&1; then
           filetype_parameter="workspace"
           file_to_build=$(ls -d *.xcworkspace | head -1)
-        elif [ -d *.xcodeproj ] 2>/dev/null; then
+        elif compgen -G "*.xcodeproj" > /dev/null 2>&1; then
           filetype_parameter="project"
           file_to_build=$(ls -d *.xcodeproj | head -1)
         else

--- a/.github/workflows/build_test_on_develop.yml
+++ b/.github/workflows/build_test_on_develop.yml
@@ -4,7 +4,7 @@ name: Build and Test
 on:
   # develop 브랜치에 push 나 pull request 이벤트가 일어났을때 해당 workflow를 트리거
   push:
-    branches: [ test/MapStoreTests-fix ]
+    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/Meomun/Meomun.xcodeproj/xcshareddata/xcschemes/Meomun.xcscheme
+++ b/Meomun/Meomun.xcodeproj/xcshareddata/xcschemes/Meomun.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AC82E3752F1EAEFB0028A081"
+               BuildableName = "MeomunTests.xctest"
+               BlueprintName = "MeomunTests"
+               ReferencedContainer = "container:Meomun.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Meomun/Meomun/App/NetworkMonitor.swift
+++ b/Meomun/Meomun/App/NetworkMonitor.swift
@@ -8,7 +8,11 @@
 import Foundation
 import Network
 
-final class NetworkMonitor {
+protocol NetworkMonitoring {
+    func checkConnection() -> Bool
+}
+
+final class NetworkMonitor: NetworkMonitoring {
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "NetworkMonitor")
     private var isConnected: Bool = false

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -85,11 +85,11 @@ final class MapStore: Store {
 
     private var getNearbyMessageTask: Task<Void, Never>?
     private let getNearbyMessagesUseCase: GetNearbyMessagesUseCase
-    private let networkMonitor: NetworkMonitor
+    private let networkMonitor: NetworkMonitoring
 
     init(
         getNearbyMessagesUseCase: GetNearbyMessagesUseCase,
-        networkMonitor: NetworkMonitor
+        networkMonitor: NetworkMonitoring
     ) {
         self.state = State()
         self.getNearbyMessagesUseCase = getNearbyMessagesUseCase

--- a/Meomun/MeomunTests/MapTests/Doubles/SpyGetNearbyMessagesUseCase.swift
+++ b/Meomun/MeomunTests/MapTests/Doubles/SpyGetNearbyMessagesUseCase.swift
@@ -22,7 +22,7 @@ final class SpyGetNearbyMessagesUseCase: GetNearbyMessagesUseCase {
         self.stubbedMessages = stubbedMessages
     }
 
-    func execute(location: Coordinate, limit: Int?) async throws -> [Message] {
+    func execute(at location: Coordinate, bounds: BoundingBox, limit: Int?) async throws -> [Message] {
         calledLocations.append(location)
         return stubbedMessages
     }

--- a/Meomun/MeomunTests/MapTests/Doubles/StubGetNearbyMessagesUseCase.swift
+++ b/Meomun/MeomunTests/MapTests/Doubles/StubGetNearbyMessagesUseCase.swift
@@ -31,7 +31,7 @@ final class StubGetNearbyMessagesUseCase: GetNearbyMessagesUseCase {
 
     // MARK: - GetNearbyMessagesUseCase
 
-    func execute(location: Coordinate, limit: Int?) async throws -> [Message] {
+    func execute(at location: Meomun.Coordinate, bounds: Meomun.BoundingBox, limit: Int?) async throws -> [Meomun.Message] {
         if stubbedDelay > 0 {
             try await Task.sleep(nanoseconds: stubbedDelay)
         }

--- a/Meomun/MeomunTests/MapTests/Doubles/StubNetworkMonitor.swift
+++ b/Meomun/MeomunTests/MapTests/Doubles/StubNetworkMonitor.swift
@@ -1,0 +1,20 @@
+//
+//  StubNetworkMonitor.swift
+//  Meomun
+//
+//  Created by MinwooJe on 1/30/26.
+//
+
+@testable import Meomun
+
+final class StubNetworkMonitor: NetworkMonitoring {
+    let isConnected: Bool
+
+    init(isConnected: Bool = true) {
+        self.isConnected = isConnected
+    }
+
+    func checkConnection() -> Bool {
+        return isConnected
+    }
+}

--- a/Meomun/MeomunTests/MapTests/Factory/DummyMessageFactory.swift
+++ b/Meomun/MeomunTests/MapTests/Factory/DummyMessageFactory.swift
@@ -31,18 +31,18 @@ enum DummyMessageFactory {
     /// 단일 메시지 생성
     static func makeMessage(
         id: UUID = UUID(),
-        authorID: UUID = UUID(),
         content: String = "테스트 메시지",
         coordinate: Coordinate,
         placeTag: Place? = nil,
+        address: String = "주소",
         createdAt: Date = Date()
     ) -> Message {
         Message(
             id: MessageID(value: id),
-            authorID: UserID(value: authorID),
             createdAt: createdAt,
             content: content,
             coordinate: coordinate,
+            address: address,
             placeTag: placeTag
         )
     }

--- a/Meomun/MeomunTests/MapTests/MapStoreTests.swift
+++ b/Meomun/MeomunTests/MapTests/MapStoreTests.swift
@@ -12,7 +12,7 @@ import Foundation
 
 // MARK: - MapStoreTests
 
-@Suite("MapStore 테스트")
+@Suite("MapStore 테스트: 카메라 위치 기준으로 메시지 불러오기")
 struct MapStoreTests {
 
     // MARK: - Scenario 1: 앱 실행 후 지도 화면 진입
@@ -21,31 +21,14 @@ struct MapStoreTests {
     struct OnAppearTests {
         let stubbedCoordinate = DummyMessageFactory.seoulCityHallCoordinate
 
-        @Test("지도 화면 진입 시 해당 좌표 근처의 메시지를 정상적으로 받아오는지")
-        func fetchMessagesOnAppear() async throws {
-            // Arrange
-            let expectedResult = DummyMessageFactory.makeMessages(count: 5, at: stubbedCoordinate)
-            let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
-            let initialLocation = DummyMessageFactory.seoulCityHallCoordinate
-
-            // Act
-            await sut.send(intent: .onAppear(initialLocation))
-
-            // Assert
-            let actualResult = sut.state.messages
-
-            #expect(actualResult.map { $0.id } == expectedResult.map { $0.id } )
-        }
-
         @Test("지도 화면 진입 시 카메라 좌표가 사용자의 현재 위치로 정상적으로 설정 되는지")
         func setCameraCoordinateOnAppear() async throws {
             // Arrange
             let expectedCoordinate = stubbedCoordinate
             let expectedResult = expectedCoordinate
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: [])
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
 
             // Act
             await sut.send(intent: .onAppear(expectedCoordinate))
@@ -54,27 +37,6 @@ struct MapStoreTests {
             let actualResult = sut.state.cameraCoordinate
 
             #expect(actualResult == expectedResult)
-        }
-
-        @Test("근처 메시지 전체 fetch 실패 시 에러 메시지가 정상적으로 설정되는지")
-        func setErrorMessageOnFetchFailure() async throws {
-            // Arrange
-            let expectedError = DummyMessageFactory.makeNetworkError()
-            let expectedResult = expectedError.localizedDescription
-            let stubUseCase = StubGetNearbyMessagesUseCase(
-                stubbedMessages: [],
-                stubbedError: expectedError
-            )
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
-
-            // Act
-            await sut.send(intent: .onAppear(DummyMessageFactory.seoulCityHallCoordinate))
-
-            // Assert
-            let actualResult = sut.state.errorMessage
-
-            #expect(actualResult == expectedResult)
-            #expect(sut.state.messages.isEmpty)
         }
     }
 
@@ -90,11 +52,14 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = DummyMessageFactory.makeMessages(count: 3, at: stubbedCoordinate)
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
             let newCameraPosition = stubbedCoordinate
 
             // Act
-            await sut.send(intent: .cameraDidIdle(newCameraPosition))
+            await sut.send(intent: .cameraDidIdle(newCameraPosition, stubBoundingBox, stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.messages
@@ -107,11 +72,14 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = testCoordinate
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: [])
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
             let movedCoordinate = testCoordinate
 
             // Act
-            await sut.send(intent: .cameraDidIdle(movedCoordinate))
+            await sut.send(intent: .cameraDidIdle(movedCoordinate, stubBoundingBox, stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.cameraCoordinate
@@ -124,7 +92,10 @@ struct MapStoreTests {
             // Arrange
             let expectedCallCount = 1
             let spyUseCase = SpyGetNearbyMessagesUseCase(stubbedMessages: [])
-            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
+            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase, networkMonitor: stubNetworkMonitor)
 
             let firstLocation = stubbedCoordinate
             let secondLocation = DummyMessageFactory.gangnamStationCoordinate
@@ -132,11 +103,11 @@ struct MapStoreTests {
 
             // Act - 100ms 간격으로 3번 드래그 (debounce 300ms 내)
             // 실제 View에서는 send를 await하지 않고 fire-and-forget으로 호출
-            Task { await sut.send(intent: .cameraDidIdle(firstLocation)) }
+            Task { await sut.send(intent: .cameraDidIdle(firstLocation, stubBoundingBox, stubMapCameraSnapshot)) }
             try await Task.sleep(nanoseconds: 100_000_000)
-            Task { await sut.send(intent: .cameraDidIdle(secondLocation)) }
+            Task { await sut.send(intent: .cameraDidIdle(secondLocation, stubBoundingBox, stubMapCameraSnapshot)) }
             try await Task.sleep(nanoseconds: 100_000_000)
-            Task { await sut.send(intent: .cameraDidIdle(thirdLocation)) }
+            Task { await sut.send(intent: .cameraDidIdle(thirdLocation, stubBoundingBox, stubMapCameraSnapshot)) }
 
             // debounce 완료 대기 (300ms + 여유)
             try await Task.sleep(nanoseconds: 500_000_000)
@@ -160,11 +131,14 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = DummyMessageFactory.makeMessages(count: 2, at: stubbedCoordinate)
             let spyUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
+            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase, networkMonitor: stubNetworkMonitor)
             let movedCoordinate = stubbedCoordinate
 
             // Act
-            await sut.send(intent: .cameraChangedByLocation(movedCoordinate))
+            await sut.send(intent: .cameraChangedByLocation(movedCoordinate, stubBoundingBox, stubMapCameraSnapshot))
             let actualResult = sut.state.messages
 
             // Assert
@@ -176,10 +150,13 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = stubbedCoordinate
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: [])
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
 
             // Act
-            await sut.send(intent: .cameraDidIdle(expectedResult))
+            await sut.send(intent: .cameraDidIdle(expectedResult, stubBoundingBox, stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.cameraCoordinate
@@ -199,14 +176,18 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = DummyMessageFactory.makeMessages(count: 4, at: stubbedCoordinate)
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase)
+            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
             let movedCoordinate = stubbedCoordinate
 
             // Act
-            await sut.send(intent: .cameraChangedByLocation(movedCoordinate))
+            await sut.send(intent: .cameraChangedByLocation(movedCoordinate, stubBoundingBox, stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.messages
+
 
             #expect(actualResult.map { $0.id } == expectedResult.map { $0.id })
         }

--- a/Meomun/MeomunTests/MapTests/MapStoreTests.swift
+++ b/Meomun/MeomunTests/MapTests/MapStoreTests.swift
@@ -15,6 +15,11 @@ import Foundation
 @Suite("MapStore 테스트: 카메라 위치 기준으로 메시지 불러오기")
 struct MapStoreTests {
 
+    /// 동일 설정으로 모든 테스트에서 공유하는 TestDouble
+    private static let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
+    private static let stubBoundingBox = BoundingBox(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
+    private static let stubMapCameraSnapshot = MapCameraSnapshot(coordinate: .init(latitude: 0, longitude: 0))
+
     // MARK: - Scenario 1: 앱 실행 후 지도 화면 진입
 
     @Suite("시나리오 1: 지도 화면 진입 시 메시지 표시")
@@ -27,8 +32,7 @@ struct MapStoreTests {
             let expectedCoordinate = stubbedCoordinate
             let expectedResult = expectedCoordinate
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: [])
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
 
             // Act
             await sut.send(intent: .onAppear(expectedCoordinate))
@@ -52,14 +56,11 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = DummyMessageFactory.makeMessages(count: 3, at: stubbedCoordinate)
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
-            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
             let newCameraPosition = stubbedCoordinate
 
             // Act
-            await sut.send(intent: .cameraDidIdle(newCameraPosition, stubBoundingBox, stubMapCameraSnapshot))
+            await sut.send(intent: .cameraDidIdle(newCameraPosition, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.messages
@@ -72,14 +73,11 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = testCoordinate
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: [])
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
-            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
             let movedCoordinate = testCoordinate
 
             // Act
-            await sut.send(intent: .cameraDidIdle(movedCoordinate, stubBoundingBox, stubMapCameraSnapshot))
+            await sut.send(intent: .cameraDidIdle(movedCoordinate, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.cameraCoordinate
@@ -92,10 +90,7 @@ struct MapStoreTests {
             // Arrange
             let expectedCallCount = 1
             let spyUseCase = SpyGetNearbyMessagesUseCase(stubbedMessages: [])
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
-            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
-            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
 
             let firstLocation = stubbedCoordinate
             let secondLocation = DummyMessageFactory.gangnamStationCoordinate
@@ -103,11 +98,11 @@ struct MapStoreTests {
 
             // Act - 100ms 간격으로 3번 드래그 (debounce 300ms 내)
             // 실제 View에서는 send를 await하지 않고 fire-and-forget으로 호출
-            Task { await sut.send(intent: .cameraDidIdle(firstLocation, stubBoundingBox, stubMapCameraSnapshot)) }
+            Task { await sut.send(intent: .cameraDidIdle(firstLocation, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot)) }
             try await Task.sleep(nanoseconds: 100_000_000)
-            Task { await sut.send(intent: .cameraDidIdle(secondLocation, stubBoundingBox, stubMapCameraSnapshot)) }
+            Task { await sut.send(intent: .cameraDidIdle(secondLocation, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot)) }
             try await Task.sleep(nanoseconds: 100_000_000)
-            Task { await sut.send(intent: .cameraDidIdle(thirdLocation, stubBoundingBox, stubMapCameraSnapshot)) }
+            Task { await sut.send(intent: .cameraDidIdle(thirdLocation, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot)) }
 
             // debounce 완료 대기 (300ms + 여유)
             try await Task.sleep(nanoseconds: 500_000_000)
@@ -131,14 +126,11 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = DummyMessageFactory.makeMessages(count: 2, at: stubbedCoordinate)
             let spyUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
-            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
-            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: spyUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
             let movedCoordinate = stubbedCoordinate
 
             // Act
-            await sut.send(intent: .cameraChangedByLocation(movedCoordinate, stubBoundingBox, stubMapCameraSnapshot))
+            await sut.send(intent: .cameraChangedByLocation(movedCoordinate, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot))
             let actualResult = sut.state.messages
 
             // Assert
@@ -150,13 +142,10 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = stubbedCoordinate
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: [])
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
-            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
 
             // Act
-            await sut.send(intent: .cameraDidIdle(expectedResult, stubBoundingBox, stubMapCameraSnapshot))
+            await sut.send(intent: .cameraDidIdle(expectedResult, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.cameraCoordinate
@@ -176,14 +165,11 @@ struct MapStoreTests {
             // Arrange
             let expectedResult = DummyMessageFactory.makeMessages(count: 4, at: stubbedCoordinate)
             let stubUseCase = StubGetNearbyMessagesUseCase(stubbedMessages: expectedResult)
-            let stubNetworkMonitor: NetworkMonitoring = StubNetworkMonitor()
-            let stubBoundingBox: BoundingBox = .init(minLatitude: 0, maxLatitude: 0, minLongitude: 0, maxLongitude: 0)
-            let stubMapCameraSnapshot: MapCameraSnapshot = .init(coordinate: .init(latitude: 0, longitude: 0))
-            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: stubNetworkMonitor)
+            let sut = MapStore(getNearbyMessagesUseCase: stubUseCase, networkMonitor: MapStoreTests.stubNetworkMonitor)
             let movedCoordinate = stubbedCoordinate
 
             // Act
-            await sut.send(intent: .cameraChangedByLocation(movedCoordinate, stubBoundingBox, stubMapCameraSnapshot))
+            await sut.send(intent: .cameraChangedByLocation(movedCoordinate, MapStoreTests.stubBoundingBox, MapStoreTests.stubMapCameraSnapshot))
 
             // Assert
             let actualResult = sut.state.messages


### PR DESCRIPTION
## 배경
- 프로덕션 코드 수정에 따른 테스트 코드 수정

## 작업 요약
- `MapStore` 메서드 시그니처 변경, 의존성 추가에 따른 테스트 코드 수정

## 작업 내용
- 테스트 환경에서 `NetworkMonitor`의 TestDouble을 사용하기 위해 `NetworkMonitoring` 프로토콜 추상화를 진행했습니다.
- BoundingBox에 해당하는 데이터를 fetch하는지 검증은 수행하지 않습니다.
    - BoundingBox 필터링 로직은 `Storage` 의 책임이므로 Store 동작 테스트와 무관하기 때문입니다.
- CI 실행 시 테스트 코드도 검증하도록 CI 파일을 수정했습니다.

## 스크린샷

## 리뷰 요구사항
- CI 스크립트는 작동 테스트를 위해 target 브랜치를 임시로 설정해두었습니다. 정상 동작 확인 후 다시 develop으로 변경 예정입니다.
## 체크리스트

- [x]  빌드 및 실행 테스트 완료
- [x]  불필요한 print / 주석 제거
- [x]  리뷰 요청 전 self-check 완료
- [x]  목적 브랜치 확인
- [x]  라벨 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 지도 메시지 로딩 관련 인터페이스가 카메라 위치 및 추가 매개변수로 갱신되었습니다.
  * 네트워크 모니터링이 프로토콜 기반으로 변경되어 유연성이 향상되었습니다.

* **테스트**
  * 테스트 더블 및 스텁이 추가/갱신되어 네트워크 및 위치 관련 시나리오를 지원합니다.
  * 테스트 스킴에 명시적 테스트 대상이 추가되었습니다.

* **Chores**
  * CI 빌드·테스트 워크플로우가 개선되어 파일 감지 및 테스트 실행이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->