### PR TITLE
지도 화면의 PathRecordOverlayView 크기가 줄어드는 문제 해결

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionHeaderView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionHeaderView.swift
@@ -45,6 +45,7 @@ struct TimelineSectionHeaderView: View {
         .padding(.horizontal, 30)
         .padding(.top, 8)
         .padding(.bottom, 16)
+        .background(Color.mmBackground)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -46,6 +46,13 @@ struct TimelineListView: View {
                 emptyContent
             }
         }
+        .fullScreenCover(isPresented: isSelectedSectionOverlayPresentedBinding) {
+            if store.state.selectedSection != nil {
+                sectionOverlay
+                    .presentationBackground(.clear)
+            }
+        }
+        .transaction({ transaction in transaction.disablesAnimations = true })
         .overlay(alignment: .bottom) {
             if store.state.isEditing {
                 selectionBar
@@ -79,15 +86,6 @@ struct TimelineListView: View {
                     .transition(.identity) // 애니메이션 없음
             }
         }
-        .overlay {
-            if store.state.selectedSection != nil {
-                sectionOverlay
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-            }
-        }
-        .animation(.easeInOut(duration: 0.3), value: store.state.selectedSection != nil)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -126,7 +126,7 @@ private extension TimelineListView {
                     }
                 }
             }
-            .padding(.top, 10)
+            .padding(.top, configuration.showsFooter && configuration.showsEditButton ? 10 : 44)
             .padding(.bottom, 16)
 
             if configuration.showsFooter && !store.state.messages.isEmpty {


### PR DESCRIPTION
## 배경
- closed #337 

## 작업 요약
- 지도 화면의 PathRecordOverlayView 크기가 줄어드는 문제 해결

## 작업 내용
- PathRecordOverlayView를 `overlay`에서 기존 방식대로 `fullScreenCover`로 변경합니다.

```swift
    var body: some View {
        VStack {
            if !store.state.messages.isEmpty {
                content
            } else {
                emptyContent
            }
        }
        .fullScreenCover(isPresented: isSelectedSectionOverlayPresentedBinding) {
            if store.state.selectedSection != nil {
                sectionOverlay
                    .presentationBackground(.clear)
            }
        }
        .transaction({ transaction in transaction.disablesAnimations = true })  // ✨ 가장 먼저 적용
        .overlay(alignment: .bottom) {
            if store.state.isEditing {
                selectionBar
                    .transition(.move(edge: .bottom).combined(with: .opacity))
            }
        }
```
- `transaction`을 가장 먼저 적용해 애니메이션 비활성화 영향이 `fullScreenCover`에만 적용되도록 수정해 해결했습니다.

## 스크린샷

https://github.com/user-attachments/assets/0025db68-b13f-43ca-b5df-80373e7e0ffa



## 리뷰 요구사항


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 섹션 오버레이가 전체 화면 모달로 표시되어 보다 명확하고 집중된 인터페이스 제공
* **Bug Fixes**
  * 섹션 오버레이 전환 시 글로벌 애니메이션이 비활성화되어 불필요한 애니메이션 제거
  * 상단 패딩 계산이 상황에 따라 조정되어 레이아웃이 더 일관되게 표시
* **Style**
  * 섹션 헤더 배경색이 앱 배경과 일치하도록 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->