### PR TITLE
페이지네이션 제거 및 중복 검색결과 제거

### DIFF
--- a/Meomun/Meomun/Data/Repository/NaverPlaceSearchRepositoryImpl.swift
+++ b/Meomun/Meomun/Data/Repository/NaverPlaceSearchRepositoryImpl.swift
@@ -22,10 +22,9 @@ final class NaverPlaceSearchRepositoryImpl: PlaceRepository {
         self.clientSecret = clientSecret
     }
 
-    func searchPlace(query: String, start: Int) async throws -> [NaverLocalItemDTO] {
+    func searchPlace(query: String) async throws -> [NaverLocalItemDTO] {
         let endpoint = NaverLocalSearchEndpoint(
             query: query,
-            start: start,
             clientId: clientId,
             clientSecret: clientSecret
         )

--- a/Meomun/Meomun/Domain/Repository/PlaceRepository.swift
+++ b/Meomun/Meomun/Domain/Repository/PlaceRepository.swift
@@ -6,5 +6,5 @@
 //
 
 protocol PlaceRepository: Sendable {
-    func searchPlace(query: String, start: Int) async throws -> [NaverLocalItemDTO]
+    func searchPlace(query: String) async throws -> [NaverLocalItemDTO]
 }

--- a/Meomun/Meomun/Domain/UseCase/SearchNearbyPlaceUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/SearchNearbyPlaceUseCase.swift
@@ -8,8 +8,7 @@
 protocol SearchNearbyPlaceUseCase {
     func execute(
         query: String,
-        userLocation: Coordinate,
-        start: Int
+        userLocation: Coordinate
     ) async throws -> [Place]
 }
 
@@ -24,11 +23,10 @@ final class SearchNearbyPlaceUseCaseImpl: SearchNearbyPlaceUseCase {
 
     func execute(
         query: String,
-        userLocation: Coordinate,
-        start: Int
+        userLocation: Coordinate
     ) async throws -> [Place] {
 
-        let candidates = try await placeRepository.searchPlace(query: query, start: start)
+        let candidates = try await placeRepository.searchPlace(query: query)
 
         let places: [Place] = candidates.compactMap { item -> Place? in
             // mapx = longitude, mapy = latitude

--- a/Meomun/Meomun/Presentation/Scene/SearchPlace/PlaceSearchOverlayView.swift
+++ b/Meomun/Meomun/Presentation/Scene/SearchPlace/PlaceSearchOverlayView.swift
@@ -137,7 +137,7 @@ extension PlaceSearchOverlayView {
             case .loaded(let results):
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 8) {
-                        ForEach(results, id: \.self) { place in
+                        ForEach(results, id: \.id) { place in
                             Button {
                                 Task { await store.send(intent: .tapResult(place)) }
                             } label: {
@@ -155,11 +155,6 @@ extension PlaceSearchOverlayView {
                                             .foregroundStyle(Color.gray)
                                     }
                                     Spacer()
-                                }
-                                .onAppear {
-                                    if place == results.last {
-                                        Task { await store.send(intent: .scrollReachedBottom) }
-                                    }
                                 }
                                 .foregroundStyle(Color.mmTextBrand)
                                 .padding(.vertical, 5)

--- a/Meomun/Meomun/Presentation/Scene/SearchPlace/PlaceSearchStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/SearchPlace/PlaceSearchStore.swift
@@ -30,7 +30,6 @@ final class PlaceSearchStore: Store {
     enum Intent {
         case queryChanged(String)
         case submit
-        case scrollReachedBottom
         case tapResult(Place)
         case dismiss
     }
@@ -39,29 +38,18 @@ final class PlaceSearchStore: Store {
         case setQuery(String)
         case setPhase(Phase)
         case clear
-
-        case appendResults([Place])
-        case setPagination(nextStart: Int, hasMore: Bool)
-        case setLoadingMore(Bool)
     }
 
     struct State {
         var query: String = ""
         var phase: Phase = .idle
         var userLocation: Coordinate?
-
-        // 페이지네이션
-        var display: Int = 5
-        var nextStart: Int = 1
-        var hasMore: Bool = true
-        var isLoadingMore: Bool = false
     }
 
     @Published var state: State
 
     // 검색 작업이 결과를 반환
     private var searchTask: Task<[Place], Never>?
-    private var loadMoreTask: Task<[Place], Never>?
 
     private let searchNearbyPlaces: SearchNearbyPlaceUseCase
 
@@ -90,17 +78,11 @@ final class PlaceSearchStore: Store {
             case .submit:
                 search(for: state.query, immediate: true)
 
-            case .scrollReachedBottom:
-                Task { @MainActor in
-                    loadMore()
-                }
-
             case .tapResult(let place):
                 onSelect(place)
 
             case .dismiss:
                 cancelSearch()
-                cancelLoadMore()
                 onDismiss()
             }
 
@@ -121,21 +103,6 @@ final class PlaceSearchStore: Store {
         case .clear:
             newState.query = ""
             newState.phase = .idle
-            newState.nextStart = 1
-            newState.hasMore = true
-            newState.isLoadingMore = false
-
-        case .appendResults(let places):
-            let current = newState.phase.results
-            let merged = current + places
-            newState.phase = .loaded(merged)
-
-        case .setPagination(nextStart: let nextStart, hasMore: let hasMore):
-            newState.nextStart = nextStart
-            newState.hasMore = hasMore
-
-        case .setLoadingMore(let flag):
-            newState.isLoadingMore = flag
         }
 
         return newState
@@ -155,7 +122,6 @@ private extension PlaceSearchStore {
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         cancelSearch()
-        cancelLoadMore()
 
         guard !trimmedQuery.isEmpty else {
             Task { @MainActor in
@@ -170,8 +136,6 @@ private extension PlaceSearchStore {
 
         // 페이지네이션 초기화
         Task { @MainActor in
-            apply(.setPagination(nextStart: 1, hasMore: true))
-            apply(.setLoadingMore(false))
             apply(.setPhase(.loading))
         }
 
@@ -187,8 +151,7 @@ private extension PlaceSearchStore {
             do {
                 let results = try await useCase.execute(
                     query: stabilizedQuery,
-                    userLocation: userLocation,
-                    start: 1
+                    userLocation: userLocation
                 )
                 return results
             } catch {
@@ -202,13 +165,11 @@ private extension PlaceSearchStore {
             let results = await task.value
             if Task.isCancelled { return }
 
-            // 첫 페이지 결과 반영 + 페이지네이션 상태 업데이트
-            let hasMore = results.count == self.state.display
-            let nextStart = 1 + results.count
+            var seen = Set<PlaceID>()
+            let deduped = results.filter { seen.insert($0.id).inserted }
 
-            let nextPhase: Phase = results.isEmpty ? .empty : .loaded(results)
+            let nextPhase: Phase = deduped.isEmpty ? .empty : .loaded(deduped)
             apply(.setPhase(nextPhase))
-            apply(.setPagination(nextStart: nextStart, hasMore: hasMore))
         }
     }
 
@@ -251,68 +212,5 @@ private extension PlaceSearchStore {
     func cancelSearch() {
         searchTask?.cancel()
         searchTask = nil
-    }
-
-    // MARK: - 페이지네이션
-
-    @MainActor
-    func loadMore() {
-        // loaded 상태에서만 더 불러오도록 함.
-        guard case .loaded = state.phase else { return }
-        guard state.hasMore else { return }
-        guard !state.isLoadingMore else { return }
-
-        let query = state.query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return }
-
-        guard let userLocation = state.userLocation else { return }
-
-        let useCase = searchNearbyPlaces
-        let start = state.nextStart
-        let display = state.display
-
-        cancelLoadMore()
-        apply(.setLoadingMore(true))
-
-        loadMoreTask = Task {
-            if Task.isCancelled { return [] }
-
-            do {
-                let results = try await useCase.execute(
-                    query: query,
-                    userLocation: userLocation,
-                    start: start
-                )
-                return results
-            } catch {
-                AppLog.error("Load more failed", category: .network, error: error)
-                return []
-            }
-        }
-
-        Task { @MainActor [weak self] in
-            guard let self, let task = self.loadMoreTask else { return }
-
-            defer {
-                apply(.setLoadingMore(false))
-            }
-
-            let results = await task.value
-            if Task.isCancelled { return }
-
-            if !results.isEmpty {
-                apply(.appendResults(results))
-            }
-
-            let hasMore = results.count == display
-            let nextStart = start + results.count
-
-            apply(.setPagination(nextStart: nextStart, hasMore: hasMore))
-        }
-    }
-
-    func cancelLoadMore() {
-        loadMoreTask?.cancel()
-        loadMoreTask = nil
     }
 }


### PR DESCRIPTION
## 배경
- closed #345

## 작업 요약
- 페이지네이션 관련 코드 정리
- 중복 검색 결과 제거

## 작업 내용
### 1. 페이지네이션 관련 코드 정리
페이지네이션을 적용하려 했으나, 다음과 같은 네이버 지역검색 API 정책으로 인하여 페이지네이션을 사용하지 못하는 것으로 확인하였습니다.

<img width="891" height="533" alt="스크린샷 2026-02-03 오전 12 24 47" src="https://github.com/user-attachments/assets/6c8f8c82-d565-4496-9350-a7f5ea53934d" />

이로 인해 페이지네이션 관련 코드를 제거하고…
5개의 검색 결과만 사용하는 것으로 …했습니다.

### 2. 중복 검색 결과 제거
#### 문제
종종 검색 결과 리스트에서 중간 요소가 빈 것으로 나옴.

#### 원인
* API에서 **중복 place가 내려옴**
* ForEach(results)로 리스트를 구성하고 있음. (Identifiable 기반)
* **중복 id가 생기면 SwiftUI diffing이 꼬여서 한 칸이 사라진 것처럼 보임**.

#### 해결
Store에서 search 결과를 받고 phase를 변경할 때 중복 제거 로직 추가
```swift
var seen = Set<PlaceID>()
let deduped = results.filter { seen.insert($0.id).inserted }

let nextPhase: Phase = deduped.isEmpty ? .empty : .loaded(deduped)
apply(.setPhase(nextPhase))
```

## 스크린샷
- 버그 재현 검색 쿼리인 ‘가산 모비우스’와 ‘서울시청’을 활용하여 테스트 완료했습니다.

https://github.com/user-attachments/assets/5ef63180-1f40-458e-8f11-9f8159566543


## 리뷰 요구사항


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 장소 검색의 페이지네이션 기능 제거 및 검색 결과 표시 방식 간소화
  * 검색 결과가 단일 페이지로 로드되도록 변경
  * 중복된 검색 결과 자동 제거 기능 추가
  * 검색 결과 식별 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->