### PR TITLE
메시지 시간 포맷터 타입 추가

### DIFF
--- a/Meomun/.swiftlint.yml
+++ b/Meomun/.swiftlint.yml
@@ -34,6 +34,10 @@ type_body_length:
 file_length:
   warning: 500 # 파일 크기 제한
 
+large_tuple:
+  warning: 3
+  error: 4
+
 # 4. 이름 규칙 커스터마이징
 identifier_name:
   min_length: # 짧은 이름 방지 (예: single-letter names)

--- a/Meomun/.swiftlint.yml
+++ b/Meomun/.swiftlint.yml
@@ -27,13 +27,14 @@ line_length:
   ignores_comments: true                   # 주석에 대해 행 길이 제한 미적용
   ignores_interpolated_strings: true       # 보간된 문자열 행 길이 제한 미적용
 
+function_parameter_count:
+  warning: 7
 function_body_length:
-  warning: 70  # 함수는 70라인 이하로 유지 (하나의 역할만!)
+  warning: 100  # 함수는 100라인 이하로 유지
 type_body_length:
   warning: 300 # 클래스/구조체는 300라인 이하로 유지
 file_length:
   warning: 500 # 파일 크기 제한
-
 large_tuple:
   warning: 3
   error: 4

--- a/Meomun/Meomun/App/AppConfig.swift
+++ b/Meomun/Meomun/App/AppConfig.swift
@@ -26,4 +26,6 @@ enum AppConfig {
         }
         return key
     }
+
+    static let timestampFormatter: MessageTimestampFormatter = MessageTimestampFormatter()
 }

--- a/Meomun/Meomun/Domain/Entity/Message.swift
+++ b/Meomun/Meomun/Domain/Entity/Message.swift
@@ -26,11 +26,10 @@ extension Message {
         }
     }
 
-    var displayDateString: String {
-        return MessageTimestampFormatter().string(from: createdAt)
-    }
-
-    var displayDateTimeString: String {
-        return MessageTimestampFormatter(style: .dateTime).string(from: createdAt)
+    func displayDateString(
+        using formatter: MessageTimestampFormatter,
+        style: MessageTimestampFormatterStyle = .date
+    ) -> String {
+        formatter.string(from: createdAt, style: style)
     }
 }

--- a/Meomun/Meomun/Domain/Entity/Message.swift
+++ b/Meomun/Meomun/Domain/Entity/Message.swift
@@ -27,6 +27,10 @@ extension Message {
     }
 
     var displayDateString: String {
-        return MessageTimestampFormatter.string(from: createdAt)
+        return MessageTimestampFormatter().string(from: createdAt)
+    }
+
+    var displayDateTimeString: String {
+        return MessageTimestampFormatter(style: .dateTime).string(from: createdAt)
     }
 }

--- a/Meomun/Meomun/Domain/MessageTimestampFormatter.swift
+++ b/Meomun/Meomun/Domain/MessageTimestampFormatter.swift
@@ -12,8 +12,15 @@ enum MessageTimestampFormatterStyle {
     case dateTime
 }
 
-struct MessageTimestampFormatter {
+final class MessageTimestampFormatter {
     let locale: Locale
+
+    private lazy var relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        formatter.locale = locale
+        return formatter
+    }()
 
     init(locale: Locale = .current) {
         self.locale = locale
@@ -24,18 +31,10 @@ struct MessageTimestampFormatter {
         let oneDay: TimeInterval = 60 * 60 * 24
 
         if elapsed < oneDay {
-            return relativeString(from: date, now: now)
+            return relativeFormatter.localizedString(for: date, relativeTo: now)
         } else {
             return absoluteString(from: date, style: style)
         }
-    }
-
-    private func relativeString(from date: Date, now: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        formatter.locale = locale
-
-        return formatter.localizedString(for: date, relativeTo: now)
     }
 
     private func absoluteString(from date: Date, style: MessageTimestampFormatterStyle) -> String {
@@ -44,7 +43,9 @@ struct MessageTimestampFormatter {
             return date.formatted(.dateTime.year().month().day().locale(locale))
 
         case .dateTime:
-            return date.formatted(date: .complete, time: .shortened)
+            return date.formatted(
+                Date.FormatStyle(date: .complete, time: .shortened).locale(locale)
+            )
         }
     }
 }

--- a/Meomun/Meomun/Domain/MessageTimestampFormatter.swift
+++ b/Meomun/Meomun/Domain/MessageTimestampFormatter.swift
@@ -7,27 +7,49 @@
 
 import Foundation
 
+enum MessageTimestampFormatterStyle {
+    case date
+    case dateTime
+}
+
 struct MessageTimestampFormatter {
-    static func string(from date: Date) -> String {
-        let now = Date()
+    let style: MessageTimestampFormatterStyle
+    let locale: Locale
+
+    init(
+        style: MessageTimestampFormatterStyle = .date,
+        locale: Locale = .current
+    ) {
+        self.style = style
+        self.locale = locale
+    }
+
+    func string(from date: Date, now: Date = Date()) -> String {
         let elapsed = now.timeIntervalSince(date)
         let oneDay: TimeInterval = 60 * 60 * 24
 
         if elapsed < oneDay {
             return relativeString(from: date, now: now)
         } else {
-            return absoluteString(from: date)
+            return absoluteString(from: date, style: style)
         }
     }
 
-    static func relativeString(from date: Date, now: Date) -> String {
+    private func relativeString(from date: Date, now: Date) -> String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .full
+        formatter.locale = locale
+
         return formatter.localizedString(for: date, relativeTo: now)
     }
 
-    static func absoluteString(from date: Date) -> String {
-        return date.formatted(.dateTime.locale(Locale.current)
-        )
+    private func absoluteString(from date: Date, style: MessageTimestampFormatterStyle) -> String {
+        switch style {
+        case .date:
+            return date.formatted(.dateTime.year().month().day().locale(locale))
+
+        case .dateTime:
+            return date.formatted(date: .complete, time: .shortened)
+        }
     }
 }

--- a/Meomun/Meomun/Domain/MessageTimestampFormatter.swift
+++ b/Meomun/Meomun/Domain/MessageTimestampFormatter.swift
@@ -13,18 +13,13 @@ enum MessageTimestampFormatterStyle {
 }
 
 struct MessageTimestampFormatter {
-    let style: MessageTimestampFormatterStyle
     let locale: Locale
 
-    init(
-        style: MessageTimestampFormatterStyle = .date,
-        locale: Locale = .current
-    ) {
-        self.style = style
+    init(locale: Locale = .current) {
         self.locale = locale
     }
 
-    func string(from date: Date, now: Date = Date()) -> String {
+    func string(from date: Date, style: MessageTimestampFormatterStyle, now: Date = Date()) -> String {
         let elapsed = now.timeIntervalSince(date)
         let oneDay: TimeInterval = 60 * 60 * 24
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/MessageBubble.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/MessageBubble.swift
@@ -103,7 +103,7 @@ private extension MessageBubble {
     }
 
     var datePart: some View {
-        Text(message.displayDateString)
+        Text(message.displayDateString(using: AppConfig.timestampFormatter))
             .font(.system(size: 11, weight: .semibold))
             .foregroundStyle(Color.mmTextSecondary)
             .frame(maxWidth: .infinity, alignment: .trailing)

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/RotatingMessageStack.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/RotatingMessageStack.swift
@@ -41,7 +41,7 @@ private extension RotatingMessageStack {
                 .frame(height: 36, alignment: .center)
                 .clipped()
 
-            Text(message.displayDateString)
+            Text(message.displayDateString(using: AppConfig.timestampFormatter))
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(Color.gray.opacity(0.8))
                 .frame(maxWidth: .infinity, alignment: .trailing)

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
@@ -18,7 +18,7 @@ final class SpaceMessageBubbleFactory {
 
         // 텍스트 가공 및 entity 생성
         let contentText = TextArranger.arrangeText(message.content)
-        let dateText = message.displayDateString
+        let dateText = message.displayDateString(using: AppConfig.timestampFormatter)
         let contentTextEntity = makeTextEntity(contentText, type: .content)
         let dateTextEntity = makeTextEntity(dateText, type: .date)
 

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
@@ -18,8 +18,7 @@ final class SpaceMessageBubbleFactory {
 
         // 텍스트 가공 및 entity 생성
         let contentText = TextArranger.arrangeText(message.content)
-        let dateText = MessageTimestampFormatter.string(from: message.createdAt)
-
+        let dateText = message.displayDateString
         let contentTextEntity = makeTextEntity(contentText, type: .content)
         let dateTextEntity = makeTextEntity(dateText, type: .date)
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/MessageBoxView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/MessageBoxView.swift
@@ -69,7 +69,7 @@ private extension MessageBoxView {
 
     var metaRowView: some View {
         HStack {
-            Text(message.displayDateTimeString)
+            Text(message.displayDateString(using: AppConfig.timestampFormatter, style: .dateTime))
                 .font(.footnote.weight(.semibold))
                 .foregroundStyle(Color.mmSecondary)
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/MessageBoxView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/MessageBoxView.swift
@@ -69,7 +69,7 @@ private extension MessageBoxView {
 
     var metaRowView: some View {
         HStack {
-            Text(message.displayDateString)
+            Text(message.displayDateTimeString)
                 .font(.footnote.weight(.semibold))
                 .foregroundStyle(Color.mmSecondary)
 


### PR DESCRIPTION
## 배경
- closed #336

## 작업 요약
- [x] 메시지 시간 포맷터 성능/일관성 개선
- [x] 포맷터 래퍼로 사용하지 않고 직접 사용하던 부분 수정
- [x] swiftlint 규칙 수정

## 작업 내용
###  메시지 시간 포맷터 성능/일관성 개선

(final class + lazy 캐시)
#### 문제 인식
- 기존 구현에서 RelativeDateTimeFormatter()를 호출마다 생성하면(메시지 렌더링/리스트/애니메이션/스크롤) 비용이 누적될 수 있는 상황

#### 해결 방안
- 이를 개선하기 위해 포맷터를 `struct` 에서 `final class`로 전환하고, 상대 시간 포맷터(`RelativeDateTimeFormatter`)를 lazy로 캐싱하여 한 번 생성 후 재사용하도록 변경
- AppConfig에서 Formatter 생성하여 뷰 전역에서 사용할 수 있도록 함

```swift
final class MessageTimestampFormatter {
    let locale: Locale
    
    private lazy var relativeFormatter: RelativeDateTimeFormatter = {
        let formatter = RelativeDateTimeFormatter()
        formatter.unitsStyle = .full
        formatter.locale = locale
        return formatter
    }()
}
```

```swift
enum AppConfig {
    static let timestampFormatter: MessageTimestampFormatter = MessageTimestampFormatter()
}
```

#### 효과
- lazy 캐시를 통해 상대 시간 포맷터를 재사용 → 반복 호출 비용 감소


### swiftlint 규칙 수정
- large_tuple: warning 2, error 3 -> warning 3, error 4
- function_parameter_count: warning 5 -> 7
- function_body_length: warning 70 -> 100

## 스크린샷

https://github.com/user-attachments/assets/059bf110-8f69-4ab8-95d8-48a2ee4d611a

https://github.com/user-attachments/assets/b9b348f4-799a-43e5-ab2c-3e69f75b8094


## 리뷰 요구 사항
- 유틸성 객체라서 어디에서 생성해줘야할지 애매하네요. 일단 AppConfig에 넣긴 했는데 더 좋은 방안 있다면 추천 부탁드립니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 앱 전역의 타임스탬프 포맷팅 일관성 강화
  * 날짜 및 날짜/시간 표시 스타일 옵션 추가
  * 다국어 로케일 지원 개선
  * 표시되는 날짜/시간의 형식과 지역화가 더 세밀하게 반영됨

* **주의 사항**
  * 포맷터 동작 변경으로 커스텀 포맷터를 사용하는 일부 표시가 달라질 수 있음

* **Chores**
  * 린팅 규칙(줄 길이·함수 본문 길이 등) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->