### PR TITLE
온보딩 구현

### DIFF
--- a/Meomun/Meomun/App/AppLog.swift
+++ b/Meomun/Meomun/App/AppLog.swift
@@ -19,6 +19,7 @@ enum LogCategory: String {
     case resource = "Resource"  // 모델, material, 에셋 로딩 관련
     case login = "Login"
     case storage = "Storage"
+    case main = "Main"
 }
 
 enum AppLog {

--- a/Meomun/Meomun/App/MeomunApp.swift
+++ b/Meomun/Meomun/App/MeomunApp.swift
@@ -21,7 +21,7 @@ struct MeomunApp: App {
             #endif
 
             try Tips.configure([
-                .displayFrequency(.monthly)
+                .displayFrequency(.immediate)
             ])
         } catch {
             // TipKit configuration failure should not block app launch.

--- a/Meomun/Meomun/App/MeomunApp.swift
+++ b/Meomun/Meomun/App/MeomunApp.swift
@@ -25,7 +25,7 @@ struct MeomunApp: App {
             ])
         } catch {
             // TipKit configuration failure should not block app launch.
-            print("[TipKit] configure failed: \(error)")
+            AppLog.error("[TipKit] configure failed: \(error)", category: .main)
         }
     }
 

--- a/Meomun/Meomun/App/MeomunApp.swift
+++ b/Meomun/Meomun/App/MeomunApp.swift
@@ -7,10 +7,27 @@
 
 import SwiftUI
 import SwiftData
+import TipKit
 
 @main
 struct MeomunApp: App {
     var meomunModelContainer: ModelContainer = AppDataConfig.makeContainer()
+
+    init() {
+        do {
+            #if DEBUG
+            // Uncomment while testing tips if they don't appear due to stored display history.
+            try Tips.resetDatastore()
+            #endif
+
+            try Tips.configure([
+                .displayFrequency(.monthly)
+            ])
+        } catch {
+            // TipKit configuration failure should not block app launch.
+            print("[TipKit] configure failed: \(error)")
+        }
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/Meomun/Meomun/Presentation/DesignSystem/Foundation/Constants.swift
+++ b/Meomun/Meomun/Presentation/DesignSystem/Foundation/Constants.swift
@@ -24,6 +24,9 @@ enum MMCornerRadius {
 }
 
 enum MMLayout {
+    /// 네비게이션 툴 아래 컴포넌트를 올릴 때 사용하는 top offset
+    static let belowNavigationToolbarOffset: CGFloat = 70
+
     /// 탭바 위에 컴포넌트를 올릴 때 사용하는 bottom offset (탭바 + 여유 공간)
     static let aboveTabBarOffset: CGFloat = 90
 

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/MapPlaceConceptTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/MapPlaceConceptTipView.swift
@@ -13,6 +13,7 @@ struct MapPlaceConceptTipView: View {
         TipView(MapPlaceConceptTip())
             .padding(.top, 12)
             .padding(.horizontal, 16)
+            .shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 6)
     }
 }
 
@@ -20,15 +21,11 @@ struct MapPlaceConceptTip: Tip {
     @Parameter static var isReady: Bool = false
 
     var title: Text {
-        Text("지도에 남긴 메세지를 찾아보세요!")
+        Text("지도에서 남긴 메시지를 확인해요.")
     }
 
     var message: Text? {
-        Text("메세지를 탭하면 그 장소에 남겨진 메세지를 모아볼 수 있어요.")
-    }
-
-    var image: Image? {
-        Image(systemName: "mappin.and.ellipse")
+        Text("메시지를 탭하면 그 장소에 남겨진 메시지를 모아볼 수 있어요.")
     }
 
     var rules: [Rule] {

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/MapPlaceConceptTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/MapPlaceConceptTipView.swift
@@ -1,0 +1,37 @@
+//
+//  MapPlaceConceptTipView.swift
+//  Meomun
+//
+//  Created by hoon on 2/3/26.
+//
+
+import SwiftUI
+import TipKit
+
+struct MapPlaceConceptTipView: View {
+    var body: some View {
+        TipView(MapPlaceConceptTip())
+            .padding(.top, 12)
+            .padding(.horizontal, 16)
+    }
+}
+
+struct MapPlaceConceptTip: Tip {
+    @Parameter static var isReady: Bool = false
+
+    var title: Text {
+        Text("지도에 남긴 메세지를 찾아보세요!")
+    }
+
+    var message: Text? {
+        Text("메세지를 탭하면 그 장소에 남겨진 메시지를 모아볼 수 있어요.")
+    }
+
+    var image: Image? {
+        Image(systemName: "mappin.and.ellipse")
+    }
+
+    var rules: [Rule] {
+        #Rule(Self.$isReady) { $0 == true }
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Map/Component/MapPlaceConceptTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/Component/MapPlaceConceptTipView.swift
@@ -24,7 +24,7 @@ struct MapPlaceConceptTip: Tip {
     }
 
     var message: Text? {
-        Text("메세지를 탭하면 그 장소에 남겨진 메시지를 모아볼 수 있어요.")
+        Text("메세지를 탭하면 그 장소에 남겨진 메세지를 모아볼 수 있어요.")
     }
 
     var image: Image? {

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TipKit
 
 fileprivate enum Constants {
     static let navigationTitle = "머문"
@@ -49,6 +50,10 @@ struct MapView: View {
             .overlay(alignment: .bottomTrailing) {
                 writeButton
                     .padding(.bottom, MMLayout.tabBarBottomOffset)
+            }
+            .overlay(alignment: .top) {
+                MapPlaceConceptTipView()
+                    .padding(.top, MMLayout.belowNavigationToolbarOffset)
             }
             .overlay(alignment: .bottom) {
                 if !store.state.carouselItems.isEmpty {
@@ -117,6 +122,7 @@ struct MapView: View {
                 setTabBarHidden(false)
                 setNavBarHidden(false)
                 locationProvider.startContinuous()
+                MapPlaceConceptTip.isReady = true
             }
             .onDisappear {
                 send(.onDisappear)

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerConfirmDisabledTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerConfirmDisabledTipView.swift
@@ -1,0 +1,43 @@
+//
+//  MessageComposerConfirmDisabledTipView.swift
+//  Meomun
+//
+//  Created by hoon on 2/3/26.
+//
+
+import SwiftUI
+import TipKit
+
+struct MessageComposerConfirmDisabledTipView: View {
+    var body: some View {
+        TipView(MessageComposerConfirmDisabledTip(), arrowEdge: .bottom)
+            .padding(.top, 4)
+            .padding(.horizontal, 4)
+    }
+}
+
+struct MessageComposerConfirmDisabledTip: Tip {
+    @Parameter static var isReady: Bool = false
+    @Parameter static var shouldShow: Bool = false
+    @Parameter static var hasStartedTyping: Bool = false
+
+    var title: Text {
+        Text("‘확인’이 아직 비활성화예요")
+    }
+
+    var message: Text? {
+        Text("메시지를 입력하면 ‘확인’ 버튼이 활성화돼요.")
+    }
+
+    var image: Image? {
+        Image(systemName: "checkmark.circle")
+    }
+
+    var rules: [Rule] {
+        [
+            #Rule(Self.$isReady) { $0 == true },
+            #Rule(Self.$shouldShow) { $0 == true },
+            #Rule(Self.$hasStartedTyping) { $0 == false }
+        ]
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerConfirmDisabledTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerConfirmDisabledTipView.swift
@@ -22,15 +22,11 @@ struct MessageComposerConfirmDisabledTip: Tip {
     @Parameter static var hasStartedTyping: Bool = false
 
     var title: Text {
-        Text("‘확인’이 아직 비활성화예요")
+        Text("장소 태그를 입력해 보세요.")
     }
 
     var message: Text? {
         Text("메시지를 입력하면 ‘확인’ 버튼이 활성화돼요.")
-    }
-
-    var image: Image? {
-        Image(systemName: "checkmark.circle")
     }
 
     var rules: [Rule] {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerPlaceConceptTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerPlaceConceptTipView.swift
@@ -20,15 +20,11 @@ struct MessageComposerPlaceConceptTip: Tip {
     @Parameter static var isReady: Bool = false
 
     var title: Text {
-        Text("이 말은 ‘지금 머문 곳’에 남아요")
+        Text("이 메세지는 ‘지금 머문 곳’에 남아요")
     }
 
     var message: Text? {
-        Text("작성한 메시지는 현재 위치(머문 장소)와 함께 저장돼요. 장소를 선택하면 더 정확해져요.")
-    }
-
-    var image: Image? {
-        Image(systemName: "mappin.and.ellipse")
+        Text("작성한 메시지는 현재 위치와 함께 저장돼요.")
     }
 
     var rules: [Rule] {

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerPlaceConceptTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/Component/MessageComposerPlaceConceptTipView.swift
@@ -1,0 +1,39 @@
+//
+//  MessageComposerPlaceConceptTipView.swift
+//  Meomun
+//
+//  Created by hoon on 2/3/26.
+//
+
+import SwiftUI
+import TipKit
+
+struct MessageComposerPlaceConceptTipView: View {
+    var body: some View {
+        TipView(MessageComposerPlaceConceptTip(), arrowEdge: .top)
+            .padding(.top, 4)
+            .padding(.horizontal, 4)
+    }
+}
+
+struct MessageComposerPlaceConceptTip: Tip {
+    @Parameter static var isReady: Bool = false
+
+    var title: Text {
+        Text("이 말은 ‘지금 머문 곳’에 남아요")
+    }
+
+    var message: Text? {
+        Text("작성한 메시지는 현재 위치(머문 장소)와 함께 저장돼요. 장소를 선택하면 더 정확해져요.")
+    }
+
+    var image: Image? {
+        Image(systemName: "mappin.and.ellipse")
+    }
+
+    var rules: [Rule] {
+        [
+            #Rule(Self.$isReady) { $0 == true }
+        ]
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TipKit
 
 fileprivate enum Constants {
     static let navigationTitle = "잠시 남겨놓기"
@@ -118,13 +119,11 @@ struct MessageComposerView: View {
 private extension MessageComposerView {
     var content: some View {
         VStack(alignment: .center, spacing: 12) {
-            MessageComposerPlaceConceptTipView()
             Spacer()
             editorSection
             Spacer(minLength: 0)
             placeSection
             Spacer(minLength: 0)
-            MessageComposerConfirmDisabledTipView()
             confirmSection
             Spacer(minLength: 0)
         }
@@ -148,6 +147,7 @@ private extension MessageComposerView {
             .font(.headline.bold())
             .foregroundStyle(Color.mmSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .popoverTip(MessageComposerPlaceConceptTip())
 
         MessageTextEditor(
             text: messageBinding,

--- a/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
+++ b/Meomun/Meomun/Presentation/Scene/MessageCompose/MessageComposerView.swift
@@ -74,7 +74,11 @@ struct MessageComposerView: View {
                 }
             }
         )
-        .onAppear { send(.onAppear) }
+        .onAppear {
+            send(.onAppear)
+            MessageComposerPlaceConceptTip.isReady = true
+            syncConfirmDisabledTipState(isFirstAppear: true)
+        }
         .onChange(of: store.state.alert) { _, newValue in
             guard presentedAlert != newValue else { return }
             presentedAlert = newValue
@@ -87,6 +91,15 @@ struct MessageComposerView: View {
             if show {
                 presentedAlert = emptyLocationAlert
             }
+        }
+        .onChange(of: store.state.message) { _, newValue in
+            if newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                MessageComposerConfirmDisabledTip.hasStartedTyping = true
+            }
+            syncConfirmDisabledTipState()
+        }
+        .onChange(of: store.state.isConfirmEnabled) { _, _ in
+            syncConfirmDisabledTipState()
         }
         .fullScreenCover(isPresented: isPlaceSearchPresentedBinding) {
             placeSearchOverlay
@@ -105,11 +118,13 @@ struct MessageComposerView: View {
 private extension MessageComposerView {
     var content: some View {
         VStack(alignment: .center, spacing: 12) {
+            MessageComposerPlaceConceptTipView()
             Spacer()
             editorSection
             Spacer(minLength: 0)
             placeSection
             Spacer(minLength: 0)
+            MessageComposerConfirmDisabledTipView()
             confirmSection
             Spacer(minLength: 0)
         }
@@ -190,6 +205,21 @@ private extension MessageComposerView {
             status: store.state.confirmStatus,
             message: mmLoadingOverlayMessage
         )
+    }
+}
+
+// MARK: TipKit helpers
+private extension MessageComposerView {
+    func syncConfirmDisabledTipState(isFirstAppear: Bool = false) {
+        if isFirstAppear {
+            MessageComposerConfirmDisabledTip.isReady = true
+        }
+
+        let isMessageEmpty = store.state.message
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+
+        MessageComposerConfirmDisabledTip.shouldShow = (store.state.isConfirmEnabled == false) && isMessageEmpty
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/Component/SpaceOnboardingTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/Component/SpaceOnboardingTipView.swift
@@ -1,0 +1,37 @@
+//
+//  SpaceOnboardingTipView.swift
+//  Meomun
+//
+//  Created by hoon on 2/3/26.
+//
+
+import SwiftUI
+import TipKit
+
+struct SpaceOnboardingTipView: View {
+    var body: some View {
+        TipView(SpaceIntroTip(), arrowEdge: .top)
+            .padding(.top, 12)
+            .padding(.horizontal, 16)
+    }
+}
+
+struct SpaceIntroTip: Tip {
+    @Parameter static var isReady: Bool = false
+
+    var title: Text {
+        Text("이 공간은 무엇인가요?")
+    }
+
+    var message: Text? {
+        Text("이 장소에 남겨진 메시지 버블이 떠다니는 3D 공간이에요. 드래그로 둘러보고, 버블을 탭해 선택할 수 있어요.")
+    }
+
+    var image: Image? {
+        Image(systemName: "sparkles")
+    }
+
+    var rules: [Rule] {
+        #Rule(Self.$isReady) { $0 == true }
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Space/Component/SpaceOnboardingTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/Component/SpaceOnboardingTipView.swift
@@ -13,6 +13,7 @@ struct SpaceOnboardingTipView: View {
         TipView(SpaceIntroTip(), arrowEdge: .top)
             .padding(.top, 12)
             .padding(.horizontal, 16)
+            .shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 6)
     }
 }
 
@@ -20,15 +21,11 @@ struct SpaceIntroTip: Tip {
     @Parameter static var isReady: Bool = false
 
     var title: Text {
-        Text("이 공간은 무엇인가요?")
+        Text("나만의 공간을 확인해요.")
     }
 
     var message: Text? {
         Text("이 장소에 남겨진 메시지 버블이 떠다니는 3D 공간이에요. 드래그로 둘러보고, 버블을 탭해 선택할 수 있어요.")
-    }
-
-    var image: Image? {
-        Image(systemName: "sparkles")
     }
 
     var rules: [Rule] {

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -41,7 +41,7 @@ struct SpaceView: View {
             .gesture(
                 DragGesture()
                     .onChanged { spaceController.handleDrag($0.translation) }
-                    .onEnded { _ in spaceController.endDrag()}
+                    .onEnded { _ in spaceController.endDrag() }
             )
             .gesture(
                 TapGesture().onEnded { send(.selectMessage(nil)) }
@@ -86,12 +86,16 @@ struct SpaceView: View {
         .overlay(alignment: .bottom) {
             selectionBar
         }
+        .overlay(alignment: .top) {
+            SpaceOnboardingTipView()
+        }
         .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.selectedMessageID)
         .allowsHitTesting(store.state.deleteStatus == .idle)
         .navigationBarBackButtonHidden()
         .toolbar { toolbarContent }
         .task {
             await store.send(intent: .onAppear(placeID: place.id))
+            SpaceIntroTip.isReady = true
         }
         .onChange(of: store.state.messages.map(\.id)) {
             spaceController.sync(messages: store.state.messages)

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionTipView.swift
@@ -1,0 +1,43 @@
+//
+//  TimelineSectionTipView.swift
+//  Meomun
+//
+//  Created by hoon on 2/3/26.
+//
+
+import SwiftUI
+import TipKit
+
+struct TimelineSectionTipView: View {
+    var body: some View {
+        TipView(TimelineSectionTip(), arrowEdge: .top)
+            .padding(.top, 12)
+            .padding(.horizontal, 16)
+    }
+}
+
+struct TimelineSectionTip: Tip {
+    @Parameter static var isReady: Bool = false
+    @Parameter static var hasContent: Bool = false
+    @Parameter static var isEditing: Bool = false
+
+    var title: Text {
+        Text("월별 기록을 한눈에")
+    }
+
+    var message: Text? {
+        Text("상단의 월(YYYY.MM) 옆 흔전 따라가기를 탭하면 해당 달의 기록을 모아볼 수 있어요.")
+    }
+
+    var image: Image? {
+        Image(systemName: "calendar")
+    }
+
+    var rules: [Rule] {
+        [
+            #Rule(Self.$isReady) { $0 == true },
+            #Rule(Self.$hasContent) { $0 == true },
+            #Rule(Self.$isEditing) { $0 == false }
+        ]
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionTipView.swift
@@ -13,6 +13,7 @@ struct TimelineSectionTipView: View {
         TipView(TimelineSectionTip(), arrowEdge: .top)
             .padding(.top, 12)
             .padding(.horizontal, 16)
+            .shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 6)
     }
 }
 
@@ -22,15 +23,11 @@ struct TimelineSectionTip: Tip {
     @Parameter static var isEditing: Bool = false
 
     var title: Text {
-        Text("월별 기록을 한눈에")
+        Text("시간 순으로 기록을 확인해요.")
     }
 
     var message: Text? {
-        Text("상단의 월(YYYY.MM) 옆 흔적 따라가기를 탭하면 해당 달의 기록을 모아볼 수 있어요.")
-    }
-
-    var image: Image? {
-        Image(systemName: "calendar")
+        Text("흔적 따라가기를 탭하면 해당 달의 기록을 모아볼 수 있어요.")
     }
 
     var rules: [Rule] {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionTipView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/Component/TimelineSectionTipView.swift
@@ -26,7 +26,7 @@ struct TimelineSectionTip: Tip {
     }
 
     var message: Text? {
-        Text("상단의 월(YYYY.MM) 옆 흔전 따라가기를 탭하면 해당 달의 기록을 모아볼 수 있어요.")
+        Text("상단의 월(YYYY.MM) 옆 흔적 따라가기를 탭하면 해당 달의 기록을 모아볼 수 있어요.")
     }
 
     var image: Image? {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -285,8 +285,9 @@ extension TimelineListView {
 }
 
 // MARK: - TipKit state sync
+
 private extension TimelineListView {
-    private func syncTimelineTipState(isFirstAppear: Bool = false) {
+    func syncTimelineTipState(isFirstAppear: Bool = false) {
         if isFirstAppear {
             TimelineSectionTip.isReady = true
         }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -40,6 +40,8 @@ struct TimelineListView: View {
 
     var body: some View {
         VStack {
+            TimelineSectionTipView()
+
             if !store.state.messages.isEmpty {
                 content
             } else {
@@ -52,7 +54,10 @@ struct TimelineListView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .onAppear { send(.onAppear) }
+        .onAppear {
+            send(.onAppear)
+            syncTimelineTipState(isFirstAppear: true)
+        }
         // 상위(MainTabStore) 편집 상태 변화 → 내부 store에 반영
         .onChange(of: isEditing) { _, newValue in
             send(.syncEditing(newValue))
@@ -61,6 +66,10 @@ struct TimelineListView: View {
         .onChange(of: store.state.isEditing) { _, newValue in
             setTabBarHidden(shouldHideTabBar)
             onEditingChanged(newValue)
+            syncTimelineTipState()
+        }
+        .onChange(of: store.state.messages.isEmpty) { _, _ in
+            syncTimelineTipState()
         }
         .onChange(of: store.state.deleteStatus) { _, _ in
             setTabBarHidden(shouldHideTabBar)
@@ -272,6 +281,18 @@ extension TimelineListView {
         static let full = Configuration(showsFooter: true, showsEditButton: true)
 
         static let bottomSheet = Configuration(showsFooter: false, showsEditButton: false)
+    }
+}
+
+// MARK: - TipKit state sync
+private extension TimelineListView {
+    private func syncTimelineTipState(isFirstAppear: Bool = false) {
+        if isFirstAppear {
+            TimelineSectionTip.isReady = true
+        }
+
+        TimelineSectionTip.hasContent = (store.state.messages.isEmpty == false)
+        TimelineSectionTip.isEditing = store.state.isEditing
     }
 }
 


### PR DESCRIPTION
## 배경

- closed #38 

## 작업 요약

- [x] 지도
- [x] 타임라인
- [x] 공간
- [x] 메세지 작성

## 작업 내용

## 배경

머문 앱은 Map → Space → Composer처럼 화면 전환이 빠르고, 화면마다 “사용자가 이해해야 하는 핵심 개념”이 다릅니다.

기존에는 기능이 있어도 사용자가 **발견하지 못하거나**, “왜 이런 동작을 하지?” 같은 **정신 모델(mental model) 부재**로 인해 사용성이 떨어질 수 있었습니다.

이를 해결하기 위해 Apple의 **TipKit**을 사용해, 화면 진입 시점에 **가볍게 1회 안내되는 온보딩 경험**을 제공하도록 개선했습니다.

## TipKit이란?

TipKit은 iOS에서 “사용자에게 기능/개념을 안내하는 작은 팁 UI”를 만들기 위한 프레임워크입니다.

### TipKit의 핵심 특징

- **조건 기반 노출(Rules)**: 특정 상태일 때만 팁을 보여줄 수 있음
- **노출 빈도 제어**: 전역 설정으로 “너무 자주 뜨지 않게” 관리 가능
- **사용자 경험 중심**: 사용자가 팁을 확인(닫음)하면 이후 재노출을 줄이는 방향으로 동작

> 중요한 포인트: TipKit은 “화면에 띄우는 배너”가 아니라, 학습을 돕는 UX 장치입니다.
> 
> 
> 따라서 “많이 보여주는 것”이 목표가 아니라 “필요한 순간에만, 최소 개수로”가 원칙입니다.
> 

## 우리 프로젝트에서의 사용 원칙

이번 PR에서 TipKit을 적용하면서 팀 내에서 동일한 방식으로 확장할 수 있도록, 다음 원칙을 정했습니다.

### 1) 화면당 Tip은 기본 1개(최대 2개)

- 사용자가 “팁이 자주 뜬다”를 느끼면 오히려 피로도가 증가함
- **각 화면에서 ‘가장 중요한 개념’ 1개만 안내**하는 것을 기본으로 함

### 2) Tip의 노출 여부는 `Rule`로 제어한다

- Tip은 언제나 떠있으면 안 되고, “보여야 하는 조건”이 명확해야 함
- 예: 화면 진입 후 준비가 끝났을 때만 eligible 하도록 `isReady`를 사용

### 3) View(화면)와 Tip 정의를 분리한다

- 화면 코드가 TipKit 구현으로 오염되지 않도록 분리
- **Tip 정의(struct Tip)** + **TipView 래퍼(View)** 를 세트로 관리

## 대표 예시: Map 화면 Tip (장소 개념 안내)

### 1) 왜 Map 화면에서 Tip이 필요한가?

Map 화면에서는 마커/클러스터가 시각적으로 직관적이지만, 사용자가 처음에는 다음처럼 오해하기 쉽습니다.

- ❌ “지도에 보이는 버블 = 메시지 1개”
- ✅ 실제 모델: “지도에 보이는 마커 = ‘장소’, 탭하면 그 장소의 메시지를 모아봄”

따라서 Map 화면에서는 조작법(드래그/줌)이 아니라, **‘장소 단위’ 개념**을 1회 안내하는 것이 가장 효과적이라고 판단했습니다.

## 구현 방식 요약 (팀 공통 패턴)

### A. Tip 정의 (rules 포함)

```swift
private struct MapPlaceConceptTip: Tip {
		@Parameterstaticvar isReady: Bool = false

		var title:Text {
				Text("지도에 남긴 메세지를 찾아보세요!")
    }

		var message:Text? {
				Text("마커를 탭하면 그 장소에 남겨진 메시지를 모아볼 수 있어요.")
    }

		var image:Image? {
				Image(systemName:"mappin.and.ellipse")
    }

		var rules: [Rule] {
        [ #Rule(Self.$isReady) {$0 == true } ]
    }
}
```

### B. TipView 래퍼 (UI 배치/패딩 담당)

```swift
privatestructMapPlaceConceptTipView:View {
		var body:someView {
				TipView(MapPlaceConceptTip(), arrowEdge: .top)
            .padding(.top,12)
            .padding(.horizontal,16)
    }
}
```

### C. 화면에서 활성화(eligibility) 트리거 설정

MapView 진입 시점에 “이제 팁이 떠도 된다”를 명시합니다.

```swift
.onAppear {
		...
		MapPlaceConceptTip.isReady = true
}
```

---

## UI 배치 주의사항 (Navigation/TabBar와의 겹침)

Map 화면은 상단에 네비게이션 툴이 존재하므로 단순 `.overlay(alignment: .top)` 사용 시 팁이 가려질 수 있습니다.

따라서 이번 구현에서는 **safeAreaInset**을 사용해 “네비게이션 바 아래”에 배치했습니다.

```swift
.safeAreaInset(edge: .top, spacing: 0) {
		MapPlaceConceptTipView()
        .padding(.top, 8)
}
```

> 이 패턴은 상단 시스템 UI와 충돌하는 화면(Map 등)에서 우선 적용합니다.
>

## 스크린샷

https://github.com/user-attachments/assets/8e938c35-a94a-4b5f-84b2-67da1eebc604

https://github.com/user-attachments/assets/8afada93-b37a-4584-91a8-49cf7301ef1c

## 리뷰 요구사항

팁 뷰가 화면에 너무 많이 표시될 때 화면의 가독성이 많이 떨어진다고 느껴졌습니다.
그래서 최대한 하나의 팁 뷰로 전체 페이지를 설명하려고 하는데 이 때 설명 메세지로 어떤 문구가 적당할 지 말씀해 주시면 좋을 것 같습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지도·메시지 작성·공간·타임라인 등 주요 화면에 TipKit 기반의 상황별 가이드 팁이 추가되어 초보 사용자가 기능을 더 쉽게 이해할 수 있습니다.
  * 팁 노출 타이밍과 상태 동기화가 도입되어 적절한 시점에 안내가 표시됩니다.

* **Chores**
  * 레이아웃 상수와 로깅 범주가 정리되어 UI 위치 제어와 디버깅 안정성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->