### PR TITLE
공간 메시지 배치 로직 개선

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/BubblePlacer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/BubblePlacer.swift
@@ -44,4 +44,54 @@ struct BubblePlacer {
         // 실패 시 fallback
         return SIMD3<Float>(minimumDistanceFromViewAxis, yRange.upperBound, -radiusRange.upperBound)
     }
+
+    func randomNonOverlappingPositionInsideHemisphere(
+        radiusRange: ClosedRange<Float>,
+        yRange: ClosedRange<Float>,
+        minimumDistanceFromCenter: Float,
+        minimumDistanceFromViewAxis: Float,
+        maxAttempts: Int,
+        requiredRadius: Float,
+        existing: [BubblePlacementRecord],
+        spacing: Float
+    ) -> SIMD3<Float> {
+        for _ in 0..<maxAttempts {
+            let candidate = randomPositionInsideHemisphere(
+                radiusRange: radiusRange,
+                yRange: yRange,
+                minimumDistanceFromCenter: minimumDistanceFromCenter,
+                minimumDistanceFromViewAxis: minimumDistanceFromViewAxis,
+                maxAttempts: 1
+            )
+
+            if isValid(candidate: candidate, requiredRadius: requiredRadius, existing: existing, spacing: spacing) {
+                return candidate
+            }
+        }
+
+        // 실패 시 fallback: 그냥 기본 배치
+        return randomPositionInsideHemisphere(
+            radiusRange: radiusRange,
+            yRange: yRange,
+            minimumDistanceFromCenter: minimumDistanceFromCenter,
+            minimumDistanceFromViewAxis: minimumDistanceFromViewAxis,
+            maxAttempts: maxAttempts
+        )
+    }
+
+    private func isValid(
+        candidate: SIMD3<Float>,
+        requiredRadius: Float,
+        existing: [BubblePlacementRecord],
+        spacing: Float
+    ) -> Bool {
+        for record in existing {
+            let minDistance = requiredRadius + record.radius + spacing
+            let distanceSquared = simd_distance_squared(candidate, record.position)
+            if distanceSquared < (minDistance * minDistance) {
+                return false
+            }
+        }
+        return true
+    }
 }

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/BubbleCollisionRadiusCalculator.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/BubbleCollisionRadiusCalculator.swift
@@ -1,0 +1,16 @@
+//
+//  BubbleCollisionRadiusCalculator.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 2/5/26.
+//
+
+import RealityKit
+
+enum BubbleCollisionRadiusCalculator {
+    static func radius(fromBoxSize boxSize: SIMD3<Float>, safetyMultiplier: Float = 1.05) -> Float {
+        // box half diagonal
+        let halfDiagonal = simd_length(boxSize) * 0.5
+        return halfDiagonal * safetyMultiplier
+    }
+}

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/BubblePlacementRecord.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/BubblePlacementRecord.swift
@@ -1,0 +1,14 @@
+//
+//  BubblePlacementRecord.swift
+//  Meomun
+//
+//  Created by Hayeon Park on 2/5/26.
+//
+
+import RealityKit
+
+struct BubblePlacementRecord: Equatable {
+    let messageID: MessageID
+    var position: SIMD3<Float>
+    var radius: Float
+}

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/SpaceBubblePolicy.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/SpaceBubblePolicy.swift
@@ -1,5 +1,5 @@
 //
-//  SpaceBubbleLayoutPolicy.swift
+//  SpaceBubblePolicy.swift
 //  Meomun
 //
 //  Created by Hayeon Park on 1/29/26.
@@ -26,4 +26,19 @@ enum SpaceBubbleLayoutPolicy {
     static let recentThresholdSeconds: TimeInterval = 20 * 60
 
     static let textAlignY: Float = 0.04
+}
+
+/// 공간 메시지 버블 공간 배치 정책을 정의하는 모델입니다.
+enum SpaceBubblePositionPolicy {
+    static let minRadius: Float = 1.4
+    static let maxRadius: Float = 1.7
+
+    static let minXPosition: Float = -0.25
+    static let maxXPosition: Float = 0.25
+    static let minYPosition: Float = 0.7
+    static let maxYPosition: Float = 1.2
+
+    static let minDistanceFromCenter: Float = 1.3
+    static let minDistanceFromViewAxis: Float = 0.25
+    static let maxAttempts: Int = 60
 }

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/SpaceBubblePolicy.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/Model/SpaceBubblePolicy.swift
@@ -41,4 +41,6 @@ enum SpaceBubblePositionPolicy {
     static let minDistanceFromCenter: Float = 1.3
     static let minDistanceFromViewAxis: Float = 0.25
     static let maxAttempts: Int = 60
+
+    static let minBubbleSpacing: Float = 0.3
 }

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/RotationCamera.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/RotationCamera.swift
@@ -23,6 +23,8 @@ final class RotationCamera {
     /// 회전 감도 조절을 위한 상수 (값이 클수록 빠르게 회전)
     private let sensitivity: Float
 
+    var position: SIMD3<Float> { camera.position }
+
     init(
         position: SIMD3<Float>,
         rotateSensitivity: Float

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
@@ -33,11 +33,11 @@ final class SpaceMessageBubbleFactory {
 
         // 버블 랜덤 배치
         bubbleRootEntity.position = bubblePlacer.randomPositionInsideHemisphere(
-            radiusRange: 1.4...1.7,
-            yRange: 0.7...1.2,
-            minimumDistanceFromCenter: 1.3,
-            minimumDistanceFromViewAxis: 0.25,
-            maxAttempts: 60
+            radiusRange: SpaceBubblePositionPolicy.minRadius...SpaceBubblePositionPolicy.maxRadius,
+            yRange: SpaceBubblePositionPolicy.minYPosition...SpaceBubblePositionPolicy.maxYPosition,
+            minimumDistanceFromCenter: SpaceBubblePositionPolicy.minDistanceFromCenter,
+            minimumDistanceFromViewAxis: SpaceBubblePositionPolicy.minDistanceFromViewAxis,
+            maxAttempts: SpaceBubblePositionPolicy.maxAttempts
         )
 
         // messageBubbleTemplateEntity 복제

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
@@ -18,8 +18,6 @@ final class SpaceMessageBubbleFactory {
         templateEntity: Entity,
         position: SIMD3<Float>
     ) -> Entity {
-        let bubblePlacer = BubblePlacer()
-
         // 텍스트 가공 및 entity 생성
         let contentText = TextArranger.arrangeText(message.content)
         let dateText = message.displayDateString(using: AppConfig.timestampFormatter)

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleFactory.swift
@@ -13,7 +13,11 @@ final class SpaceMessageBubbleFactory {
     enum BubbleTextType { case content, date }
     enum TextAlignment { case center, above, below }
 
-    func makeBubbleRoot(message: Message, templateEntity: Entity) -> Entity {
+    func makeBubbleRoot(
+        message: Message,
+        templateEntity: Entity,
+        position: SIMD3<Float>
+    ) -> Entity {
         let bubblePlacer = BubblePlacer()
 
         // 텍스트 가공 및 entity 생성
@@ -32,13 +36,7 @@ final class SpaceMessageBubbleFactory {
         bubbleRootEntity.components.set(BillboardComponent())
 
         // 버블 랜덤 배치
-        bubbleRootEntity.position = bubblePlacer.randomPositionInsideHemisphere(
-            radiusRange: SpaceBubblePositionPolicy.minRadius...SpaceBubblePositionPolicy.maxRadius,
-            yRange: SpaceBubblePositionPolicy.minYPosition...SpaceBubblePositionPolicy.maxYPosition,
-            minimumDistanceFromCenter: SpaceBubblePositionPolicy.minDistanceFromCenter,
-            minimumDistanceFromViewAxis: SpaceBubblePositionPolicy.minDistanceFromViewAxis,
-            maxAttempts: SpaceBubblePositionPolicy.maxAttempts
-        )
+        bubbleRootEntity.position = position
 
         // messageBubbleTemplateEntity 복제
         let bubbleBubbleEntity = templateEntity.clone(recursive: true)
@@ -76,6 +74,14 @@ final class SpaceMessageBubbleFactory {
         placeTextInFrontOfBubble(dateTextEntity, bubbleEntity: bubbleBubbleEntity)
 
         return bubbleRootEntity
+    }
+
+    func bubbleUniformMultiplier(message: Message, templateEntity: Entity) -> Float {
+        let contentText = TextArranger.arrangeText(message.content)
+        let contentTextEntity = makeTextEntity(contentText, type: .content)
+        alignTextEntity(contentTextEntity, align: .center)
+
+        return uniformMultiplierToFitText(textEntity: contentTextEntity, bubbleEntity: templateEntity)
     }
 
     private func bubbleBaseSize(entity: Entity) -> SIMD2<Float> {

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleSynchronizer.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/SpaceMessageBubbleSynchronizer.swift
@@ -10,6 +10,7 @@ import RealityKit
 @MainActor
 final class SpaceMessageBubbleSynchronizer {
     private var bubbleRootByID: [MessageID: Entity] = [:]
+    private var placementByID: [MessageID: BubblePlacementRecord] = [:]
     private let factory: SpaceMessageBubbleFactory
 
     init(factory: SpaceMessageBubbleFactory = .init()) {
@@ -41,17 +42,48 @@ final class SpaceMessageBubbleSynchronizer {
         root: Entity,
         templateEntity: Entity
     ) {
+        let bubblePlacer = BubblePlacer()
+
+        let multiplier = factory.bubbleUniformMultiplier(message: message, templateEntity: templateEntity)
+        let finalScale = SpaceBubbleLayoutPolicy.baseBubbleScale * multiplier
+
+        let collisionBoxSize = SIMD3<Float>(
+            repeating: 0.3 * finalScale / SpaceBubbleLayoutPolicy.baseBubbleScale
+        )
+        let radius = BubbleCollisionRadiusCalculator.radius(fromBoxSize: collisionBoxSize)
+
+        let existing = Array(placementByID.values)
+
+        let position = bubblePlacer.randomNonOverlappingPositionInsideHemisphere(
+            radiusRange: SpaceBubblePositionPolicy.minRadius...SpaceBubblePositionPolicy.maxRadius,
+            yRange: SpaceBubblePositionPolicy.minYPosition...SpaceBubblePositionPolicy.maxYPosition,
+            minimumDistanceFromCenter: SpaceBubblePositionPolicy.minDistanceFromCenter,
+            minimumDistanceFromViewAxis: SpaceBubblePositionPolicy.minDistanceFromViewAxis,
+            maxAttempts: SpaceBubblePositionPolicy.maxAttempts,
+            requiredRadius: radius,
+            existing: existing,
+            spacing: SpaceBubblePositionPolicy.minBubbleSpacing
+        )
+
         let bubbleRoot = factory.makeBubbleRoot(
             message: message,
-            templateEntity: templateEntity
+            templateEntity: templateEntity,
+            position: position
         )
+
         root.addChild(bubbleRoot)
         bubbleRootByID[message.id] = bubbleRoot
+        placementByID[message.id] = BubblePlacementRecord(
+            messageID: message.id,
+            position: position,
+            radius: radius
+        )
     }
 
     private func removeMessage(id: MessageID) {
         guard let entity = bubbleRootByID[id] else { return }
         entity.removeFromParent()
         bubbleRootByID[id] = nil
+        placementByID[id] = nil
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Space/PortalLoadingOverlay.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/PortalLoadingOverlay.swift
@@ -104,6 +104,10 @@ struct PortalLoadingOverlay: View {
                         Text(title)
                             .font(.callout.weight(.semibold))
                             .foregroundStyle(.mmSecondary)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: portalSize * 0.95)
 
                         Text("공간을 구성 중…")
                             .font(.caption)

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -160,8 +160,23 @@ extension SpaceController {
                 messages: snapshot,
                 templateEntity: template
             )
-        }
 
+            bringOneBubbleIntoView(root: root)
+        }
+    }
+
+    private func bringOneBubbleIntoView(root: Entity) {
+        let bubbleEntities = root.allDescendants().filter { $0.name.hasPrefix("MessageBubble-") }
+        guard let first = bubbleEntities.first else { return }
+
+        // 카메라 앞에 랜덤 배치
+        let distance = SpaceBubblePositionPolicy.minDistanceFromCenter
+        let x = Float.random(in: SpaceBubblePositionPolicy.minXPosition...SpaceBubblePositionPolicy.maxXPosition)
+        AppLog.debug("\(x)", category: .space)
+        let y = Float.random(in: SpaceBubblePositionPolicy.minYPosition...SpaceBubblePositionPolicy.maxYPosition)
+        let z = rotationCamera.position.z - distance
+
+        first.position = SIMD3<Float>(x, y, z)
     }
 }
 
@@ -181,5 +196,18 @@ extension SpaceController {
 
     func endDrag() {
         rotationCamera.endDrag()
+    }
+}
+
+private extension Entity {
+    func allDescendants() -> [Entity] {
+        var descendants: [Entity] = []
+
+        for child in children {
+            descendants.append(child)
+            descendants.append(contentsOf: child.allDescendants())
+        }
+
+        return descendants
     }
 }

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -172,7 +172,6 @@ extension SpaceController {
         // 카메라 앞에 랜덤 배치
         let distance = SpaceBubblePositionPolicy.minDistanceFromCenter
         let x = Float.random(in: SpaceBubblePositionPolicy.minXPosition...SpaceBubblePositionPolicy.maxXPosition)
-        AppLog.debug("\(x)", category: .space)
         let y = Float.random(in: SpaceBubblePositionPolicy.minYPosition...SpaceBubblePositionPolicy.maxYPosition)
         let z = rotationCamera.position.z - distance
 


### PR DESCRIPTION
## 배경
- closed #229

## 작업 요약
- [x]  공간 진입 시, 시야에 메시지 최소 한 개 보이게 하기
- [x]  공간 메시지 로직 변경
- [x]  공간 이름 길때 축약(...)되는 이슈 수정

## 작업 내용

### 공간 진입 시, 시야에 메시지 최소 한 개 보이게 하기

```swift
private func bringOneBubbleIntoView(root: Entity) {
    let bubbleEntities = root.allDescendants().filter { $0.name.hasPrefix("MessageBubble-") }
    guard let first = bubbleEntities.first else { return }

    let distance = SpaceBubblePositionPolicy.minDistanceFromCenter
    let x = Float.random(in: SpaceBubblePositionPolicy.minXPosition...SpaceBubblePositionPolicy.maxXPosition)
    let y = Float.random(in: SpaceBubblePositionPolicy.minYPosition...SpaceBubblePositionPolicy.maxYPosition)
    let z = rotationCamera.position.z - distance

    first.position = SIMD3<Float>(x, y, z)
}
```

- 카메라 앞쪽(시야 중심 근처)에 버블 1개를 재배치하여 진입 UX를 보장
- 동기화 직후 `bringOneBubbleIntoView(root:)`로 1개를 전면에 두는 방식 구현

---

### 공간 메시지 배치 로직 변경

#### 핵심 문제
- `BubblePlacer`가 단일 포인트만 랜덤 샘플링하고, `SpaceMessageBubbleFactory` 내부에서 position을 결정하므로, 이미 배치된 버블들과의 충돌/겹침을 제어할 수 없음

#### 설계
- Non-overlap 배치(거부 샘플링)
  - 새 후보 위치가 기존 버블들과 최소 거리를 만족할 때만 채택
  - 버블 크기가 메시지 길이에 따라 달라지므로 버블별 radius를 둠

#### 책임 분리
- Factory: “버블을 생성(모델/텍스트/스케일 계산)”
- Synchronizer(또는 Coordinator): “position 결정(기존 배치 고려)”

(1) BubblePlacer에 non-overlap 배치 함수 추가

```swift
func randomNonOverlappingPositionInsideHemisphere(
    radiusRange: ClosedRange<Float>,
    yRange: ClosedRange<Float>,
    minimumDistanceFromCenter: Float,
    minimumDistanceFromViewAxis: Float,
    maxAttempts: Int,
    requiredRadius: Float,
    existing: [BubblePlacementRecord],
    margin: Float
) -> SIMD3<Float> { ... }
```

(2) 배치 상태 저장 구조

```swift
struct BubblePlacementRecord {
    let messageID: MessageID
    var position: SIMD3<Float>
    var radius: Float
}
```

(3) Synchronizer가 position을 결정 후 Factory에 주입

```swift
let position = bubblePlacer.randomNonOverlappingPositionInsideHemisphere(...)
let bubbleRoot = factory.makeBubbleRoot(
    message: message,
    templateEntity: templateEntity,
    position: position
)
```

---

### 공간 이름 다 표시하기

```swift
Text(title)
    .font(.callout.weight(.semibold))
    .foregroundStyle(.mmSecondary)
    .multilineTextAlignment(.center)      // 가운데 정렬
    .lineLimit(nil)                       // 줄 수 제한 해제
    .fixedSize(horizontal: false, vertical: true) // 세로로 늘어나며 전체 표시
    .frame(maxWidth: portalSize * 0.95)   // 너무 길 때도 적절히 줄바꿈되도록 폭 제한
```

- 멀티라인 허용 + 줄바꿈 정책 + 프레임 확장 으로 해소

## 스크린샷

- 공간 진입 시 메시지 항시 보이게 하기

https://github.com/user-attachments/assets/5321e050-06c3-40f6-a7c0-d5576984e80c


- 공간 이름 길 때 축약 되는 이슈 수정

https://github.com/user-attachments/assets/ca9b9c32-f62e-4130-bbd0-f8bc4d7f1d58


## 리뷰 요구사항
- 로직만으로 랜덤 배치시 겹치는 문제를 해소해보려고 했는데 잘 안됐어요.. ㅠ
- 그나마 메시지 버블이 투명해서 메시지가 보이긴 하는데 근본적인 해결은 아니라서 고민이네여..
- 메시지 갯수가 10개 이하일때는 거의 안겹치는데 15개 넘어가니까 많이 겹치네요..;

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 3D 공간에서 버블 간 겹침을 피하는 비중복 배치 로직 추가
  * 박스 크기 기반 충돌 반경 계산으로 배치 안정성 향상
  * 메시지별 배치 추적으로 일관된 위치 유지 및 제거 시 정리 보장
  * 텍스트에 맞춘 버블 스케일 보정 기능 추가

* **UI 개선**
  * 로딩 오버레이 제목 텍스트 중앙 정렬, 멀티라인 및 유연한 높이 지원

* **카메라 및 시점**
  * 한 개 버블을 카메라 앞으로 재배치해 가시성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->