### PR TITLE
틸트 토글 기능 추가

### DIFF
--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -11,8 +11,10 @@ import Combine
 final class MapStore: Store {
     enum Intent {
         case onAppear(Coordinate)
-        case userLocationReady(Coordinate)
+        case userLocationReady(Coordinate?)
         case onDisappear
+
+        case tapTiltToggle
 
         case userDidInteractMap
         case followUserRequested
@@ -27,6 +29,10 @@ final class MapStore: Store {
         case dismissPlaceSearch
         case selectPlace(Place)
 
+        case tapCarouselPlace(Place)
+
+        case dismissSpace
+
         case dismissAddMessage
 
         case tapNoPlaceMarker([Message])
@@ -39,19 +45,26 @@ final class MapStore: Store {
     }
 
     enum Action {
+        case setHasAnyMessage(Bool)
+
         case setCameraCoordinate(Coordinate)
         case setFollowingUser(Bool)
         case setCameraMoveTarget(MapCameraMoveCommand?)
         case setCameraSnapshot(MapCameraSnapshot?)
         case setCameraBounds(BoundingBox)
+        case setDidApplyResolvedUserLocation(Bool)
 
         case presentPlaceSearch(Bool)
+
+        case setTiltOn(Bool)
 
         case setShowAddMessage(Bool)
         case setMessages([Message])
 
         case setSelectedNoPlace([Message])
         case setCarouselItems([PlaceCarouselDisplayModel])
+
+        case setSelectedPlaceForSpace(Place?)
 
         case setLoading(Bool)
         case setNetworkConnected(Bool)
@@ -75,6 +88,10 @@ final class MapStore: Store {
 
         var selectedNoPlaceMessages: [Message] = []
         var carouselItems: [PlaceCarouselDisplayModel] = []
+
+        var isTiltOn: Bool = true
+        var selectedPlaceForSpace: Place?
+        var didApplyResolvedUserLocation: Bool = false
 
         var isLoading: Bool = false
         var isNetworkConnected = true
@@ -128,6 +145,10 @@ final class MapStore: Store {
                 }
 
             case .userLocationReady(let coordinate):
+                guard state.didApplyResolvedUserLocation == false else { break }
+                guard let coordinate else { break }
+
+                continuation.yield(.setDidApplyResolvedUserLocation(true))
                 continuation.yield(.setCameraCoordinate(coordinate))
 
                 if state.isFollowingUser {
@@ -145,6 +166,9 @@ final class MapStore: Store {
                 self.lastFetchZoomBucket = nil
                 continuation.yield(.setLoading(false))
 
+            case .tapTiltToggle:
+                continuation.yield(.setTiltOn(!state.isTiltOn))
+
             case .userDidInteractMap:
                 continuation.yield(.setFollowingUser(false))
 
@@ -161,7 +185,7 @@ final class MapStore: Store {
                     snapshot: snapshot,
                     continuation: continuation
                 )
-                self.refreshHasAnyMessage()
+                self.refreshHasAnyMessage(continuation)
                 return
 
             case .cameraChangedByLocation(let coordinate, let boundingBox, let snapshot):
@@ -211,6 +235,13 @@ final class MapStore: Store {
                 )
                 continuation.yield(.setCameraMoveTarget(target))
 
+            case .tapCarouselPlace(let place):
+                continuation.yield(.setSelectedPlaceForSpace(place))
+                continuation.yield(.setCarouselItems([]))
+
+            case .dismissSpace:
+                continuation.yield(.setSelectedPlaceForSpace(nil))
+
             case .dismissAddMessage:
                 continuation.yield(.setShowAddMessage(false))
 
@@ -242,6 +273,9 @@ final class MapStore: Store {
         var newState = state
 
         switch action {
+        case .setHasAnyMessage(let value):
+            newState.hasAnyMessage = value
+
         case .setMessages(let messages):
             newState.messages = messages
 
@@ -257,11 +291,17 @@ final class MapStore: Store {
         case .setCameraBounds(let bounds):
             newState.cameraBounds = bounds
 
+        case .setDidApplyResolvedUserLocation(let value):
+            newState.didApplyResolvedUserLocation = value
+
         case .setCameraMoveTarget(let snapshot):
             newState.cameraMoveTarget = snapshot
 
         case .presentPlaceSearch(let isPresented):
             newState.isPlaceSearchPresented = isPresented
+
+        case .setTiltOn(let isTiltOn):
+            newState.isTiltOn = isTiltOn
 
         case .setShowAddMessage(let isShown):
             newState.isShowingAddMessage = isShown
@@ -271,6 +311,9 @@ final class MapStore: Store {
 
         case .setCarouselItems(let items):
             newState.carouselItems = items
+
+        case .setSelectedPlaceForSpace(let place):
+            newState.selectedPlaceForSpace = place
 
         case .setLoading(let isLoading):
             newState.isLoading = isLoading
@@ -358,13 +401,13 @@ final class MapStore: Store {
         }
     }
 
-    private func refreshHasAnyMessage() {
+    private func refreshHasAnyMessage(_ continuation: AsyncStream<Action>.Continuation? = nil) {
         Task { @MainActor in
             do {
                 let hasAny = try await hasAnyMessageUseCase.execute()
-                state.hasAnyMessage = hasAny
+                continuation?.yield(.setHasAnyMessage(hasAny))
             } catch {
-                state.hasAnyMessage = false
+                continuation?.yield(.setHasAnyMessage(false))
             }
         }
     }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapStore.swift
@@ -11,7 +11,7 @@ import Combine
 final class MapStore: Store {
     enum Intent {
         case onAppear(Coordinate)
-        case userLocationReady(Coordinate?)
+        case userLocationReady(Coordinate)
         case onDisappear
 
         case tapTiltToggle
@@ -146,7 +146,6 @@ final class MapStore: Store {
 
             case .userLocationReady(let coordinate):
                 guard state.didApplyResolvedUserLocation == false else { break }
-                guard let coordinate else { break }
 
                 continuation.yield(.setDidApplyResolvedUserLocation(true))
                 continuation.yield(.setCameraCoordinate(coordinate))

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -23,11 +23,6 @@ struct MapView: View {
     @Environment(\.isSplashVisible) private var isSplashVisible
 
     @State private var navigationPath = NavigationPath()
-    @State private var selectedPlaceForSpace: Place?
-    @State private var showSpace: Bool = false
-    @State private var didApplyResolvedUserLocation = false
-    @State private var isTimelineListPresented = false
-    @State private var isTiltOn: Bool = true
 
     @ObservedObject private var store: MapStore
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -76,11 +71,7 @@ struct MapView: View {
                     PlaceCarousel(
                         items: store.state.carouselItems,
                         onTapped: { place in
-                            send(.dismissPlaceCarousel)
-                            selectedPlaceForSpace = place
-                            withAnimation(.easeInOut(duration: 0.25)) {
-                                showSpace = true
-                            }
+                            send(.tapCarouselPlace(place))
                         }
                     )
                     .padding(.bottom, MMLayout.aboveTabBarOffset)
@@ -100,17 +91,17 @@ struct MapView: View {
                         send(.dismissPlaceCarousel)
                     }
             )
-            .fullScreenCover(isPresented: $showSpace) {
-                if let place = selectedPlaceForSpace {
+            .fullScreenCover(isPresented: isSpacePresentedBinding) {
+                if let place = store.state.selectedPlaceForSpace {
                     spaceView(place: place)
-                    .onAppear {
-                        setTabBarHidden(true)
-                        setNavBarHidden(true)
-                    }
-                    .onDisappear {
-                        setTabBarHidden(false)
-                        setNavBarHidden(false)
-                    }
+                        .onAppear {
+                            setTabBarHidden(true)
+                            setNavBarHidden(true)
+                        }
+                        .onDisappear {
+                            setTabBarHidden(false)
+                            setNavBarHidden(false)
+                        }
                 }
             }
             .navigationDestination(for: MapDestination.self) { destination in
@@ -128,28 +119,10 @@ struct MapView: View {
             .task {
                 let initial = locationProvider.current ?? .seoulCity
                 send(.onAppear(initial))
-
-                if let coordinate = locationProvider.current, !didApplyResolvedUserLocation {
-                    didApplyResolvedUserLocation = true
-                    send(.userLocationReady(coordinate))
-                }
+                send(.userLocationReady(locationProvider.current))
             }
             .onChange(of: locationProvider.current) { _, newValue in
-                guard didApplyResolvedUserLocation == false else { return }
-                guard let coordinate = newValue else { return }
-
-                didApplyResolvedUserLocation = true
-                send(.userLocationReady(coordinate))
-            }
-            .onChange(of: store.state.selectedNoPlaceMessages.isEmpty) { _, isEmpty in
-                guard isEmpty, isTimelineListPresented else { return }
-
-                Task { @MainActor in
-                    try? await Task.sleep(for: .milliseconds(1000))
-                    withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
-                        isTimelineListPresented = false
-                    }
-                }
+                send(.userLocationReady(newValue))
             }
             .onAppear {
                 setTabBarHidden(false)
@@ -184,7 +157,7 @@ private extension MapView {
         MapViewWrapper(
             userLocation: locationProvider.current ?? .seoulCity,
             isFollowingUser: store.state.isFollowingUser,
-            isTiltOn: isTiltOn,
+            isTiltOn: store.state.isTiltOn,
             markerManager: messageMarkerManager,
             messages: store.state.messages,
             cameraMoveTarget: store.state.cameraMoveTarget,
@@ -195,7 +168,6 @@ private extension MapView {
                 send(.tapPlaceMarker(messages))
             },
             onTapNoPlace: { messages in
-                isTimelineListPresented = true
                 send(.tapNoPlaceMarker(messages))
             },
             onUserGesture: {
@@ -233,10 +205,9 @@ private extension MapView {
 
     var tiltToggleButton: some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isTiltOn.toggle()
-            }
+            send(.tapTiltToggle)
         } label: {
+            let isTiltOn = store.state.isTiltOn
             HStack(spacing: 6) {
                 Image(systemName: isTiltOn ? "graph.3d" : "graph.2d")
                 Text(isTiltOn ? "3D" : "2D")
@@ -328,6 +299,15 @@ private extension MapView {
         )
     }
 
+    var isSpacePresentedBinding: Binding<Bool> {
+        Binding(
+            get: { store.state.selectedPlaceForSpace != nil },
+            set: { isPresented in
+                if !isPresented { send(.dismissSpace) }
+            }
+        )
+    }
+
     var timeLineListView: some View {
         let factory: TimelineListStoreFactory = DIContainer.resolveOrDie()
 
@@ -343,24 +323,17 @@ private extension MapView {
             onBecameEmpty: {
                 Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(1000))
-
-                    guard isTimelineListPresented else { return }
-
-                    withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
-                        isTimelineListPresented = false
-                    }
+                    send(.dismissTimelineView)
                 }
-                send(.dismissTimelineView)
             }
         )
     }
 
     var isTimelineListPresentedBinding: Binding<Bool> {
         Binding(
-            get: { isTimelineListPresented },
+            get: { store.state.selectedNoPlaceMessages.isEmpty == false },
             set: { isPresented in
                 if !isPresented {
-                    isTimelineListPresented = false
                     send(.dismissTimelineView)
                 }
             }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -27,6 +27,7 @@ struct MapView: View {
     @State private var showSpace: Bool = false
     @State private var didApplyResolvedUserLocation = false
     @State private var isTimelineListPresented = false
+    @State private var isTiltOn: Bool = true
 
     @ObservedObject private var store: MapStore
     @EnvironmentObject private var locationProvider: LocationProvider
@@ -64,6 +65,11 @@ struct MapView: View {
                     writeButton
                         .padding(.bottom, MMLayout.tabBarBottomOffset)
                 }
+            }
+            .overlay(alignment: .topLeading) {
+                tiltToggleButton
+                    .padding(.top, MMLayout.belowNavigationToolbarOffset + 20)
+                    .padding(.leading, 30)
             }
             .overlay(alignment: .bottom) {
                 if !store.state.carouselItems.isEmpty {
@@ -178,6 +184,7 @@ private extension MapView {
         MapViewWrapper(
             userLocation: locationProvider.current ?? .seoulCity,
             isFollowingUser: store.state.isFollowingUser,
+            isTiltOn: isTiltOn,
             markerManager: messageMarkerManager,
             messages: store.state.messages,
             cameraMoveTarget: store.state.cameraMoveTarget,
@@ -222,6 +229,26 @@ private extension MapView {
                 send(.setToast(Constants.locationToastMessage))
             }
         }
+    }
+
+    var tiltToggleButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isTiltOn.toggle()
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isTiltOn ? "graph.3d" : "graph.2d")
+                Text(isTiltOn ? "3D" : "2D")
+            }
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(Color.mmWriteButton)
+            .frame(width: 75, height: 38)
+            .background(Color.mmFloatingBackground)
+            .clipShape(Capsule())
+        }
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 4)
+        .buttonStyle(.plain)
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -119,9 +119,9 @@ struct MapView: View {
             .task {
                 let initial = locationProvider.current ?? .seoulCity
                 send(.onAppear(initial))
-                send(.userLocationReady(locationProvider.current))
+                send(.userLocationReady(initial))
             }
-            .onChange(of: locationProvider.current) { _, newValue in
+            .onChange(of: locationProvider.current ?? .seoulCity) { _, newValue in
                 send(.userLocationReady(newValue))
             }
             .onAppear {

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -224,18 +224,19 @@ extension MapViewController {
 extension MapViewController {
     func setFollowingUser(_ isFollowing: Bool) {
         self.isFollowingUser = isFollowing
+
+        if !isFollowing {
+            if naverMapView.mapView.positionMode != .normal {
+                naverMapView.mapView.positionMode = .normal
+            }
+        }
     }
 
     func updateUserLocation(_ coordinate: Coordinate?) {
         guard let coordinate else { return }
+        updateUserLocationOverlayOnly(coordinate)
 
-        let latLng = NMGLatLng(lat: coordinate.latitude, lng: coordinate.longitude)
-
-        let overlay = naverMapView.mapView.locationOverlay
-        overlay.hidden = false
-        overlay.location = latLng
-
-        if naverMapView.mapView.positionMode != .direction {
+        if isFollowingUser, naverMapView.mapView.positionMode != .direction {
             naverMapView.mapView.positionMode = .direction
         }
     }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewController.swift
@@ -290,6 +290,28 @@ extension MapViewController {
             heading: position.heading
         )
     }
+
+    func setTiltEnabled(_ enabled: Bool, animated: Bool = true) {
+        let mapView = naverMapView.mapView
+        let current = mapView.cameraPosition
+
+        let targetTilt: Double = enabled ? 45.0 : 0.0
+
+        if abs(current.tilt - targetTilt) < 0.1 { return }
+
+        let newPosition = NMFCameraPosition(
+            current.target,
+            zoom: current.zoom,
+            tilt: targetTilt,
+            heading: current.heading
+        )
+
+        let update = NMFCameraUpdate(position: newPosition)
+        update.animation = animated ? .easeIn : .none
+        update.animationDuration = animated ? 0.25 : 0
+
+        mapView.moveCamera(update)
+    }
 }
 
 // MARK: - Messages

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewWrapper.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewWrapper.swift
@@ -64,6 +64,9 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         var lastMessagesSnapshot: Int?
         var lastCameraMoveTarget: MapCameraMoveCommand?
         var didInitialLoad = false
+
+        var lastUserLocation: Coordinate?
+        var lastIsFollowingUser: Bool?
     }
 
     func makeUIViewController(context: Context) -> MapViewController {
@@ -90,17 +93,41 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
-        uiViewController.setFollowingUser(isFollowingUser)
-        uiViewController.setTiltEnabled(isTiltOn, animated: true)
-
-        // 추적 상태에 따라 위치 반영
-        if isFollowingUser {
-            uiViewController.updateUserLocation(userLocation)
-        } else {
-            // 추적 해제 모드 시 파란점만 유지하고 카메라는 안 움직이도록 설정
-            uiViewController.updateUserLocationOverlayOnly(userLocation)
+        // 1) following 상태 변경 diff
+        if context.coordinator.lastIsFollowingUser != isFollowingUser {
+            context.coordinator.lastIsFollowingUser = isFollowingUser
+            uiViewController.setFollowingUser(isFollowingUser)
         }
 
+        // 2) 틸트는 바뀔 때만
+        uiViewController.setTiltEnabled(isTiltOn, animated: true)
+
+        // 3) 위치 업데이트 diff
+        let didUserLocationChange: Bool = {
+            guard let new = userLocation else { return false }
+            guard let old = context.coordinator.lastUserLocation else { return true }
+
+            // Coordinate가 Equatable이면 그냥 new != old
+            // 아니면 오차 허용 비교 (GPS 튐 방지)
+            return abs(new.latitude - old.latitude) > 0.00001
+            || abs(new.longitude - old.longitude) > 0.00001
+        }()
+
+        let didFollowingChange = (context.coordinator.lastIsFollowingUser != isFollowingUser)
+
+        if didUserLocationChange || didFollowingChange {
+            context.coordinator.lastUserLocation = userLocation
+
+            // 추적 상태에 따라 위치 반영
+            if isFollowingUser {
+                uiViewController.updateUserLocation(userLocation)
+            } else {
+                // 추적 해제 모드 시 파란점만 유지하고 카메라는 안 움직이도록 설정
+                uiViewController.updateUserLocationOverlayOnly(userLocation)
+            }
+        }
+
+        // 4) cameraMoveTarget diff
         if let target = cameraMoveTarget, context.coordinator.lastCameraMoveTarget != target {
             // 동일 target인 경우 호출 X
             context.coordinator.lastCameraMoveTarget = target
@@ -114,6 +141,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
             }
         }
 
+        // 5) messages diff
         let snap = messagesSnapshot(messages)
 
         // 동일 메시지인 경우 loadMessages() 호출 X

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewWrapper.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewWrapper.swift
@@ -22,10 +22,12 @@ struct MapViewWrapper: UIViewControllerRepresentable {
 
     private let messageMarkerManager: MessageMarkerManager
     private let isFollowingUser: Bool
+    private let isTiltOn: Bool
 
     init(
         userLocation: Coordinate?,
         isFollowingUser: Bool,
+        isTiltOn: Bool,
         markerManager: MessageMarkerManager,
         messages: [Message],
         cameraMoveTarget: MapCameraMoveCommand?,
@@ -40,6 +42,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
     ) {
         self.userLocation = userLocation
         self.isFollowingUser = isFollowingUser
+        self.isTiltOn = isTiltOn
         self.messageMarkerManager = markerManager
         self.messages = messages
         self.cameraMoveTarget = cameraMoveTarget
@@ -88,6 +91,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
         uiViewController.setFollowingUser(isFollowingUser)
+        uiViewController.setTiltEnabled(isTiltOn, animated: true)
 
         // 추적 상태에 따라 위치 반영
         if isFollowingUser {

--- a/Meomun/Meomun/Presentation/Scene/Map/MapViewWrapper.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapViewWrapper.swift
@@ -81,6 +81,7 @@ struct MapViewWrapper: UIViewControllerRepresentable {
         )
 
         viewController.onFirstMapIdle = onFirstMapIdle
+        viewController.loadViewIfNeeded()
 
         // 초기 1회 loadMessages() 호출
         viewController.loadMessages(messages)
@@ -88,14 +89,18 @@ struct MapViewWrapper: UIViewControllerRepresentable {
 
         context.coordinator.lastMessagesSnapshot = messagesSnapshot(messages)
         context.coordinator.didInitialLoad = true
+        context.coordinator.lastUserLocation = userLocation
+        context.coordinator.lastIsFollowingUser = isFollowingUser
 
         return viewController
     }
 
     func updateUIViewController(_ uiViewController: MapViewController, context: Context) {
         // 1) following 상태 변경 diff
-        if context.coordinator.lastIsFollowingUser != isFollowingUser {
-            context.coordinator.lastIsFollowingUser = isFollowingUser
+        let prevFollowing = context.coordinator.lastIsFollowingUser
+        let didFollowingChange = (prevFollowing != isFollowingUser)
+
+        if didFollowingChange {
             uiViewController.setFollowingUser(isFollowingUser)
         }
 
@@ -104,16 +109,16 @@ struct MapViewWrapper: UIViewControllerRepresentable {
 
         // 3) 위치 업데이트 diff
         let didUserLocationChange: Bool = {
-            guard let new = userLocation else { return false }
+            guard let new = userLocation else {
+                return context.coordinator.lastUserLocation != nil
+            }
             guard let old = context.coordinator.lastUserLocation else { return true }
 
             // Coordinate가 Equatable이면 그냥 new != old
             // 아니면 오차 허용 비교 (GPS 튐 방지)
-            return abs(new.latitude - old.latitude) > 0.00001
-            || abs(new.longitude - old.longitude) > 0.00001
+            return abs(new.latitude - old.latitude) > 0.000001
+            || abs(new.longitude - old.longitude) > 0.000001
         }()
-
-        let didFollowingChange = (context.coordinator.lastIsFollowingUser != isFollowingUser)
 
         if didUserLocationChange || didFollowingChange {
             context.coordinator.lastUserLocation = userLocation
@@ -126,6 +131,8 @@ struct MapViewWrapper: UIViewControllerRepresentable {
                 uiViewController.updateUserLocationOverlayOnly(userLocation)
             }
         }
+
+        context.coordinator.lastIsFollowingUser = isFollowingUser
 
         // 4) cameraMoveTarget diff
         if let target = cameraMoveTarget, context.coordinator.lastCameraMoveTarget != target {


### PR DESCRIPTION

## 배경
- closed #380

## 작업 요약
- 틸트 조절 기능 추가
- 맵뷰 상태 관리 리팩터링
  - 맵뷰 기존 코드에 남아있던 상태 관리 변수 삭제
  - 뷰에 혼재되어 있던 상태 관리 책임을 Store에게 위임

## 작업 내용
### 1. 틸트 토글 기능 추가
실사용자의 피드백을 반영하여 틸트 정도를 토글 버튼으로 간단하게 조절할 수 있도록 기능을 추가하였음. (2D - 3D)

### 이슈: 틸트 토글이 지도 드래그 후에만 동작함.

#### 문제
지도에서 3D(tilt=45) ↔ 2D(tilt=0) 토글 버튼을 눌러도 **지도를 한 번이라도 드래그하기 전에는 틸트 전환이 적용되지 않음**.

#### 원인 분석
- 지도를 드래그하면 positionMode = .normal로 바뀜 -> 이때부터 수동 카메라 업데이트가 먹히므로 틸트 조정이 가능.
- 추적 모드(positionMode = .direction/.compass) 일 땐 **지도 내부적으로 ‘카메라는 위치 추적이 컨트롤한다’고 인식** -> **수동 업데이트가 무시됨 ( = 틸트 조정이 무시됨)**
  - 버튼 누르면 isTiltOn 변경 → MapViewWrapper.updateUIViewController 호출됨.
  - 그 안에서 setTiltEnabled() 호출됨.
  - **바로 이어서** **updateUserLocation()이 호출되면서 positionMode를** **.direction으로 만들고** 지도 SDK가 카메라를 다시 위치추적으로 가져가 버림.

#### 해결
* updateUIViewController에서 **updateUserLocation()을 매번 호출하지 않도록** 변경.
* Coordinator에 lastUserLocation, lastIsFollowingUser를 저장
  * **userLocation이 실제로 변했거나** **following 상태가 변했을 때만** 위치 업데이트를 호출하도록 **diff**를 적용.

#### 결과
* **틸트 토글 시에는 위치 업데이트가 불필요하게 실행되지 않아서** 추적 모드가 tilt 변경을 덮어쓰는 충돌이 사라지고 드래그 없이도 바로 2D/3D 전환이 정상 동작함.

### 2. MapView 상태 관리 리팩터링
MapView에 섞인 일부 상태 관리 책임을 Store로 옮겨 정리.

#### 목표
* **MapView는 UI 조합과 라우팅만 담당**
* 현재 화면의 상태는 전부 **MapStore(State)로 단일화(SSOT)**

#### 1) View에 있던 상태를 Store로 이동
- **AS-IS**
  - 기존에는 View가 아래 같은 상태를 `@State`로 들고 있었음.
    * 틸트 모드(2D/3D 토글)
    * 공간(Space) 진입 여부와 선택된 Place
    * 타임라인 시트 표시 여부(선택된 NoPlace 메시지 여부로 결정 가능)
    * 최초 위치 1회 적용 플래그(didApplyResolvedUserLocation)
- **TO-BE**
  - 리팩토링 후 모두 Store State로 이동
  - View는 Store 상태를 바인딩하여 보여주는 형태로 정리

#### 2) UI 이벤트는 Intent로 표준화
MapView에서 직접 상태를 바꾸지 않고, 모든 UI 이벤트를 Store의 Intent로 통일했다.

* 틸트 버튼 탭 → tapTiltToggle
* 캐러셀 Place 탭 → tapCarouselPlace(place)
* 지도 제스처 → userDidInteractMap
* NoPlace 마커 탭 → tapNoPlaceMarker(messages)
* Space 닫힘 → dismissSpace
* 시트 닫힘 → dismissTimelineView

-> **View의 역할은 이벤트 전달로만 제한**하고, ‘어떤 상태를 어떻게 바꿀지’는 Store가 책임지도록 함.

## 스크린샷

https://github.com/user-attachments/assets/e5abfeb1-1399-490e-82ec-21a55b26d718

- 메시지 버블이 삭제되지 않는 것처럼 보이는 이유는 더미 데이터라서 그렇습니다.
- 다른 동작은 상태 관리 리팩터링 이후에도 기존과 동일 동작 유지를 확인하기 위해서 담았습니다.


## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 기울기 토글 버튼 추가
  * 캐러셀에서 장소 선택 시 공간(스페이스) 표시 흐름 추가

* **개선 사항**
  * 지도 화면의 상태 관리를 중앙화해 UI 일관성 및 안정성 향상
  * 공간(스페이스) 및 타임라인 표시/해제 흐름 개선으로 전환이 더 부드러움
  * 사용자 위치 및 카메라 업데이트 처리 개선으로 위치 추적과 카메라 동작 신뢰성 증가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->