### PR TITLE
공간 화면 카메라 자이로 기능 추가

### DIFF
--- a/Meomun/Meomun/Presentation/DesignSystem/Component/Button/WriteButton.swift
+++ b/Meomun/Meomun/Presentation/DesignSystem/Component/Button/WriteButton.swift
@@ -33,8 +33,6 @@ struct WriteButton: View {
                 )
                 .shadow(color: .black.opacity(0.15), radius: 6, y: 4)
         }
-        .padding(.horizontal, 35)
-        .padding(.vertical, 17)
     }
 }
 

--- a/Meomun/Meomun/Presentation/DesignSystem/Foundation/Constants.swift
+++ b/Meomun/Meomun/Presentation/DesignSystem/Foundation/Constants.swift
@@ -31,5 +31,5 @@ enum MMLayout {
     static let aboveTabBarOffset: CGFloat = 90
 
     /// 탭바 높이를 고려한 기본 bottom offset
-    static let tabBarBottomOffset: CGFloat = 96
+    static let tabBarBottomOffset: CGFloat = 113
 }

--- a/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Map/MapView.swift
@@ -57,12 +57,13 @@ struct MapView: View {
                         Color.clear
                             .frame(width: 50, height: 1)
                             .padding(.trailing, 120)
-                            .padding(.bottom, MMLayout.tabBarBottomOffset + 90)
+                            .padding(.bottom, MMLayout.tabBarBottomOffset + 73)
                             .popoverTip(MapPlaceConceptTip())
                     }
 
                     writeButton
                         .padding(.bottom, MMLayout.tabBarBottomOffset)
+                        .padding(.trailing, MMSpacing.floatingHorizontalPadding + 5)
                 }
             }
             .overlay(alignment: .bottom) {

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/RotationCamera.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/RotationCamera.swift
@@ -23,7 +23,9 @@ final class RotationCamera {
     /// 회전 감도 조절을 위한 상수 (값이 클수록 빠르게 회전)
     private let sensitivity: Float
 
+    /// 카메라 위치, 카메라가 바라보는 방향
     var position: SIMD3<Float> { camera.position }
+    var orientation: simd_quatf { camera.orientation }
 
     init(
         position: SIMD3<Float>,
@@ -38,6 +40,11 @@ final class RotationCamera {
         content.add(camera)
     }
 
+    /// 카메라가 바라보는 방향을 설정합니다
+    func setOrientation(_ orientation: simd_quatf) {
+        camera.orientation = orientation
+    }
+
     /// 드래그 입력을 처리하여 카메라를 회전시킵니다
     func handleDrag(translationX: Float, translationY: Float) {
         let deltaX = translationX - lastTranslation.x
@@ -50,6 +57,23 @@ final class RotationCamera {
 
     /// 드래그가 끝났을 때 호출합니다
     func endDrag() {
+        lastTranslation = (0, 0)
+    }
+
+    /// 현재 카메라 orientation으로부터 forward 벡터를 뽑아 yaw/pitch를 역산하여 내부 상태를 동기화합니다
+    func syncDragAnglesFromCurrentOrientation() {
+        let matrix = camera.transform.matrix
+        let forward = simd_normalize(SIMD3<Float>(
+            -matrix.columns.2.x,
+            -matrix.columns.2.y,
+            -matrix.columns.2.z
+            ))
+
+        yaw = atan2(forward.x, forward.z)
+
+        let rawPitch = asin(max(-1, min(1, forward.y)))
+        pitch = max(0, min(Float.pi / 2, rawPitch))
+
         lastTranslation = (0, 0)
     }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/3DComponents/RotationCamera.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/3DComponents/RotationCamera.swift
@@ -60,23 +60,6 @@ final class RotationCamera {
         lastTranslation = (0, 0)
     }
 
-    /// 현재 카메라 orientation으로부터 forward 벡터를 뽑아 yaw/pitch를 역산하여 내부 상태를 동기화합니다
-    func syncDragAnglesFromCurrentOrientation() {
-        let matrix = camera.transform.matrix
-        let forward = simd_normalize(SIMD3<Float>(
-            -matrix.columns.2.x,
-            -matrix.columns.2.y,
-            -matrix.columns.2.z
-            ))
-
-        yaw = atan2(forward.x, forward.z)
-
-        let rawPitch = asin(max(-1, min(1, forward.y)))
-        pitch = max(0, min(Float.pi / 2, rawPitch))
-
-        lastTranslation = (0, 0)
-    }
-
     private func rotate(deltaX: Float, deltaY: Float) {
         yaw += deltaX * sensitivity
         pitch += deltaY * sensitivity

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -16,6 +16,7 @@ final class SpaceController {
 
     // MARK: - Gyro
     private let motionManager = CMMotionManager()
+    private let coreMotionToRealityKitBasis = simd_quatf(angle: -.pi / 2, axis: SIMD3<Float>(1, 0, 0))
     private var isGyroEnabled: Bool = false
     private var gyroBaseAttitude: simd_quatf?
     private var gyroBaseCameraOrientation: simd_quatf?
@@ -245,10 +246,16 @@ extension SpaceController {
                     let current = self.simdQuat(from: attitude.quaternion)
 
                     if self.gyroBaseAttitude == nil {
+                        // 첫 자세를 기준으로 잡음
                         self.gyroBaseAttitude = current
                     } else if let baseAttitude = self.gyroBaseAttitude,
                               let baseCamera = self.gyroBaseCameraOrientation {
-                        let delta = current * baseAttitude.inverse
+                        // base → current 상대 회전 (CoreMotion reference frame 기준)
+                        let deltaCM = current * baseAttitude.inverse
+                        // CoreMotion(Z-up) → RealityKit(Y-up) basis change
+                        let delta = self.remapCoreMotionDeltaToRealityKit(deltaCM)
+
+                        // 기존 카메라 기준 방향에 델타를 누적
                         let target = baseCamera * delta
 
                         self.rotationCamera.setOrientation(target)
@@ -270,6 +277,11 @@ extension SpaceController {
 
     private func simdQuat(from quat: CMQuaternion) -> simd_quatf {
         simd_quatf(ix: Float(quat.x), iy: Float(quat.y), iz: Float(quat.z), r: Float(quat.w))
+    }
+
+    private func remapCoreMotionDeltaToRealityKit(_ delta: simd_quatf) -> simd_quatf {
+        let basis = coreMotionToRealityKitBasis
+        return basis * delta * basis.inverse
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -48,7 +48,7 @@ final class SpaceController {
         self.materialConfigurator = SpaceMaterialConfigurator()
     }
 
-    deinit {
+    isolated deinit {
         motionManager.stopDeviceMotionUpdates()
         gyroUpdateTask?.cancel()
     }
@@ -239,9 +239,9 @@ extension SpaceController {
 
         gyroUpdateTask?.cancel()
         gyroUpdateTask = Task { [weak self] in
-            guard let self else { return }
-
             while !Task.isCancelled {
+                guard let self else { return }
+
                 if let attitude = self.motionManager.deviceMotion?.attitude {
                     let current = self.simdQuat(from: attitude.quaternion)
 

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -219,8 +219,6 @@ extension SpaceController {
             startGyroUpdates()
         } else {
             stopGyroUpdates()
-
-            rotationCamera.syncDragAnglesFromCurrentOrientation()
         }
     }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceController.swift
@@ -7,11 +7,19 @@
 
 import RealityKit
 import SwiftUI
+import CoreMotion
 
 @MainActor
 final class SpaceController {
     private var domeEnvironment: DomeEnvironment?
     private var rotationCamera: RotationCamera
+
+    // MARK: - Gyro
+    private let motionManager = CMMotionManager()
+    private var isGyroEnabled: Bool = false
+    private var gyroBaseAttitude: simd_quatf?
+    private var gyroBaseCameraOrientation: simd_quatf?
+    private var gyroUpdateTask: Task<Void, Never>?
 
     private var spaceRootEntity: Entity?
     private var messageBubbleTemplateEntity: Entity?
@@ -37,6 +45,11 @@ final class SpaceController {
         self.rotationCamera = rotationCamera
         self.bubbleSynchronizer = SpaceMessageBubbleSynchronizer()
         self.materialConfigurator = SpaceMaterialConfigurator()
+    }
+
+    deinit {
+        motionManager.stopDeviceMotionUpdates()
+        gyroUpdateTask?.cancel()
     }
 
     // MARK: - Space Setup
@@ -188,17 +201,75 @@ extension SpaceController {
 extension SpaceController {
     func handleDrag(_ translation: CGSize) {
         rotationCamera.handleDrag(
-            translationX: Float(
-                translation.width
-            ),
-            translationY: Float(
-                translation.height
-            )
+            translationX: Float(translation.width),
+            translationY: Float(translation.height)
         )
     }
 
     func endDrag() {
         rotationCamera.endDrag()
+    }
+
+    func setGyroEnabled(_ isEnabled: Bool) {
+        guard isEnabled != isGyroEnabled else { return }
+        isGyroEnabled = isEnabled
+
+        if isEnabled {
+            startGyroUpdates()
+        } else {
+            stopGyroUpdates()
+
+            rotationCamera.syncDragAnglesFromCurrentOrientation()
+        }
+    }
+
+    private func startGyroUpdates() {
+        guard motionManager.isDeviceMotionAvailable else {
+            AppLog.debug("DeviceMotion 비활성화 상태 (혹은 시뮬레이터)", category: .space)
+            return
+        }
+
+        // Baseline 초기화
+        gyroBaseAttitude = nil
+        gyroBaseCameraOrientation = rotationCamera.orientation
+
+        motionManager.deviceMotionUpdateInterval = 1.0 / 60.0
+        motionManager.startDeviceMotionUpdates(using: .xArbitraryZVertical)
+
+        gyroUpdateTask?.cancel()
+        gyroUpdateTask = Task { [weak self] in
+            guard let self else { return }
+
+            while !Task.isCancelled {
+                if let attitude = self.motionManager.deviceMotion?.attitude {
+                    let current = self.simdQuat(from: attitude.quaternion)
+
+                    if self.gyroBaseAttitude == nil {
+                        self.gyroBaseAttitude = current
+                    } else if let baseAttitude = self.gyroBaseAttitude,
+                              let baseCamera = self.gyroBaseCameraOrientation {
+                        let delta = current * baseAttitude.inverse
+                        let target = baseCamera * delta
+
+                        self.rotationCamera.setOrientation(target)
+                    }
+                }
+
+                try? await Task.sleep(for: .milliseconds(16))
+            }
+        }
+    }
+
+    private func stopGyroUpdates() {
+        gyroUpdateTask?.cancel()
+        gyroUpdateTask = nil
+        gyroBaseAttitude = nil
+        gyroBaseCameraOrientation = nil
+        motionManager.stopDeviceMotionUpdates()
+    }
+
+    private func simdQuat(from quat: CMQuaternion) -> simd_quatf {
+        simd_quatf(ix: Float(quat.x), iy: Float(quat.y), iz: Float(quat.z), r: Float(quat.w))
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceStore.swift
@@ -16,6 +16,7 @@ final class SpaceStore: Store {
         case requestDeleteMessage(MessageID)
         case confirmDeleteMessage(MessageID)
         case dismissAlert
+        case setGyroEnabled(Bool)
     }
 
     enum Action {
@@ -30,6 +31,7 @@ final class SpaceStore: Store {
         case showDeleteAlert(MMAlertModel)
         case hideAlert
         case setDeleteStatus(LoadingStatus)
+        case setGyroEnabled(Bool)
     }
 
     struct State {
@@ -40,6 +42,7 @@ final class SpaceStore: Store {
         var currentPlaceID: PlaceID?
         var toastMessage: String?
         var selectedMessageID: MessageID?
+        var isGyroEnabled: Bool = false
         var deleteAlert: MMAlertModel?
         var deleteStatus: LoadingStatus = .idle
     }
@@ -96,6 +99,10 @@ final class SpaceStore: Store {
             case .dismissAlert:
                 continuation.yield(.hideAlert)
                 continuation.finish()
+
+            case .setGyroEnabled(let enabled):
+                continuation.yield(.setGyroEnabled(enabled))
+                continuation.finish()
             }
         }
     }
@@ -136,6 +143,9 @@ final class SpaceStore: Store {
 
         case .setDeleteStatus(let status):
             newState.deleteStatus = status
+
+        case .setGyroEnabled(let enabled):
+            newState.isGyroEnabled = enabled
         }
 
         return newState

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -49,11 +49,23 @@ struct SpaceView: View {
                 .allowsHitTesting(isSpaceReady)
                 .gesture(
                     DragGesture()
-                        .onChanged { spaceController.handleDrag($0.translation) }
-                        .onEnded { _ in spaceController.endDrag()}
+                        .onChanged {
+                            if store.state.isGyroEnabled {
+                                send(.setGyroEnabled(false))
+                            }
+                            spaceController.handleDrag($0.translation)
+                        }
+                        .onEnded { _ in
+                            spaceController.endDrag()
+                        }
                 )
                 .gesture(
-                    TapGesture().onEnded { send(.selectMessage(nil)) }
+                    TapGesture().onEnded {
+                        if store.state.isGyroEnabled {
+                            send(.setGyroEnabled(false))
+                        }
+                        send(.selectMessage(nil))
+                    }
                 )
                 .highPriorityGesture(
                     SpatialTapGesture()
@@ -141,10 +153,14 @@ struct SpaceView: View {
             .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.selectedMessageID)
             .allowsHitTesting(store.state.deleteStatus == .idle)
             .overlay(alignment: .top) {
-                SpaceTopBar(
-                    title: store.place.name,
-                    onBack: { dismissWithFade() }
-                )
+                ZStack(alignment: .topTrailing) {
+                    SpaceTopBar(
+                        title: store.place.name,
+                        onBack: { dismissWithFade() }
+                    )
+
+                    gyroToggleButton
+                }
                 .padding(.top, 12)
                 .opacity(!showPortal ? 1 : 0)
             }
@@ -165,6 +181,9 @@ struct SpaceView: View {
             .onChange(of: store.state.selectedMessageID) { _, newValue in
                 spaceController.selectMessage(newValue)
             }
+            .onChange(of: store.state.isGyroEnabled) { _, newValue in
+                spaceController.setGyroEnabled(newValue)
+            }
             .opacity(appearOpacity)
             .onAppear {
                 withAnimation(.easeInOut(duration: 0.25)) {
@@ -175,6 +194,9 @@ struct SpaceView: View {
     }
 
     func dismissWithFade() {
+        if store.state.isGyroEnabled {
+            send(.setGyroEnabled(false))
+        }
         Task { @MainActor in
             withAnimation(.easeInOut(duration: 0.25)) {
                 appearOpacity = 0
@@ -242,6 +264,21 @@ extension SpaceView {
             }
         }
         .mmFloatingContainer(color: Color.mmBackground, opacity: 0.8)
+    }
+
+    var gyroToggleButton: some View {
+        Button {
+            send(.setGyroEnabled(!store.state.isGyroEnabled))
+        } label: {
+            Image(systemName: store.state.isGyroEnabled ? "gyroscope" : "hand.draw")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Color.mmTextBrand)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(.mmFloatingBackground)
+                .clipShape(Circle())
+                .accessibilityLabel(store.state.isGyroEnabled ? "자이로스코프 끄기" : "자이로스코프 켜기")
+        }
     }
 }
 

--- a/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
+++ b/Meomun/Meomun/Presentation/Scene/Space/SpaceView.swift
@@ -79,7 +79,9 @@ struct SpaceView: View {
                 VStack {
                     Spacer()
 
-                    HStack {
+                    HStack(alignment: .center) {
+                        gyroToggleButton
+
                         Spacer()
 
                         WriteButton(mode: .white) {
@@ -92,10 +94,11 @@ struct SpaceView: View {
                                 )
                             }
                         }
-                        .opacity(!showPortal ? 1 : 0)
-                        .allowsHitTesting(!showPortal && isSpaceReady)
                     }
-                    .padding(.bottom, 96)
+                    .opacity(!showPortal ? 1 : 0)
+                    .allowsHitTesting(!showPortal && isSpaceReady)
+                    .padding(.bottom, MMLayout.tabBarBottomOffset)
+                    .padding(.horizontal, MMSpacing.floatingHorizontalPadding)
                 }
 
                 if store.state.deleteStatus != .idle {
@@ -153,16 +156,12 @@ struct SpaceView: View {
             .animation(.spring(response: 0.25, dampingFraction: 0.9), value: store.state.selectedMessageID)
             .allowsHitTesting(store.state.deleteStatus == .idle)
             .overlay(alignment: .top) {
-                ZStack(alignment: .topTrailing) {
-                    SpaceTopBar(
-                        title: store.place.name,
-                        onBack: { dismissWithFade() }
-                    )
-
-                    gyroToggleButton
-                }
-                .padding(.top, 12)
-                .opacity(!showPortal ? 1 : 0)
+                SpaceTopBar(
+                    title: store.place.name,
+                    onBack: { dismissWithFade() }
+                )
+                    .padding(.top, 12)
+                    .opacity(!showPortal ? 1 : 0)
             }
             .task {
                 if !isSpaceReady {
@@ -271,12 +270,12 @@ extension SpaceView {
             send(.setGyroEnabled(!store.state.isGyroEnabled))
         } label: {
             Image(systemName: store.state.isGyroEnabled ? "gyroscope" : "hand.draw")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Color.mmTextBrand)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .background(.mmFloatingBackground)
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(.mmWriteButton)
+                .frame(width: 53, height: 53)
+                .background(.mmFloatingBackground.opacity(0.85))
                 .clipShape(Circle())
+                .shadow(color: .black.opacity(0.15), radius: 6, y: 4)
                 .accessibilityLabel(store.state.isGyroEnabled ? "자이로스코프 끄기" : "자이로스코프 켜기")
         }
     }


### PR DESCRIPTION
## 배경
- closed #58 
- closed #117 

## 작업 요약
- [x]  공간 화면 자이로 기능 추가
- [x]  쫀득꾸 버튼 내부 패딩 제거

## 이슈: 좌우 회전이 수직 회전으로 적용되는 문제

https://github.com/user-attachments/assets/06e94cd7-e9e4-434c-b909-de0d59f0419a


### 원인

- CoreMotion과 RealityKit 뷰 좌표 축이 다른 것이 원인!
- CoreMotion의 reference frame은 Z-up(수직이 +Z)이고, RealityKit은 Y-up(+Y가 위) 이어서, 좌우로 움직이는데 수직으로 화면이 보여졌음.

### 해결

```swift
private let coreMotionToRealityKitBasis = simd_quatf(angle: -.pi / 2, axis: SIMD3<Float>(1, 0, 0))
```

- CoreMotion → RealityKit 변환을 위해 X축 기준 -90° basis change를 적용

```swift
private func remapCoreMotionDeltaToRealityKit(_ delta: simd_quatf) -> simd_quatf {
    let basis = coreMotionToRealityKitBasis
    return basis * delta * basis.inverse
}
```

- CoreMotion(Z-up world)에서 나온 delta quaternion을 RealityKit(Y-up world) 기준으로 변환
- 수학적으로는 basis change: q' = B * q * B⁻¹

## 스크린샷

https://github.com/user-attachments/assets/8656433d-4012-4dc0-896b-8ae89e32adfa



## 리뷰 요구사항

- 자이로 회전 -> 터치 해서 자이로 <-> 드래그로 모드 변경한 뒤에, 다시 드래그로 화면 움직이면 어색함이 존재해요.
  - 드래그가 roll 없이 yaw, pitch만 사용하도록 강제로 조정하는 부분이 있는데 그 부분에서 강제 변환이 일어나면서 어색함이 발생하는 것으로 추정됩니다~~

- 수학적 수식은 지피띠니 도움을 많이 받았습니다 ㅎㅎ;

## 체크리스트

- [x] 빌드 및 실행 테스트 완료
- [x] 불필요한 print / 주석 제거
- [x] 리뷰 요청 전 self-check 완료
- [x] 목적 브랜치 확인
- [x] 라벨 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기기의 자이로스코프를 이용한 카메라 회전 제어 기능 추가
  * 3D 공간 탐색 시 자이로 센서로 직관적인 카메라 조작 가능
  * 화면 상단 우측에 자이로 활성화/비활성화 토글 버튼 추가
  * 드래그 및 탭 제스처 수행 시 자이로 자동 비활성화로 안정적인 조작 보장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->