### PR TITLE
맵뷰 메세지 생성/삭제에 따른 동기 처리

### DIFF
--- a/Meomun/Meomun/Presentation/Root/LocationProvider.swift
+++ b/Meomun/Meomun/Presentation/Root/LocationProvider.swift
@@ -161,8 +161,6 @@ extension LocationProvider: CLLocationManagerDelegate {
         let coordinate = Coordinate(latitude: last.coordinate.latitude,
                                     longitude: last.coordinate.longitude)
         current = coordinate
-        AppLog.debug("Current location updated", category: .location)
-
         succeedOneShots(coordinate)
     }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -21,13 +21,13 @@ final class MapStore: Store {
         case cameraChangedByLocation(Coordinate, BoundingBox, MapCameraSnapshot)
         case cameraMoveConsumed
 
+        case refreshVisibleMessages
+
         case tapSearch
         case dismissPlaceSearch
         case selectPlace(Place)
 
         case dismissAddMessage
-
-        case updateMessages([Message])
 
         case tapNoPlaceMarker([Message])
         case tapPlaceMarker([Message])
@@ -43,6 +43,7 @@ final class MapStore: Store {
         case setFollowingUser(Bool)
         case setCameraMoveTarget(MapCameraMoveCommand?)
         case setCameraSnapshot(MapCameraSnapshot?)
+        case setCameraBounds(BoundingBox)
 
         case presentPlaceSearch(Bool)
 
@@ -63,6 +64,7 @@ final class MapStore: Store {
         var cameraSnapshot: MapCameraSnapshot?
 
         var cameraCoordinate: Coordinate?
+        var cameraBounds: BoundingBox?
         var isFollowingUser: Bool = true
 
         var isPlaceSearchPresented: Bool = false
@@ -150,6 +152,7 @@ final class MapStore: Store {
             case .cameraDidIdle(let coordinate, let boundingBox, let snapshot):
                 continuation.yield(.setCameraCoordinate(coordinate))
                 continuation.yield(.setCameraSnapshot(snapshot))
+                continuation.yield(.setCameraBounds(boundingBox))
                 self.getNearbyMessages(
                     at: coordinate,
                     bounds: boundingBox,
@@ -160,6 +163,7 @@ final class MapStore: Store {
             case .cameraChangedByLocation(let coordinate, let boundingBox, let snapshot):
                 continuation.yield(.setCameraCoordinate(coordinate))
                 continuation.yield(.setCameraSnapshot(snapshot))
+                continuation.yield(.setCameraBounds(boundingBox))
                 self.getNearbyMessages(
                     at: coordinate,
                     bounds: boundingBox,
@@ -170,6 +174,21 @@ final class MapStore: Store {
             case .cameraMoveConsumed:
                 continuation.yield(.setCameraMoveTarget(nil))
                 continuation.yield(.presentPlaceSearch(false))
+
+            case .refreshVisibleMessages:
+                guard let coordinate = state.cameraCoordinate,
+                      let bounds = state.cameraBounds
+                else {
+                    continuation.finish()
+                    return
+                }
+
+                self.getNearbyMessages(
+                    at: coordinate,
+                    bounds: bounds,
+                    continuation: continuation
+                )
+                return
 
             case .tapSearch:
                 continuation.yield(.presentPlaceSearch(true))
@@ -186,9 +205,6 @@ final class MapStore: Store {
 
             case .dismissAddMessage:
                 continuation.yield(.setShowAddMessage(false))
-
-            case .updateMessages(let messages):
-                continuation.yield(.setMessages(messages))
 
             case .tapNoPlaceMarker(let messages):
                 continuation.yield(.setSelectedNoPlace(messages))
@@ -232,6 +248,9 @@ final class MapStore: Store {
         case .setCameraSnapshot(let snapshot):
             newState.cameraSnapshot = snapshot
 
+        case .setCameraBounds(let bounds):
+            newState.cameraBounds = bounds
+
         case .setCameraMoveTarget(let snapshot):
             newState.cameraMoveTarget = snapshot
 
@@ -259,6 +278,8 @@ final class MapStore: Store {
         case .setToastMessage(let message):
             newState.toastMessage = message
         }
+
+        AppLog.debug("[MapView] message: \(newState.messages.count)", category: .store)
 
         return newState
     }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -206,7 +206,11 @@ private extension MapView {
                         remote: SupabaseServiceImpl(network: NetworkClientImpl())
                     )
                 ),
-                onClose: { _ in
+                onClose: { isSuccess in
+                    if isSuccess {
+                        Task { await store.send(intent: .refreshVisibleMessages) }
+                    }
+                    
                     onClose()
                 }
             )
@@ -229,6 +233,9 @@ private extension MapView {
                 onNavigate(coordinate, place)
             }
         )
+        .onDisappear {
+            Task { await store.send(intent: .refreshVisibleMessages) }
+        }
     }
 }
 
@@ -282,7 +289,10 @@ private extension MapView {
                 fetchRecentMessagesUseCase: FetchRecentMessagesUseCaseImpl(
                     repository: MessageRepositoryImpl()
                 ),
-                deleteMessagesUseCase: DeleteMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl())
+                deleteMessagesUseCase: DeleteMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl()),
+                onDeletedMessages: { _ in
+                    Task { await store.send(intent: .refreshVisibleMessages) }
+                }
             ),
             isEditing: false,
             configuration: .bottomSheet

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -220,7 +220,7 @@ private extension MapView {
                 ),
                 onClose: { isSuccess in
                     if isSuccess {
-                        Task { await store.send(intent: .refreshVisibleMessages) }
+                        send(.refreshVisibleMessages)
                     }
 
                     onClose()
@@ -246,7 +246,7 @@ private extension MapView {
             }
         )
         .onDisappear {
-            Task { await store.send(intent: .refreshVisibleMessages) }
+            send(.refreshVisibleMessages)
         }
     }
 }
@@ -304,7 +304,7 @@ private extension MapView {
                 ),
                 deleteMessagesUseCase: DeleteMessagesUseCaseImpl(messageRepository: MessageRepositoryImpl()),
                 onDeletedMessages: { _ in
-                    Task { await store.send(intent: .refreshVisibleMessages) }
+                    send(.refreshVisibleMessages)
                 }
             ),
             isEditing: false,
@@ -312,11 +312,15 @@ private extension MapView {
             onBecameEmpty: {
                 Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(1000))
+
+                    guard isTimelineListPresented else { return }
+
                     withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
                         isTimelineListPresented = false
                     }
-                    send(.dismissTimelineView)
                 }
+                
+                send(.dismissTimelineView)
             }
         )
     }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -22,6 +22,7 @@ struct MapView: View {
 
     @State private var navigationPath = NavigationPath()
     @State private var didApplyResolvedUserLocation = false
+    @State private var isTimelineListPresented = false
 
     @ObservedObject private var store: MapStore
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -113,6 +114,16 @@ struct MapView: View {
                 didApplyResolvedUserLocation = true
                 send(.userLocationReady(coordinate))
             }
+            .onChange(of: store.state.selectedNoPlaceMessages.isEmpty) { _, isEmpty in
+                guard isEmpty, isTimelineListPresented else { return }
+
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(1000))
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
+                        isTimelineListPresented = false
+                    }
+                }
+            }
             .onAppear {
                 setTabBarHidden(false)
                 setNavBarHidden(false)
@@ -154,6 +165,7 @@ private extension MapView {
                 send(.tapPlaceMarker(messages))
             },
             onTapNoPlace: { messages in
+                isTimelineListPresented = true
                 send(.tapNoPlaceMarker(messages))
             },
             onUserGesture: {
@@ -210,7 +222,7 @@ private extension MapView {
                     if isSuccess {
                         Task { await store.send(intent: .refreshVisibleMessages) }
                     }
-                    
+
                     onClose()
                 }
             )
@@ -278,7 +290,8 @@ private extension MapView {
             set: { isPresented in
                 if !isPresented {
                     send(.dismissPlaceSearch)
-            }}
+                }
+            }
         )
     }
 
@@ -295,15 +308,25 @@ private extension MapView {
                 }
             ),
             isEditing: false,
-            configuration: .bottomSheet
+            configuration: .bottomSheet,
+            onBecameEmpty: {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(1000))
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
+                        isTimelineListPresented = false
+                    }
+                    send(.dismissTimelineView)
+                }
+            }
         )
     }
 
     var isTimelineListPresentedBinding: Binding<Bool> {
         Binding(
-            get: { store.state.selectedNoPlaceMessages.isEmpty == false },
+            get: { isTimelineListPresented },
             set: { isPresented in
                 if !isPresented {
+                    isTimelineListPresented = false
                     send(.dismissTimelineView)
                 }
             }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -133,16 +133,16 @@ struct MapView: View {
                 send(.onDisappear)
                 locationProvider.stopContinuous()
             }
-            .sheet(isPresented: isTimelineListPresentedBinding) {
-                timeLineListView
-                    .presentationDetents(.init(arrayLiteral: .medium, .large))
-                    .presentationDragIndicator(.visible)
-            }
             .fullScreenCover(isPresented: isPlaceSearchPresentedBinding) {
                 placeSearchOverlay
                     .presentationBackground(.clear)
             }
             .transaction { $0.disablesAnimations = true }
+            .sheet(isPresented: isTimelineListPresentedBinding) {
+                timeLineListView
+                    .presentationDetents(.init(arrayLiteral: .medium, .large))
+                    .presentationDragIndicator(.visible)
+            }
         }
         .mmToast(toastBinding, bottomPadding: 100)
     }

--- a/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Marker/MessageMarkerManager.swift
@@ -156,9 +156,8 @@ extension MessageMarkerManager {
         onTapPlace: (([Message]) -> Void)?,
         onTapNoPlace: (([Message]) -> Void)?
     ) {
-        guard messages.isEmpty == false else {
-            return
-        }
+        AppLog.debug("[MessageMarkerManager] loadMessages: \(messages.count) messages", category: .location)
+
         // 바인딩 저장
         boundMapView = mapView
 
@@ -871,6 +870,8 @@ private extension MessageMarkerManager {
         // 2) cluster item map 구성
         var keyTagMap: [ItemKey: NSObject] = [:]
         keyTagMap.reserveCapacity(desiredGroupKeys.count)
+
+        AppLog.debug("[MessageMarkerManager] update \(desiredGroupKeys.count) messages", category: .location)
 
         for groupKey in desiredGroupKeys {
             let coord = groupKey.coordinate

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -55,15 +55,18 @@ final class TimelineListStore: Store {
 
     private let fetchRecentMessagesUseCase: FetchRecentMessagesUseCase
     private let deleteMessagesUseCase: DeleteMessagesUseCase
+    private let onDeletedMessages: (Set<MessageID>) -> Void
 
     init(
         initialMessages: [Message] = [],
         fetchRecentMessagesUseCase: FetchRecentMessagesUseCase,
-        deleteMessagesUseCase: DeleteMessagesUseCase
+        deleteMessagesUseCase: DeleteMessagesUseCase,
+        onDeletedMessages: @escaping (Set<MessageID>) -> Void = { _ in }
     ) {
         self.state = State(messages: initialMessages)
         self.fetchRecentMessagesUseCase = fetchRecentMessagesUseCase
         self.deleteMessagesUseCase = deleteMessagesUseCase
+        self.onDeletedMessages = onDeletedMessages
     }
 
     func action(intent: Intent) -> AsyncStream<Action> {
@@ -240,6 +243,7 @@ private extension TimelineListStore {
                 do {
                     try await deleteMessagesUseCase.execute(for: messageIDs)
                     continuation.yield(.deleteMessages(messageIDs))
+                    self.onDeletedMessages(messageIDs)
 
                     // 성공 시 추가 액션 실행
                     onSuccess.forEach { continuation.yield($0) }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -213,6 +213,7 @@ final class TimelineListStore: Store {
             newState.messages.removeAll { messageIDs.contains($0.id) }
             newState.selectedMessageIDs.subtract(messageIDs)
             cleanupSectionIfNeeded(&newState)
+            AppLog.debug("[TimelineListStore] Deleted messages: \(newState.messages.count) left", category: .store)
 
         case .showDeleteAlert(let alert):
             newState.deleteAlert = alert

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -17,6 +17,7 @@ struct TimelineListView: View {
     @Environment(\.setTabBarHidden) private var setTabBarHidden
     @StateObject private var store: TimelineListStore
     private let configuration: Configuration
+    private let onBecameEmpty: () -> Void
 
     // 외부 편집 상태 (SSOT: MainTabStore)
     private let isEditing: Bool
@@ -27,11 +28,14 @@ struct TimelineListView: View {
     init(store: TimelineListStore,
          isEditing: Bool,
          configuration: Configuration = .full,
-         onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+         onEditingChanged: @escaping (Bool) -> Void = { _ in },
+         onBecameEmpty: @escaping () -> Void = { }
+    ) {
         _store = StateObject(wrappedValue: store)
         self.isEditing = isEditing
         self.configuration = configuration
         self.onEditingChanged = onEditingChanged
+        self.onBecameEmpty = onBecameEmpty
     }
 
     private func send(_ intent: TimelineListStore.Intent) {
@@ -64,6 +68,10 @@ struct TimelineListView: View {
         }
         .onChange(of: store.state.deleteStatus) { _, _ in
             setTabBarHidden(shouldHideTabBar)
+        }
+        .onChange(of: store.state.messages.isEmpty) { _, isEmpty in
+            guard isEmpty else { return }
+            onBecameEmpty()
         }
         .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.isEditing)
         .background(Color.mmBackground)
@@ -271,7 +279,7 @@ extension TimelineListView {
 
         static let full = Configuration(showsFooter: true, showsEditButton: true)
 
-        static let bottomSheet = Configuration(showsFooter: false, showsEditButton: false)
+        static let bottomSheet = Configuration(showsFooter: true, showsEditButton: false)
     }
 }
 


### PR DESCRIPTION
## 배경

- closed #338 

## 작업 요약

- [x] 앱 초기화
- [x] 메세지 생성
- [x] 메세지 삭제

## 작업 내용

### 1) 마커 싱크 불일치 문제 정리 및 원인 파악

**문제 상황**

- 메시지 작성/삭제가 SwiftData에는 정상 반영되는데, **지도(MapView) 마커가 즉시 반영되지 않는 경우**가 간헐적으로 발생.
- 특히 아래 상황에서 사용자 입장에서는 “저장/삭제가 안 된 것처럼” 느껴짐
    - 메시지 작성 완료 후 지도에 새 마커가 바로 보이지 않음
    - 타임라인(하프 모달)에서 메시지 삭제 후 지도 마커가 남아 있음
    - 그룹(장소 태그 없는 메시지 묶음) 내 메시지를 전부 삭제했는데 모달이 어색하게 즉시 닫히거나, 마커는 남아 있는 상태가 잠깐 유지됨

**핵심 원인**

- 지도 마커 갱신(`MessageMarkerManager.loadMessages`)은 **MapStore.state.messages 변경을 트리거로만 발생**.
- 그런데 메시지 “작성/삭제”는 MapStore를 직접 갱신하지 않으면:
    - 카메라 이동 이벤트(`cameraDidIdle`, `cameraChangedByLocation`)가 다시 발생하지 않는 이상
    - `getNearbyMessagesUseCase.execute(...)`가 재호출되지 않고
    - 결과적으로 `store.state.messages`가 그대로 유지되어 **마커 업데이트가 발생하지 않음**.

### 2) 메시지 작성 후 지도 마커 싱크 보장

**개선 내용**

- 메시지 작성 화면에서 **저장 성공 후**, 현재 지도 시야 기준으로 메시지를 다시 불러오도록 refresh 트리거 추가.

**적용 방식**

- `MapView.messageComposerView(...)`의 `onClose`에서 성공 여부를 확인하고 성공 시 refresh 실행

```swift
onClose: { isSuccessin
		if isSuccess {
				Task { await store.send(intent: .refreshVisibleMessages) }
    }
    onClose()
}
```

**효과**

- “저장 → SwiftData 반영” 이후 **MapStore가 즉시 최신 메시지를 refetch**하여 `store.state.messages`가 갱신됨
- `MapViewWrapper.updateUIViewController` → `loadMessages` 호출로 이어져 **지도 마커가 즉시 동기화**됨

### 3) 타임라인(하프 모달) 삭제 후 지도 마커 싱크 보장

**문제 상황**

- 장소 태그가 없는 메시지를 탭하면 하프 모달 타임라인이 표시되고,
    
    여기서 삭제하면 SwiftData에서는 삭제되지만, **MapStore가 갱신되지 않아 지도 마커 반영이 늦거나 누락**됨.
    

**개선 내용**

- 타임라인 삭제 성공 시 `MapStore.refreshVisibleMessages`를 호출하도록 연결.

**적용 방식**

- `TimelineListStore`를 “재사용 가능한 뷰” 관점으로 유지하기 위해,
    
    삭제 성공 후 상위에서 후속 처리를 결정할 수 있도록 `onDeletedMessages` 콜백을 주입받는 구조로 확장.
    
- MapView의 하프 모달 생성부에서 콜백을 연결하여 refresh 트리거 실행

```swift
onDeletedMessages: { _ in
		Task { await store.send(intent: .refreshVisibleMessages) }
}
```

**효과**

- 타임라인에서 삭제가 발생하면 SwiftData 삭제와 동시에 MapStore가 refetch
- 결과적으로 **지도 마커가 즉시 제거**되어 싱크 불일치가 해결됨

### 4) 타임라인 메시지가 모두 삭제된 경우 모달 자동 dismiss + UX 개선

**요구**

- 하프 모달 타임라인에서 표시 중인 메시지가 모두 삭제되면, 모달을 자동으로 내리고 싶음.
- 단, 즉시 dismiss되면 “갑자기 사라지는” 느낌이 강해 UX가 거침.

**개선 내용**

1. `TimelineListView`에 “빈 상태 감지 콜백”인 `onBecameEmpty`를 추가해 재사용성을 유지
    - 탭바의 전체 타임라인에서는 전달하지 않으면 아무 동작도 하지 않음(기본 no-op)
2. MapView의 하프 모달에서만 `onBecameEmpty`를 연결하여 **부드러운 dismiss** 수행
3. 모달 표시 상태를 메시지 배열의 empty 여부에서 분리하고,
    
    `isTimelineListPresented` 상태로 명시적으로 제어하도록 개선
    

**MapView 적용 코드**

- 마커 탭 시 sheet 표시 상태를 명시적으로 true로 설정

```swift
onTapNoPlace: { messages in
    isTimelineListPresented = true
    send(.tapNoPlaceMarker(messages))
}
```

- 메시지가 모두 삭제되면 1초 딜레이 후 스프링 애니메이션으로 부드럽게 dismiss

```swift
onBecameEmpty: {
		Task { @MainActor in
				try? await Task.sleep(for: .milliseconds(1000))
        withAnimation(.spring(response:0.25, dampingFraction:0.9)) {
            isTimelineListPresented = false
        }
        send(.dismissTimelineView)
    }
}
```

- selection이 외부에서 비워지는 경우도 동일하게 부드럽게 dismiss

```swift
.onChange(of: store.state.selectedNoPlaceMessages.isEmpty) {_, isEmpty in
		guard isEmpty, isTimelineListPresentedelse { return }
		Task { @MainActor in
				try? await Task.sleep(for: .milliseconds(1000))
        withAnimation(.spring(response:0.25, dampingFraction:0.9)) {
            isTimelineListPresented=false
        }
    }
}
```

## 스크린샷

https://github.com/user-attachments/assets/0aec77c9-7657-4844-a13a-7a5ca710e9a5

## 리뷰 요구사항

실제 테스트를 해보며 상황에 따라 예외사항이 발생하는지 한번 더 테스트 해주시면 감사하겠습니다!!
태그 없는 메세지가 같은 좌표에 생기는 경우 스택 메세지로 랜더링 하는 과정에서 지연이 발생하는 부분이 있습니다. 또한, 타임라인 뷰가 sheet로 표시될 때 메세지가 전부 삭제되는 경우 애니메이션이 조금 부자연스러워서 이 부분도 어떻게 개선하면 좋을지 알려주시면 감사하겠습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 화면 범위 기반으로 화면에 보이는 메시지를 자동 새로고침하는 기능 추가

* **개선 사항**
  * 타임라인 목록 표시/숨김 흐름 개선 및 지연 후 자동 닫기 동작 추가
  * 메시지 삭제·작성·뷰 전환 시 목록 자동 갱신 트리거 추가
  * 타임라인 하단 표시(푸터) 활성화 및 편집 버튼 구성 보완
  * 지도 관련 상태 변경에 대한 진단 로그 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->