### PR TITLE
타임라인 페이지네이션 구현

### DIFF
--- a/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
+++ b/Meomun/Meomun/Data/Storage/SwiftData/MessageSwiftDataStorage.swift
@@ -78,12 +78,11 @@ actor MessageSwiftDataStorage: MessageStorage {
     func fetchRecent(page: Int, pageSize: Int) async throws -> [MessageResponseDTO] {
         let context = makeContext()
 
-        let descriptor = FetchDescriptor<MessageModel>(
+        var descriptor = FetchDescriptor<MessageModel>(
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
-        // TODO: 페이지네이션 구현 후 살리기
-        // descriptor.fetchLimit = pageSize
-        // descriptor.fetchOffset = max(0, page) * pageSize
+        descriptor.fetchLimit = pageSize
+        descriptor.fetchOffset = max(0, page) * pageSize
 
         let results = try context.fetch(descriptor)
         return results.map { $0.toDTO() }

--- a/Meomun/Meomun/Domain/UseCase/FetchRecentMessagesUseCase.swift
+++ b/Meomun/Meomun/Domain/UseCase/FetchRecentMessagesUseCase.swift
@@ -16,7 +16,7 @@ final class FetchRecentMessagesUseCaseImpl: FetchRecentMessagesUseCase {
         self.repository = repository
     }
 
-    func execute(page: Int, pageSize: Int = 100) async throws -> [Message] {
+    func execute(page: Int, pageSize: Int) async throws -> [Message] {
         try await repository.fetchRecentMessages(page: page, pageSize: pageSize)
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -20,6 +20,7 @@ final class TimelineListStore: Store {
         var enableFetching: Bool = true
         var pagination: Pagination = .init()
         var isRefreshing: Bool = false
+        var toastMessage: String?
 
         var messages: [Message] = []
         var selectedSection: YearMonth?
@@ -38,6 +39,7 @@ final class TimelineListStore: Store {
         case onAppear
         case requestNextPage
         case refresh
+        case setToast(String?)
 
         case requestDeleteSelectedMessages          // 편집 모드 -> 삭제
         case confirmDeleteSelectedMessages          // 얼럿 - 삭제
@@ -59,6 +61,7 @@ final class TimelineListStore: Store {
 
         case setRefreshing(Bool)
         case prependMessages([Message])
+        case setToastMessage(String?)
 
         case setSelectedSection(YearMonth?)
 
@@ -105,6 +108,12 @@ final class TimelineListStore: Store {
 
         case .refresh:
             return performRefresh()
+
+        case .setToast(let message):
+            return .init { continuation in
+                continuation.yield(.setToastMessage(message))
+                continuation.finish()
+            }
 
         case .tapSection(let section):
             return .init { continuation in
@@ -215,6 +224,9 @@ final class TimelineListStore: Store {
 
             newState.messages = onlyNewMessages + newState.messages
             cleanupSectionIfNeeded(&newState)
+
+        case .setToastMessage(let message):
+            newState.toastMessage = message
 
         case .toggleMessageSelection(let messageID):
             if newState.selectedMessageIDs.contains(messageID) {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -355,4 +355,8 @@ extension TimelineListStore {
     func messages(in section: YearMonth) -> [Message] {
         state.sections.first(where: { $0.key == section })?.value ?? []
     }
+
+    func isLastMessage(messageId: MessageID) -> Bool {
+        state.messages.last?.id == messageId
+    }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -9,7 +9,17 @@ import Foundation
 import Combine
 
 final class TimelineListStore: Store {
+    struct Pagination: Equatable {
+        var currentPage: Int = 0
+        var pageSize: Int = 10
+        var isLoadingNextPage: Bool = false
+        var hasReachedEndPage: Bool = false
+    }
+
     struct State: Equatable {
+        var enableFetching: Bool = true
+        var pagination: Pagination = .init()
+
         var messages: [Message] = []
         var selectedSection: YearMonth?
         var isEditing: Bool = false
@@ -26,6 +36,7 @@ final class TimelineListStore: Store {
     enum Intent: Equatable {
         case onAppear
         case setMessages([Message])
+
         case requestDeleteSelectedMessages          // 편집 모드 -> 삭제
         case confirmDeleteSelectedMessages          // 얼럿 - 삭제
         case requestDeleteMessage(MessageID)        // 단일 메시지 삭제 요청 (메뉴 버튼)
@@ -63,7 +74,11 @@ final class TimelineListStore: Store {
         deleteMessagesUseCase: DeleteMessagesUseCase,
         onDeletedMessages: @escaping (Set<MessageID>) -> Void = { _ in }
     ) {
-        self.state = State(messages: initialMessages)
+        if initialMessages.isEmpty {
+            self.state = .init()
+        } else {
+            self.state = .init(enableFetching: false, messages: initialMessages)
+        }
         self.fetchRecentMessagesUseCase = fetchRecentMessagesUseCase
         self.deleteMessagesUseCase = deleteMessagesUseCase
         self.onDeletedMessages = onDeletedMessages

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -57,14 +57,20 @@ final class TimelineListStore: Store {
         case setReachedEndPage(Bool)
         case addMessages([Message])
 
+        case setRefreshing(Bool)
+        case prependMessages([Message])
+
+        case setSelectedSection(YearMonth?)
+
+        case setEditing(Bool)
         case toggleMessageSelection(MessageID)
         case clearSelectedMessageIDs
-        case setSelectedSection(YearMonth?)
-        case setEditing(Bool)
+
+        case setDeleteStatus(LoadingStatus)
         case deleteMessages(Set<MessageID>)
+
         case showDeleteAlert(MMAlertModel)
         case hideAlert
-        case setDeleteStatus(LoadingStatus)
     }
 
     @Published var state: State

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -35,6 +35,7 @@ final class TimelineListStore: Store {
 
     enum Intent: Equatable {
         case onAppear
+        case requestNextPage
 
         case requestDeleteSelectedMessages          // 편집 모드 -> 삭제
         case confirmDeleteSelectedMessages          // 얼럿 - 삭제
@@ -49,7 +50,11 @@ final class TimelineListStore: Store {
     }
 
     enum Action {
+        case setCurrentPage(Int)
+        case setLoadingNextPage(Bool)
+        case setReachedEndPage(Bool)
         case addMessages([Message])
+
         case toggleMessageSelection(MessageID)
         case clearSelectedMessageIDs
         case setSelectedSection(YearMonth?)
@@ -85,24 +90,10 @@ final class TimelineListStore: Store {
     func action(intent: Intent) -> AsyncStream<Action> {
         switch intent {
         case .onAppear:
-            return .init { continuation in
-                guard state.messages.isEmpty else {
-                    continuation.finish()
-                    return
-                }
+            return loadPage(page: 0)
 
-                Task {
-                    do {
-                        // TODO: 페이지네이션 구현
-                        let messages = try await fetchRecentMessagesUseCase.execute(page: 0, pageSize: 10)
-                        continuation.yield(.addMessages(messages))
-                    } catch {
-                        AppLog.error(error.localizedDescription, category: .store, error: error)
-                    }
-
-                    continuation.finish()
-                }
-            }
+        case .requestNextPage:
+            return loadPage(page: state.pagination.currentPage)
 
         case .tapSection(let section):
             return .init { continuation in
@@ -191,9 +182,18 @@ final class TimelineListStore: Store {
         var newState = state
 
         switch action {
+        case .setCurrentPage(let page):
+            newState.pagination.currentPage = page
+
+        case .setLoadingNextPage(let isLoadingNextPage):
+            newState.pagination.isLoadingNextPage = isLoadingNextPage
+
+        case .setReachedEndPage(let hasReachedEndPage):
+            newState.pagination.hasReachedEndPage = hasReachedEndPage
 
         case .addMessages(let messages):
             newState.messages += messages
+            cleanupSectionIfNeeded(&newState)
 
         case .toggleMessageSelection(let messageID):
             if newState.selectedMessageIDs.contains(messageID) {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -35,7 +35,6 @@ final class TimelineListStore: Store {
 
     enum Intent: Equatable {
         case onAppear
-        case setMessages([Message])
 
         case requestDeleteSelectedMessages          // 편집 모드 -> 삭제
         case confirmDeleteSelectedMessages          // 얼럿 - 삭제
@@ -50,7 +49,6 @@ final class TimelineListStore: Store {
     }
 
     enum Action {
-        case setMessages([Message])
         case addMessages([Message])
         case toggleMessageSelection(MessageID)
         case clearSelectedMessageIDs
@@ -186,12 +184,6 @@ final class TimelineListStore: Store {
                 continuation.yield(.hideAlert)
                 continuation.finish()
             }
-
-        case .setMessages(let messages):
-            return .init { continuation in
-                continuation.yield(.setMessages(messages))
-                continuation.finish()
-            }
         }
     }
 
@@ -199,9 +191,6 @@ final class TimelineListStore: Store {
         var newState = state
 
         switch action {
-        case .setMessages(let messages):
-            newState.messages = messages
-            cleanupSectionIfNeeded(&newState)
 
         case .addMessages(let messages):
             newState.messages += messages

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -19,6 +19,7 @@ final class TimelineListStore: Store {
     struct State: Equatable {
         var enableFetching: Bool = true
         var pagination: Pagination = .init()
+        var isRefreshing: Bool = false
 
         var messages: [Message] = []
         var selectedSection: YearMonth?
@@ -36,6 +37,7 @@ final class TimelineListStore: Store {
     enum Intent: Equatable {
         case onAppear
         case requestNextPage
+        case refresh
 
         case requestDeleteSelectedMessages          // 편집 모드 -> 삭제
         case confirmDeleteSelectedMessages          // 얼럿 - 삭제
@@ -90,10 +92,13 @@ final class TimelineListStore: Store {
     func action(intent: Intent) -> AsyncStream<Action> {
         switch intent {
         case .onAppear:
-            return loadPage(page: 0)
+            return state.messages.isEmpty ? loadPage(page: 0) : performRefresh()
 
         case .requestNextPage:
             return loadPage(page: state.pagination.currentPage)
+
+        case .refresh:
+            return performRefresh()
 
         case .tapSection(let section):
             return .init { continuation in
@@ -195,6 +200,16 @@ final class TimelineListStore: Store {
             newState.messages += messages
             cleanupSectionIfNeeded(&newState)
 
+        case .setRefreshing(let isRefreshing):
+            newState.isRefreshing = isRefreshing
+
+        case .prependMessages(let messages):
+            let existingIDs = Set(newState.messages.map(\.id))
+            let onlyNewMessages = messages.filter { !existingIDs.contains($0.id) }
+
+            newState.messages = onlyNewMessages + newState.messages
+            cleanupSectionIfNeeded(&newState)
+
         case .toggleMessageSelection(let messageID):
             if newState.selectedMessageIDs.contains(messageID) {
                 // 이미 선택되어 있으면 -> 선택 해제
@@ -289,6 +304,12 @@ private extension TimelineListStore {
                 return
             }
 
+            // 4. 새로고침 상태 확인
+            guard state.isRefreshing == false else {
+                continuation.finish()
+                return
+            }
+
             continuation.yield(.setLoadingNextPage(true))
 
             let pageSize = state.pagination.pageSize
@@ -311,6 +332,45 @@ private extension TimelineListStore {
                     if newMessages.count < pageSize {
                         continuation.yield(.setReachedEndPage(true))
                     }
+                } catch {
+                    AppLog.error(error.localizedDescription, category: .store, error: error)
+                }
+            }
+        }
+    }
+
+    func performRefresh() -> AsyncStream<Action> {
+        AsyncStream { continuation in
+            guard state.enableFetching else {
+                continuation.finish()
+                return
+            }
+
+            guard state.isRefreshing == false else {
+                continuation.finish()
+                return
+            }
+
+            guard state.pagination.isLoadingNextPage == false else {
+                continuation.finish()
+                return
+            }
+
+            continuation.yield(.setRefreshing(true))
+            let pageSize = state.pagination.pageSize
+
+            Task {
+                defer {
+                    continuation.yield(.setRefreshing(false))
+                    continuation.finish()
+                }
+
+                do {
+                    let latestMessages = try await fetchRecentMessagesUseCase.execute(
+                        page: 0,
+                        pageSize: pageSize
+                    )
+                    continuation.yield(.prependMessages(latestMessages))
                 } catch {
                     AppLog.error(error.localizedDescription, category: .store, error: error)
                 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListStore.swift
@@ -268,6 +268,55 @@ private extension TimelineListStore {
             }
         }
     }
+
+    func loadPage(page: Int) -> AsyncStream<Action> {
+        AsyncStream { continuation in
+            // 1. fetching 조건 확인
+            guard state.enableFetching else {
+                continuation.finish()
+                return
+            }
+
+            // 2. 마지막 페이지 도달 여부 확인
+            guard state.pagination.hasReachedEndPage == false else {
+                continuation.finish()
+                return
+            }
+
+            // 3. 페이지 로딩 상태 확인
+            guard state.pagination.isLoadingNextPage == false else {
+                continuation.finish()
+                return
+            }
+
+            continuation.yield(.setLoadingNextPage(true))
+
+            let pageSize = state.pagination.pageSize
+
+            Task {
+                defer {
+                    continuation.yield(.setLoadingNextPage(false))
+                    continuation.finish()
+                }
+
+                do {
+                    let newMessages = try await fetchRecentMessagesUseCase.execute(
+                        page: page,
+                        pageSize: pageSize
+                    )
+
+                    continuation.yield(.addMessages(newMessages))
+                    continuation.yield(.setCurrentPage(page + 1))
+
+                    if newMessages.count < pageSize {
+                        continuation.yield(.setReachedEndPage(true))
+                    }
+                } catch {
+                    AppLog.error(error.localizedDescription, category: .store, error: error)
+                }
+            }
+        }
+    }
 }
 
 // MARK: Section Helper

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -16,6 +16,7 @@ fileprivate enum Constants {
 struct TimelineListView: View {
     @Environment(\.setTabBarHidden) private var setTabBarHidden
     @StateObject private var store: TimelineListStore
+
     private let configuration: Configuration
     private let onBecameEmpty: () -> Void
 
@@ -151,6 +152,9 @@ private extension TimelineListView {
             if configuration.showsFooter && !store.state.messages.isEmpty {
                 footer
             }
+        }
+        .refreshable {
+            await triggerRefreshIfPossible()
         }
     }
 
@@ -290,6 +294,24 @@ private extension TimelineListView {
         case .success: return Constants.deleteSuccessMessage
         case .fail: return Constants.deleteFailMessage
         case .idle: return ""
+        }
+    }
+
+    @MainActor
+    private func triggerRefreshIfPossible() async {
+        guard store.state.isEditing == false else { return }
+        guard store.state.deleteStatus == .idle else { return }
+        guard store.state.isRefreshing == false else { return }
+        guard store.state.pagination.isLoadingNextPage == false else { return }
+
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        await store.send(intent: .refresh)
+
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.state.isRefreshing, Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(50))
         }
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -307,6 +307,7 @@ private extension TimelineListView {
 
     @MainActor
     private func triggerRefreshIfPossible() async {
+        guard store.state.enableFetching == true else { return }
         guard store.state.isEditing == false else { return }
         guard store.state.deleteStatus == .idle else { return }
         guard store.state.isRefreshing == false else { return }
@@ -322,6 +323,7 @@ private extension TimelineListView {
             try? await Task.sleep(for: .milliseconds(100))
         }
 
+        guard store.state.isRefreshing == false else { return }
         await store.send(intent: .setToast("새로고침 완료!"))
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -105,6 +105,7 @@ struct TimelineListView: View {
                     .transition(.identity) // 애니메이션 없음
             }
         }
+        .mmToast(toastBinding, bottomPadding: 0)
     }
 }
 
@@ -297,6 +298,13 @@ private extension TimelineListView {
         }
     }
 
+    var toastBinding: Binding<String?> {
+        Binding(
+            get: { store.state.toastMessage },
+            set: { send(.setToast($0)) }
+        )
+    }
+
     @MainActor
     private func triggerRefreshIfPossible() async {
         guard store.state.isEditing == false else { return }
@@ -311,8 +319,10 @@ private extension TimelineListView {
 
         let deadline = Date().addingTimeInterval(2.0)
         while store.state.isRefreshing, Date() < deadline {
-            try? await Task.sleep(for: .milliseconds(50))
+            try? await Task.sleep(for: .milliseconds(100))
         }
+
+        await store.send(intent: .setToast("새로고침 완료!"))
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -128,6 +128,11 @@ private extension TimelineListView {
                                     }
                                 }
                             )
+                            .onAppear {
+                                if !store.state.enableFetching { return }
+                                guard store.isLastMessage(messageId: message.id) else { return }
+                                send(.requestNextPage)
+                            }
                             .animation(.spring(response: 0.3, dampingFraction: 0.6), value: store.state.isEditing)
                             .onTapGesture { send(.tapMessage(message.id)) }
                         }
@@ -163,19 +168,32 @@ private extension TimelineListView {
         }
     }
 
+    @ViewBuilder
     var footer: some View {
         VStack(spacing: 10) {
-            Image(systemName: "book.pages")
-                .font(.system(size: 26, weight: .regular))
-                .foregroundStyle(Color.mmSecondary)
+            if store.state.pagination.hasReachedEndPage {
+                Image(systemName: "book.pages")
+                    .font(.system(size: 26, weight: .regular))
+                    .foregroundStyle(Color.mmSecondary)
 
-            Text("END OF RECORDS")
-                .font(.footnote.weight(.semibold))
-                .tracking(1.2)
-                .foregroundStyle(Color.mmSecondary)
+                Text("END OF RECORDS")
+                    .font(.footnote.weight(.semibold))
+                    .tracking(1.2)
+                    .foregroundStyle(Color.mmSecondary)
+
+            } else if store.state.pagination.isLoadingNextPage {
+                ProgressView()
+                    .padding(.top, 8)
+
+                Text("내 기록 불러오는 중...")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color.mmSecondary)
+            } else {
+                EmptyView()
+            }
         }
         .frame(maxWidth: .infinity)
-        .padding(.bottom, 100)
+        .padding(.bottom, 30)
     }
 
     var selectionBar: some View {

--- a/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Timeline/TimelineListView.swift
@@ -122,11 +122,7 @@ private extension TimelineListView {
                                 showTopLine: index != 0,
                                 showBottomLine: index != monthMessages.count - 1,
                                 selectionState: store.selectionState(for: message),
-                                onDelete: {
-                                    Task {
-                                        await store.send(intent: .requestDeleteMessage(message.id))
-                                    }
-                                }
+                                onDelete: { send(.requestDeleteMessage(message.id)) }
                             )
                             .onAppear {
                                 if !store.state.enableFetching { return }


### PR DESCRIPTION
## 배경
- closed #364 

## 작업 요약
- [x] Timeline 페이지네이션 구현
- [x] Timeline 당겨서 새로고침 구현

## 작업 내용
### Timeline 페이지네이션 구현

#### 페이지네이션 흐름

```mermaid
sequenceDiagram
autonumber
participant V as TimelineListView
participant S as TimelineListStore
participant U as FetchRecentMessagesUseCase

V->>S: send(.onAppear)
alt messages empty
  S->>S: loadPage(page=0)
else messages exist
  S->>S: performRefresh()
end

loop 마지막 row onAppear
  V->>S: send(.requestNextPage)
  alt guard 통과(enableFetching & !hasReachedEnd & !isLoadingNextPage & !isRefreshing)
    S-->>S: Action.setLoadingNextPage(true)
    S->>U: execute(page=currentPage, pageSize)
    U-->>S: [Message]
    S-->>S: Action.addMessages
    S-->>S: Action.setCurrentPage(page+1)
    alt newMessages.count < pageSize
      S-->>S: Action.setReachedEndPage(true)
    end
    S-->>S: Action.setLoadingNextPage(false)
  else guard 실패
    S-->>S: finish (no-op)
  end
end
````

#### Store 페이지네이션 상태 구조화

```swift
    struct Pagination: Equatable {
        var currentPage: Int = 0
        var pageSize: Int = 10
        var isLoadingNextPage: Bool = false
        var hasReachedEndPage: Bool = false
    }
```

#### TimelineListView: `.refreshable` 트리거 + 종료 타이밍 제어
- SwiftUI의 `.refreshable`은 내부적으로 “async 작업이 끝날 때까지” 스피너를 유지
- 하지만 `await store.send(intent:)`는 **intent dispatch 완료**이지, **실제 refresh side effect 완료**가 아님
-> View에서 “최대 2초” 폴링으로 isRefreshing 종료를 기다리는 형태로 마무리

```swift
    await store.send(intent: .refresh)
    
    let deadline = Date().addingTimeInterval(2.0)
        while store.state.isRefreshing,Date() < deadline {
            try? await Task.sleep(for: .milliseconds(100))
    }
```

**추가 UX**

- refresh 시작 시 햅틱 발생:

```swift
    let generator=UIImpactFeedbackGenerator(style: .medium)
    generator.impactOccurred()
```

### Timeline 당겨서 새로고침 구현

#### 새로고침 흐름

```mermaid
sequenceDiagram
autonumber
participant V as TimelineListView
participant S as TimelineListStore
participant U as FetchRecentMessagesUseCase

V->>V: .refreshable { triggerRefreshIfPossible() }
alt guard 통과(!isEditing & deleteStatus==idle & !isRefreshing & !isLoadingNextPage)
  V->>S: send(.refresh)
  S-->>S: Action.setRefreshing(true)
  S->>U: execute(page=0, pageSize)
  U-->>S: latestMessages
  S-->>S: Action.prependMessages(중복ID 제거 후 앞에 추가)
  S-->>S: Action.setRefreshing(false)

  V->>V: while isRefreshing { sleep } (최대 2초)
  V-->>S: send(.setToast("새로고침 완료!"))  %% 현재 구현 기준(토스트를 뷰에서 쏘는 경우)
else guard 실패
  V-->>V: return (no-op)
end
```

#### 새로고침 조건 정리

`triggerRefreshIfPossible()`에서 다음 조건을 모두 통과해야 refresh 가능:

- 편집 중이면 refresh 금지
- 삭제 overlay 상태면 금지
- 이미 refresh 중이면 금지
- 페이지네이션 로딩 중이면 금지

```swift
    guard store.state.isEditing == false else {return }
    guard store.state.deleteStatus == .idle else {return }
    guard store.state.isRefreshing == false else {return }
    guard store.state.pagination.isLoadingNextPage == false else {return }
```

### Store: 페이지 로딩 - 새로고침 상호 배타 처리
- 동시에 두 네트워크 호출이 겹치면서 messages가 꼬이는 상황을 방지하기 위해 상호 배타처리 진행

- `loadPage(page:)`에서 아래 가드를 추가해서 **리프레시 중 페이지네이션을 막음**:

```swift
    guard state.isRefreshing == false else {
        continuation.finish()
        return
    }
```

- `performRefresh()`에서도 반대로 **다음 페이지 로딩 중이면 refresh를 막음**:

```swift
    guard state.pagination.isLoadingNextPage == false else {
        continuation.finish()
        return
    }
```

## 스크린샷

- pageSize = 10개로 맞추고 찍었어용

https://github.com/user-attachments/assets/95aea598-b5e8-490c-b6fc-3f961e48b8a5

- 새로고침 토스트


https://github.com/user-attachments/assets/64ba7602-957d-4969-8ea5-211cb44a9d79


## 리뷰 요구사항


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 무한 스크롤(페이지네이션) 활성화로 이전 메시지 자동 로드
  * Pull-to-Refresh 지원 및 새로고침 완료 토스트 알림 추가
  * 마지막 메시지 판단 API 공개

* **개선**
  * 로딩/페이징 상태 표시 강화(다음 페이지 로딩, 끝 도달 등)
  * 리스트 행 진입 시 다음 페이지 자동 호출 및 푸터 패딩 축소
  * 푸터 렌더링 및 토스트 연동 개선

* **버그 수정**
  * 페이지 크기 파라미터를 필수로 하여 페이징 동작 명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->