### PR TITLE
지도 화면에서 메시지 fetch 방식 수정

### DIFF
--- a/Meomun/Meomun/Domain/Entity/BoundingBox.swift
+++ b/Meomun/Meomun/Domain/Entity/BoundingBox.swift
@@ -27,4 +27,11 @@ extension BoundingBox {
             maxLongitude: maxLongitude + longitudePadding
         )
     }
+
+    func contains(_ other: BoundingBox) -> Bool {
+        minLatitude <= other.minLatitude &&
+        maxLatitude >= other.maxLatitude &&
+        minLongitude <= other.minLongitude &&
+        maxLongitude >= other.maxLongitude
+    }
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -294,6 +294,13 @@ final class MapStore: Store {
             bounds: bounds,
             snapshot: snapshot
         ) {
+            getNearbyMessageTask?.cancel()
+            getNearbyMessageTask = nil
+
+            if state.isLoading {
+                continuation.yield(.setLoading(false))
+            }
+
             continuation.finish()
             return
         }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -84,8 +84,11 @@ final class MapStore: Store {
     @Published var state: State
 
     private let debounceInterval: UInt64 = 300_000_000 // 300ms
+    private let prefetchRatio: Double = 0.2
 
     private var getNearbyMessageTask: Task<Void, Never>?
+    private var lastFetchBounds: BoundingBox?
+    private var lastFetchZoomBucket: Int?
     private let getNearbyMessagesUseCase: GetNearbyMessagesUseCase
     private let networkMonitor: NetworkMonitoring
 
@@ -133,6 +136,8 @@ final class MapStore: Store {
             case .onDisappear:
                 self.getNearbyMessageTask?.cancel()
                 self.getNearbyMessageTask = nil
+                self.lastFetchBounds = nil
+                self.lastFetchZoomBucket = nil
                 continuation.yield(.setLoading(false))
 
             case .userDidInteractMap:
@@ -148,6 +153,7 @@ final class MapStore: Store {
                 self.getNearbyMessages(
                     at: coordinate,
                     bounds: boundingBox,
+                    snapshot: snapshot,
                     continuation: continuation
                 )
                 return
@@ -159,6 +165,7 @@ final class MapStore: Store {
                 self.getNearbyMessages(
                     at: coordinate,
                     bounds: boundingBox,
+                    snapshot: snapshot,
                     continuation: continuation
                 )
                 return
@@ -174,10 +181,13 @@ final class MapStore: Store {
                     continuation.finish()
                     return
                 }
+                let snapshot = state.cameraSnapshot ?? .init(coordinate: coordinate)
 
                 self.getNearbyMessages(
                     at: coordinate,
                     bounds: bounds,
+                    snapshot: snapshot,
+                    force: true,
                     continuation: continuation
                 )
                 return
@@ -275,8 +285,19 @@ final class MapStore: Store {
     private func getNearbyMessages(
         at coordinate: Coordinate,
         bounds: BoundingBox,
+        snapshot: MapCameraSnapshot,
+        force: Bool = false,
         continuation: AsyncStream<Action>.Continuation
     ) {
+        if !force, shouldSkipFetch(
+            coordinate: coordinate,
+            bounds: bounds,
+            snapshot: snapshot
+        ) {
+            continuation.finish()
+            return
+        }
+
         getNearbyMessageTask?.cancel()
 
         getNearbyMessageTask = Task { [weak self] in
@@ -308,6 +329,9 @@ final class MapStore: Store {
 
                 guard !Task.isCancelled else { return }
 
+                self.lastFetchBounds = bounds.expanded(by: self.prefetchRatio)
+                self.lastFetchZoomBucket = self.zoomBucket(from: snapshot)
+
                 continuation.yield(.setMessages(messages))
                 continuation.yield(.setError(""))
             } catch is CancellationError {
@@ -323,6 +347,28 @@ final class MapStore: Store {
 }
 
 private extension MapStore {
+    func shouldSkipFetch(
+        coordinate: Coordinate,
+        bounds: BoundingBox,
+        snapshot: MapCameraSnapshot
+    ) -> Bool {
+        guard let lastFetchBounds,
+              let lastFetchZoomBucket
+        else {
+            return false
+        }
+
+        if lastFetchZoomBucket != zoomBucket(from: snapshot) {
+            return false
+        }
+
+        return lastFetchBounds.contains(bounds)
+    }
+
+    func zoomBucket(from snapshot: MapCameraSnapshot) -> Int {
+        Int(floor(snapshot.zoom))
+    }
+
     /// 메시지 배열을 Place별로 그룹화하여 캐러셀 아이템 배열로 변환
     func groupMessagesByPlace(_ messages: [Message]) -> [PlaceCarouselDisplayModel] {
         var placeMessages: [Place: [Message]] = [:]

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -16,6 +16,7 @@ final class MapViewController: UIViewController {
 
     private var appLifecycleObservers: [NSObjectProtocol] = []
     private var isFollowingUser: Bool = true
+    private var tileCoverHelper: NMFTileCoverHelper?
 
     // MARK: - Animation Properties
 
@@ -126,6 +127,11 @@ final class MapViewController: UIViewController {
 
         // 카메라 delegate 등록
         naverMapView.mapView.addCameraDelegate(delegate: self)
+
+        // 타일 커버 헬퍼 등록 (타일 변경 시 fetch 트리거)
+        let tileCoverHelper = NMFTileCoverHelper(naverMapView.mapView)
+        tileCoverHelper.delegate = self
+        self.tileCoverHelper = tileCoverHelper
 
         // 앱 라이프사이클 옵저버 등록
         registerAppLifecycleObservers()
@@ -335,12 +341,6 @@ extension MapViewController: NMFMapViewCameraDelegate {
             onFirstMapIdle?()
         }
 
-        let center = mapView.cameraPosition.target
-        let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
-        let domainBounds = makeBoundingBox(from: mapView)
-        let snapshot = currentSnapshot(from: mapView)
-
-        onCameraIdle?(coordinate, domainBounds, snapshot)
         messageMarkerManager.updateClusterModeIfNeeded(
             zoomLevel: mapView.zoomLevel,
             mapView: mapViewAdapter
@@ -367,14 +367,6 @@ extension MapViewController: NMFMapViewCameraDelegate {
             onFollowRequested?()
             return
         }
-
-        // 카메라 중심 좌표 추출 및 콜백 호출
-        let center = mapView.cameraPosition.target
-        let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
-        let domainBounds = makeBoundingBox(from: mapView)
-        let snapshot = currentSnapshot(from: mapView)
-
-        onCameraChangedByLocation?(coordinate, domainBounds, snapshot)
     }
 
     private func makeBoundingBox(from mapView: NMFMapView) -> BoundingBox {
@@ -385,5 +377,22 @@ extension MapViewController: NMFMapViewCameraDelegate {
             minLongitude: nmfBounds.southWestLng,
             maxLongitude: nmfBounds.northEastLng
         )
+    }
+}
+
+// MARK: - NMFTileCoverHelperDelegate
+
+extension MapViewController: NMFTileCoverHelperDelegate {
+    func onTileChanged(_ addedTileIds: [NSNumber]?, removedTileIds: [NSNumber]?) {
+        let addedEmpty = addedTileIds?.isEmpty ?? true
+        let removedEmpty = removedTileIds?.isEmpty ?? true
+        guard !(addedEmpty && removedEmpty) else { return }
+
+        let center = naverMapView.mapView.cameraPosition.target
+        let coordinate = Coordinate(latitude: center.lat, longitude: center.lng)
+        let domainBounds = makeBoundingBox(from: naverMapView.mapView)
+        let snapshot = currentSnapshot(from: naverMapView.mapView)
+
+        onCameraIdle?(coordinate, domainBounds, snapshot)
     }
 }


### PR DESCRIPTION
## 배경

- closed #350 

## 작업 요약

- [x] fetch 트리거 변경
- [x] fetch 스킵 조건 강화

## 작업 내용

이번 PR은 **“맵 메시지 fetch 트리거를 카메라 이벤트 기반(Idle/Location)에서 ‘타일 커버 변화’ 기반으로 전환**하고, **이미 가져온 영역(bounds+zoom)에서는 fetch를 스킵**하도록 정책을 재정의한 작업입니다. 결과적으로 드래그/줌/위치 추적 등에서 발생하던 중복 fetch 시도를 줄이고, “의미 있는 뷰포트 변화”에서만 fetch가 일어나도록 구조를 단순화했습니다.

## **1. Fetch 트리거 정책 변경: 카메라 이벤트 → 타일 커버 변화로 통합**

### **배경**

기존에는 맵의 데이터 로딩(fetch)이 카메라 이벤트에 직접 연결되어 있어, 같은 사용자 동작에서 fetch가 중복되거나 빈번하게 발생할 여지가 있었습니다.

- 드래그/줌 이후 cameraDidIdle 시점마다 fetch
- 위치 추적(현위치 버튼/팔로우 등)으로 cameraChangedByLocation 시점마다 fetch
- 위 2개가 연속으로 발생하는 상황에서는 “사용자 입장에서는 1번 움직였는데 fetch 시도는 여러 번” 발생 가능

### **개선 방향**

- “뷰포트가 실질적으로 새 영역을 포함하기 시작했는지”에 더 가까운 신호로 **타일 커버 변화(Tile cover change)**를 사용
- SDK가 제공하는 NMFTileCoverHelperDelegate.onTileChanged를 **fetch 트리거 기준**으로 삼아, 뷰포트 전환/위치 이동을 하나의 기준으로 통합

### **구현**

- MapViewController에서 NMFTileCoverHelper를 생성하고 delegate로 등록
- 타일 커버가 바뀐 경우에만, 현재 카메라/뷰포트 정보를 만들어 기존 흐름(onCameraIdle → MapStore.cameraDidIdle)으로 전달
- 반대로, 카메라 delegate에서 fetch를 직접 트리거하던 코드는 제거

적용 포인트:

- MapViewController.swift에서
    - NMFTileCoverHelper 등록 및 onTileChanged에서만 fetch 트리거 전달
    - mapViewCameraIdle에서는 더 이상 fetch 트리거를 발생시키지 않음(클러스터 업데이트 등 UI 처리는 유지)
    - cameraDidChangeByReason(reason == location)에서도 fetch 트리거를 발생시키지 않음(팔로우 UX 처리만 유지)

### **기대 효과**

- 드래그/줌/위치 추적 등 다양한 원인으로 발생하는 카메라 변화 이벤트를 **“타일 커버 변화”라는 단일 기준으로 통합**
- 작은 이동/미세한 카메라 변화로 “실제로 커버 타일이 안 바뀌는” 경우에는 fetch 트리거 자체가 줄어듦
- “위치 이동 vs 뷰포트 전환”을 이벤트 종류가 아니라 **결과(커버 타일 변화)**로 판단하게 되어 정책이 단순해짐

## **2. Fetch 스킵 정책 정의: bounds + zoom 기반 캐시**

### **배경**

타일 변화가 fetch 트리거 기준이 되더라도, 실제로는 이전 fetch 결과가 **현재 화면을 이미 커버하는 경우**가 있습니다. 이런 경우에도 매번 fetch하면 비용이 증가합니다.

### **개선 방향**

- fetch 성공 시점의 “커버 가능한 범위”를 캐시하고,
- 다음 트리거가 와도 **이미 가져온 범위 안이면 fetch를 스킵**하는 정책을 둠
- 줌 변화는 화면 범위를 크게 바꾸므로, 줌 구간이 바뀌면 스킵하지 않도록 안전장치 추가

### **정책**

아래 조건을 모두 만족하면 fetch를 스킵합니다.

1. **줌 버킷이 동일**
    - zoomBucket = floor(snapshot.zoom)
    - lastFetchZoomBucket == zoomBucket
2. **현재 뷰포트 bounds가 “마지막 fetch 기준 prefetch bounds” 안에 포함**
- lastFetchBounds.contains(currentBounds) == true

여기서 lastFetchBounds는 fetch 성공 시 아래처럼 저장됩니다.

- lastFetchBounds = currentBounds.expanded(by: 0.2)
- 의미: “현재 화면 bounds보다 20% 확장된 범위를 이미 커버했다고 간주”

※ 참고: 이 20% 확장은 도메인 레이어의 prefetch 정책(근처 메시지 조회 시 bounds 확장)과 같은 방향으로 맞춘 캐시 정책입니다.

### **구현**

- BoundingBox.contains(_:) 추가: bounds 포함 판단을 명시적 유틸로 제공
- MapStore에 캐시 상태 저장 및 스킵 판단 로직 추가
    - lastFetchBounds, lastFetchZoomBucket
    - shouldSkipFetch(...)에서 위 정책대로 스킵 여부 결정

### **캐시 리셋 정책**

- 화면 이탈 시(onDisappear) 캐시를 초기화합니다.
    - in-flight task cancel
    - lastFetchBounds/zoomBucket 초기화
- 목적: 화면을 나갔다가 다시 들어왔을 때 “이전 상태 캐시”로 fetch가 억제되는 상황 방지

## **3. 강제 갱신 정책 유지: 사용자 액션 후에는 무조건 fetch**

### **배경**

메시지 작성/삭제 등 사용자 액션 직후에는 “지금 화면을 즉시 최신화”하는 것이 더 중요합니다. 이 경우 스킵 정책이 적용되면 UX가 흔들릴 수 있습니다.

### **정책**

- .refreshVisibleMessages는 **항상 fetch(force)** 합니다. (스킵 조건 무시)

### **구현**

- MapStore.refreshVisibleMessages 경로에서 force: true로 호출

## **4. 빈번 이벤트 제어 정책 유지: Task cancel + 300ms debounce**

### **배경**

타일 변화 이벤트도 연속적으로 발생할 수 있습니다(빠른 드래그/줌). 불필요한 중간 상태 fetch를 줄이기 위해 “마지막 상태 중심”으로 실행되도록 제어가 필요합니다.

### **정책**

- 새 fetch 요청이 들어오면 이전 fetch task를 cancel
- 300ms 디바운스 후 마지막 요청만 실행

### **구현**

- getNearbyMessageTask cancel + Task.sleep(300ms) 유지

---

## **5. 상황별로 보는 최종 동작 요약(“위치 이동/뷰포트 전환” 관점)**

### **A) 사용자 드래그/줌(뷰포트 전환)**

- **트리거**: 드래그/줌 결과로 커버 타일이 바뀌는 경우 onTileChanged 발생 → fetch 흐름 진입
- **스킵**: 동일 zoomBucket이고, 현재 bounds가 lastFetchBounds(=bounds+20%) 안이면 스킵

### **B) 현위치 버튼/팔로우 등(위치 이동)**

- **트리거**: 위치 이동 그 자체가 아니라, 그 결과로 커버 타일이 바뀌는 경우 onTileChanged 발생 → fetch 흐름 진입
- **스킵**: 동일 zoomBucket이고 bounds가 prefetch 범위 안이면 스킵

### **C) 작성/삭제 등 “즉시 최신화가 필요한 사용자 액션”**

- **트리거**: .refreshVisibleMessages
- **스킵 없음**: force fetch

## 리뷰 요구사항

fetch 트리거와 스킵 정책이 충분할 지 리뷰 주시면 감사하겠습니다.

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지도 타일 기반 갱신으로 카메라 변경 처리 방식 개선
  * 영역 포함 여부 판단 기능 추가(범위 비교)

* **성능 개선**
  * 근처 데이터 사전 패치(prefetch) 및 확대/축소 버킷 기반 캐싱 도입
  * 불필요한 중복 페칭 조기 중단으로 로딩 및 응답성 향상

* **리팩터**
  * 카메라/타일 이벤트 흐름 정리로 코드 흐름 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->